### PR TITLE
fixing indentation in the cancel request rule

### DIFF
--- a/layer2/samples/mobility_1.1.0.yaml
+++ b/layer2/samples/mobility_1.1.0.yaml
@@ -2325,9 +2325,9 @@ paths:
                                     - CONFIRM_CANCEL
                               required:
                                 - code
-                              cancellation_reason_id:
-                                type: string
-                                pattern: '^[0-9]+$'
+                            cancellation_reason_id:
+                              type: string
+                              pattern: '^[0-9]+$'
                           required:
                             - order_id
                             - descriptor


### PR DESCRIPTION
### Description

This PR fixes a wrong indentation in api/l2-config/oas-3.1/ondemandride/example-rules/requests/cancel/cancellation_rules.yaml