### PR TITLE
Registry error

### DIFF
--- a/install/beckn-onix.sh
+++ b/install/beckn-onix.sh
@@ -48,12 +48,8 @@ update_registry_details() {
     sed "s|REGISTRY_URL|$registry_url|g; s|REGISTRY_PORT|$registry_port|g; s|PROTOCOL|$protocol|g" "$config_file" > "$tmp_file"
     mv "$tmp_file" "$config_file"
     docker volume create registry_data_volume
-    docker run --rm -v $SCRIPT_DIR/../registry_data/config:/source -v registry_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
     docker volume create registry_database_volume
-    if [ -e $SCRIPT_DIR/../registry_data/database/db.txt ]
-    then
-        docker run --rm -v $SCRIPT_DIR/../registry_data/database:/source -v registry_database_volume:/target busybox cp /source/db.txt /target/db.txt
-    fi    
+    docker run --rm -v $SCRIPT_DIR/../registry_data/config:/source -v registry_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
     docker rmi busybox
 }
 # Function to start the MongoDB, Redis, and RabbitMQ Services

--- a/install/beckn-onix.sh
+++ b/install/beckn-onix.sh
@@ -12,7 +12,7 @@ install_package(){
 start_container(){
     #ignore orphaned containers warning
     export COMPOSE_IGNORE_ORPHANS=1
-    docker-compose -f docker-compose-v2.yml up -d $1
+    docker-compose -f $1 up -d $2
 }
 
 update_registry_details() {
@@ -50,7 +50,10 @@ update_registry_details() {
     docker volume create registry_data_volume
     docker run --rm -v $SCRIPT_DIR/../registry_data/config:/source -v registry_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
     docker volume create registry_database_volume
-    docker run --rm -v $SCRIPT_DIR/../registry_data/database:/source -v registry_database_volume:/target busybox cp /source/db.txt /target/db.txt
+    if [ -e $SCRIPT_DIR/../registry_data/database/db.txt ]
+    then
+        docker run --rm -v $SCRIPT_DIR/../registry_data/database:/source -v registry_database_volume:/target busybox cp /source/db.txt /target/db.txt
+    fi    
     docker rmi busybox
 }
 # Function to start the MongoDB, Redis, and RabbitMQ Services
@@ -77,7 +80,7 @@ install_gateway() {
         bash scripts/update_gateway_details.sh registry 
     fi
     echo "${GREEN}................Installing Gateway service................${NC}"
-    start_container gateway
+    start_container "docker-compose-gateway.yml" gateway
     echo "Registering Gateway in the registry"
 
     sleep 10
@@ -99,7 +102,7 @@ install_registry(){
     fi
 
     echo "${GREEN}................Installing Registry service................${NC}"
-    start_container registry
+    start_container "docker-compose-registry.yml" registry
     sleep 10
     echo "Registry installation successful"
 }
@@ -117,8 +120,8 @@ install_bap_protocol_server(){
         bash scripts/update_bap_config.sh
     fi
     sleep 10
-    start_container "bap-client"
-    start_container "bap-network"
+    start_container "docker-compose-bap.yml" "bap-client"
+    start_container "docker-compose-bap.yml" "bap-network"
     sleep 10
     echo "Protocol server BAP installation successful"
 }
@@ -141,8 +144,8 @@ install_bpp_protocol_server(){
     fi
 
     sleep 10
-    start_container "bpp-client"
-    start_container "bpp-network"
+    start_container "docker-compose-bpp.yml" "bpp-client"
+    start_container "docker-compose-bpp.yml" "bpp-network"
     sleep 10
     echo "Protocol server BPP installation successful"
 }

--- a/install/beckn-onix.sh
+++ b/install/beckn-onix.sh
@@ -166,34 +166,17 @@ read -p "Enter your choice: " choice
 boldGreen="\e[1m\e[92m"
 reset="\e[0m"
 
-# Function to request network configuration URL
-requestNetworkConfig() {
-    echo "Please provide the network-specific configuration URL."
-    read -p "Paste the URL of the network configuration here (or press Enter to skip): " config_url
-    if [ -n "$config_url" ]; then
-        echo "Network configuration URL provided: $config_url"
-    else
-        echo "No network configuration URL provided, proceeding without it."
-    fi
-    echo ""
-}
-
 # Function to handle the setup process for each platform
 completeSetup() {
     platform=$1
-    config_url=$2  # Passing this as an argument, though it could be optional or ignored by some setups
 
     public_address="https://<your public IP address>"
 
     echo "Proceeding with the setup for $platform..."
-    if [ -n "$config_url" ]; then
-        echo "Using network configuration from: $config_url"
-    fi
     
     # Insert the specific commands for each platform, including requesting network config if necessary
     case $platform in
         "Registry")
-            requestNetworkConfig
             read -p "Enter publicly accessible registry URL: " registry_url
             if [[ $registry_url =~ /$ ]]; then
                 new_registry_url=${registry_url%/}
@@ -205,7 +188,6 @@ completeSetup() {
             install_registry $new_registry_url
             ;;
         "Gateway"|"Beckn Gateway")
-            requestNetworkConfig
             read -p "Enter your registry URL: " registry_url
             read -p "Enter publicly accessible gateway URL: " gateway_url
             
@@ -223,7 +205,6 @@ completeSetup() {
             install_gateway $new_registry_url $gateway_url
             ;;
         "BAP")
-            requestNetworkConfig
             echo "${GREEN}................Installing Protocol Server for BAP................${NC}"
             
             read -p "Enter BAP Subscriber ID: " bap_subscriber_id
@@ -235,7 +216,6 @@ completeSetup() {
             install_bap_protocol_server $registry_url $bap_subscriber_id $bap_subscriber_key_id $bap_subscriber_url
             ;;
         "BPP")
-            requestNetworkConfig
             echo "${GREEN}................Installing Protocol Server for BAP................${NC}"
             read -p "Enter BPP Subscriber ID: " bpp_subscriber_id
             read -p "Enter BPP Subscriber URL: " bpp_subscriber_url
@@ -274,8 +254,7 @@ read -p "Enter your choice: " platform_choice
 selected_platform="${platforms[$((platform_choice-1))]}"
 
 if [[ -n $selected_platform ]]; then
-    # Note: Passing an empty string for config_url since it's optionally handled within `completeSetup`
-    completeSetup "$selected_platform" ""
+    completeSetup "$selected_platform"
 else
     echo "Invalid option. Please restart the script and select a valid option."
     exit 1

--- a/install/docker-compose-bap.yml
+++ b/install/docker-compose-bap.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+  bap-client:
+    image: fidedocker/protocol-server
+    container_name: bap-client
+    networks:
+      - beckn_network
+    ports:
+      - 5001:5001
+    restart: unless-stopped
+    volumes:
+      - ./protocol-server-data/bap-client.yml:/usr/src/app/config/default.yml
+
+  bap-network:
+    image: fidedocker/protocol-server
+    container_name: bap-network
+    networks:
+      - beckn_network
+    ports:
+      - 5002:5002
+    restart: unless-stopped
+    volumes:
+      - ./protocol-server-data/bap-network.yml:/usr/src/app/config/default.yml
+networks:
+  beckn_network:
+    driver: bridge

--- a/install/docker-compose-bpp.yml
+++ b/install/docker-compose-bpp.yml
@@ -1,0 +1,28 @@
+version: "3"
+
+services:
+  bpp-client:
+    image: fidedocker/protocol-server
+    container_name: bpp-client
+    networks:
+      - beckn_network
+    ports:
+      - 6001:6001
+    restart: unless-stopped
+    volumes:
+      - ./protocol-server-data/bpp-client.yml:/usr/src/app/config/default.yml
+
+  bpp-network:
+    image: fidedocker/protocol-server
+    container_name: bpp-network
+    networks:
+      - beckn_network
+    ports:
+      - 6002:6002
+    restart: unless-stopped
+    volumes:
+      - ./protocol-server-data/bpp-network.yml:/usr/src/app/config/default.yml
+
+networks:
+  beckn_network:
+    driver: bridge

--- a/install/docker-compose-gateway.yml
+++ b/install/docker-compose-gateway.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+  gateway:
+    image: fidedocker/gateway
+    container_name: gateway
+    networks:
+      - beckn_network
+    ports:
+      - 4000:4000
+      - 4030:4030
+    restart: unless-stopped
+    volumes:
+      - gateway_data_volume:/gateway/overrideProperties/config
+      - gateway_database_volume:/gateway/database
+
+networks:
+  beckn_network:
+    driver: bridge
+
+volumes:
+  gateway_data_volume:
+    name: gateway_data_volume
+    external: true
+  gateway_database_volume:
+    name: gateway_database_volume
+    external: true

--- a/install/docker-compose-registry.yml
+++ b/install/docker-compose-registry.yml
@@ -1,0 +1,27 @@
+version: "3"
+
+services:
+  registry:
+    image: fidedocker/registry
+    container_name: registry
+    networks:
+      - beckn_network
+    ports:
+      - 3000:3000
+      - 3030:3030
+    restart: unless-stopped
+    volumes:
+      - registry_data_volume:/registry/overrideProperties/config
+      - registry_database_volume:/registry/database
+
+networks:
+  beckn_network:
+    driver: bridge
+
+volumes:
+  registry_data_volume:
+    name: registry_data_volume
+    external: true
+  registry_database_volume:
+    name: registry_database_volume
+    external: true

--- a/install/docker-compose-v2.yml
+++ b/install/docker-compose-v2.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   registry:
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
     volumes:
       - registry_data_volume:/registry/overrideProperties/config
-      - registry_data_volume:/registry/database
+      - registry_database_volume:/registry/database
 
   gateway:
     image: fidedocker/gateway
@@ -111,10 +111,13 @@ networks:
 volumes:
   registry_data_volume:
     name: registry_data_volume
+    external: true
   registry_database_volume:
     name: registry_database_volume
+    external: true
   gateway_data_volume:
     name: gateway_data_volume
+    external: true
   gateway_database_volume:
     name: gateway_database_volume
-
+    external: true

--- a/install/scripts/update_gateway_details.sh
+++ b/install/scripts/update_gateway_details.sh
@@ -53,7 +53,7 @@ update_gateway_config() {
         docker volume create gateway_data_volume
         docker volume create gateway_database_volume
         docker run --rm -v $SCRIPT_DIR/../gateway_data/config:/source -v gateway_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
-        docker run --rm -v $SCRIPT_DIR/../registry_data/database:/source -v gateway_database_volume:/target busybox cp /source/db.txt /target/db.txt
+        docker run --rm -v $SCRIPT_DIR/../gateway_data/database:/source -v gateway_database_volume:/target busybox cp /source/db.txt /target/db.txt
         update_network_json
 
 }

--- a/install/scripts/update_gateway_details.sh
+++ b/install/scripts/update_gateway_details.sh
@@ -53,10 +53,6 @@ update_gateway_config() {
         docker volume create gateway_data_volume
         docker volume create gateway_database_volume
         docker run --rm -v $SCRIPT_DIR/../gateway_data/config:/source -v gateway_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
-        if [ -e $SCRIPT_DIR/../gateway_data/database/db.txt ]
-        then
-            docker run --rm -v $SCRIPT_DIR/../gateway_data/database:/source -v gateway_database_volume:/target busybox cp /source/db.txt /target/db.txt
-        fi    
         update_network_json
 
 }

--- a/install/scripts/update_gateway_details.sh
+++ b/install/scripts/update_gateway_details.sh
@@ -53,7 +53,10 @@ update_gateway_config() {
         docker volume create gateway_data_volume
         docker volume create gateway_database_volume
         docker run --rm -v $SCRIPT_DIR/../gateway_data/config:/source -v gateway_data_volume:/target busybox cp /source/{envvars,logger.properties,swf.properties} /target/
-        docker run --rm -v $SCRIPT_DIR/../gateway_data/database:/source -v gateway_database_volume:/target busybox cp /source/db.txt /target/db.txt
+        if [ -e $SCRIPT_DIR/../gateway_data/database/db.txt ]
+        then
+            docker run --rm -v $SCRIPT_DIR/../gateway_data/database:/source -v gateway_database_volume:/target busybox cp /source/db.txt /target/db.txt
+        fi    
         update_network_json
 
 }


### PR DESCRIPTION
Linked to issue https://github.com/beckn/beckn-onix/issues/52

I did the following:

1. Fixed an error where the registry_data_volume was mapped instead of registry_database_volume
2. Added check to remove the db.txt file not available error.
3. The gateway volumes were getting created on registry. Since we support individual deployments, we need individual docker files. So created separate files for gateway and registry (and also bap and bpp)
4. Removed network configuration question at the beginning. We do not do anything with the response. Its just confusing as seen in the screenshot in the issue above.