### PR TITLE
Use docker volumes for support services and bap/bpp

### DIFF
--- a/install/beckn-onix.sh
+++ b/install/beckn-onix.sh
@@ -119,7 +119,9 @@ install_bap_protocol_server(){
     docker volume create bap_client_config_volume
     docker volume create bap_network_config_volume
     docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_client_config_volume:/target busybox cp /source/bap-client.yml /target/default.yml
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_client_config_volume:/target busybox cp /source/bap-client.yaml-sample /target
     docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_network_config_volume:/target busybox cp /source/bap-network.yml /target/default.yml
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_network_config_volume:/target busybox cp /source/bap-network.yaml-sample /target
     docker rmi busybox
 
     start_container "docker-compose-bap.yml" "bap-client"
@@ -146,6 +148,14 @@ install_bpp_protocol_server(){
     fi
 
     sleep 10
+    docker volume create bpp_client_config_volume
+    docker volume create bpp_network_config_volume
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bpp_client_config_volume:/target busybox cp /source/bpp-client.yml /target/default.yml
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bpp_client_config_volume:/target busybox cp /source/bpp-client.yaml-sample /target
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bpp_network_config_volume:/target busybox cp /source/bpp-network.yml /target/default.yml
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bpp_network_config_volume:/target busybox cp /source/bpp-network.yaml-sample /target
+    docker rmi busybox
+
     start_container "docker-compose-bpp.yml" "bpp-client"
     start_container "docker-compose-bpp.yml" "bpp-network"
     sleep 10

--- a/install/beckn-onix.sh
+++ b/install/beckn-onix.sh
@@ -116,6 +116,12 @@ install_bap_protocol_server(){
         bash scripts/update_bap_config.sh
     fi
     sleep 10
+    docker volume create bap_client_config_volume
+    docker volume create bap_network_config_volume
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_client_config_volume:/target busybox cp /source/bap-client.yml /target/default.yml
+    docker run --rm -v $SCRIPT_DIR/../protocol-server-data:/source -v bap_network_config_volume:/target busybox cp /source/bap-network.yml /target/default.yml
+    docker rmi busybox
+
     start_container "docker-compose-bap.yml" "bap-client"
     start_container "docker-compose-bap.yml" "bap-network"
     sleep 10

--- a/install/docker-compose-app.yml
+++ b/install/docker-compose-app.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mongo_db:
     image: mongo

--- a/install/docker-compose-app.yml
+++ b/install/docker-compose-app.yml
@@ -6,7 +6,7 @@ services:
     restart: unless-stopped
     container_name: mongoDB
     volumes:
-      - ./docker_data/mongo_DB:/data/db
+      - beckn_mongo_db:/data/db
     networks:
       - beckn_network
     ports:
@@ -25,7 +25,7 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - ./docker_data/redis_DB:/data
+      - beckn_redis:/data
 
   queue_service:
     image: rabbitmq:3.9.11-management-alpine
@@ -43,4 +43,11 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
+
+volumes:
+  beckn_mongo_db:
+    name: beckn_mongo_db
+  beckn_redis:
+    name: beckn_redis

--- a/install/docker-compose-bap.yml
+++ b/install/docker-compose-bap.yml
@@ -35,12 +35,14 @@ networks:
 volumes:
   bap_client_config_volume:
     name: bap_client_config_volume
+    external: true
   bap_client_schemas_volume:
     name: bap_client_schemas_volume
   bap_client_logs_volume:
     name: bap_client_logs_volume
   bap_network_config_volume:
     name: bap_network_config_volume
+    external: true
   bap_network_schemas_volume:
     name: bap_network_schemas_volume
   bap_network_logs_volume:

--- a/install/docker-compose-bap.yml
+++ b/install/docker-compose-bap.yml
@@ -10,7 +10,9 @@ services:
       - 5001:5001
     restart: unless-stopped
     volumes:
-      - ./protocol-server-data/bap-client.yml:/usr/src/app/config/default.yml
+      - bap_client_config_volume:/usr/src/app/config
+      - bap_client_schemas_volume:/usr/src/app/schemas
+      - bap_client_logs_volume:/usr/src/app/logs
 
   bap-network:
     image: fidedocker/protocol-server
@@ -21,7 +23,25 @@ services:
       - 5002:5002
     restart: unless-stopped
     volumes:
-      - ./protocol-server-data/bap-network.yml:/usr/src/app/config/default.yml
+      - bap_network_config_volume:/usr/src/app/config
+      - bap_network_schemas_volume:/usr/src/app/schemas
+      - bap_network_logs_volume:/usr/src/app/logs
+
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
+
+volumes:
+  bap_client_config_volume:
+    name: bap_client_config_volume
+  bap_client_schemas_volume:
+    name: bap_client_schemas_volume
+  bap_client_logs_volume:
+    name: bap_client_logs_volume
+  bap_network_config_volume:
+    name: bap_network_config_volume
+  bap_network_schemas_volume:
+    name: bap_network_schemas_volume
+  bap_network_logs_volume:
+    name: bap_network_logs_volume

--- a/install/docker-compose-bap.yml
+++ b/install/docker-compose-bap.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   bap-client:
     image: fidedocker/protocol-server

--- a/install/docker-compose-bpp.yml
+++ b/install/docker-compose-bpp.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   bpp-client:
     image: fidedocker/protocol-server

--- a/install/docker-compose-bpp.yml
+++ b/install/docker-compose-bpp.yml
@@ -10,7 +10,9 @@ services:
       - 6001:6001
     restart: unless-stopped
     volumes:
-      - ./protocol-server-data/bpp-client.yml:/usr/src/app/config/default.yml
+      - bpp_client_config_volume:/usr/src/app/config
+      - bpp_client_schemas_volume:/usr/src/app/schemas
+      - bpp_client_logs_volume:/usr/src/app/logs
 
   bpp-network:
     image: fidedocker/protocol-server
@@ -21,9 +23,27 @@ services:
       - 6002:6002
     restart: unless-stopped
     volumes:
-      - ./protocol-server-data/bpp-network.yml:/usr/src/app/config/default.yml
+      - bpp_network_config_volume:/usr/src/app/config
+      - bpp_network_schemas_volume:/usr/src/app/schemas
+      - bpp_network_logs_volume:/usr/src/app/logs
 
 networks:
   beckn_network:
     name: beckn_network
     driver: bridge
+
+volumes:
+  bpp_client_config_volume:
+    name: bpp_client_config_volume
+    external: true
+  bpp_client_schemas_volume:
+    name: bpp_client_schemas_volume
+  bpp_client_logs_volume:
+    name: bpp_client_logs_volume
+  bpp_network_config_volume:
+    name: bpp_network_config_volume
+    external: true
+  bpp_network_schemas_volume:
+    name: bpp_network_schemas_volume
+  bpp_network_logs_volume:
+    name: bpp_network_logs_volume

--- a/install/docker-compose-bpp.yml
+++ b/install/docker-compose-bpp.yml
@@ -25,4 +25,5 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge

--- a/install/docker-compose-gateway.yml
+++ b/install/docker-compose-gateway.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   gateway:
     image: fidedocker/gateway

--- a/install/docker-compose-gateway.yml
+++ b/install/docker-compose-gateway.yml
@@ -16,6 +16,7 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
 
 volumes:

--- a/install/docker-compose-registry.yml
+++ b/install/docker-compose-registry.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   registry:
     image: fidedocker/registry

--- a/install/docker-compose-registry.yml
+++ b/install/docker-compose-registry.yml
@@ -16,6 +16,7 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
 
 volumes:

--- a/install/docker-compose-v2.yml
+++ b/install/docker-compose-v2.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   registry:
     image: fidedocker/registry

--- a/install/docker-compose-v2.yml
+++ b/install/docker-compose-v2.yml
@@ -106,6 +106,7 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
 
 volumes:

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   registry:
@@ -114,5 +114,5 @@ services:
 
 networks:
   beckn_network:
+    name: beckn_network
     driver: bridge
-

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   registry:
     image: fidedocker/registry

--- a/install/scripts/update_bpp_config.sh
+++ b/install/scripts/update_bpp_config.sh
@@ -117,7 +117,7 @@ else
 
     )
 
-    echo "Configuring BAP protocol server"
+    echo "Configuring BPP protocol server"
     # Apply replacements in both files
     for file in "$clientFile" "$networkFile"; do
         for key in "${!replacements[@]}"; do


### PR DESCRIPTION
This PR does the following:
1. Use docker volume instead of bind mount for redis and mongodb
2. Use docker volume for BAP and BPP for config, logs and schemas folder
3. Remove the version tag as it gives obsolete warning