### PR TITLE
Issue 527 - Remove static record_name from DeDI plugin config to enable dynamic participant lookup

### DIFF
--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -31,6 +31,8 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 	if timeoutStr, exists := config["timeout"]; exists && timeoutStr != "" {
 		if timeout, err := strconv.Atoi(timeoutStr); err == nil {
 			dediConfig.Timeout = timeout
+		} else {
+			log.Warnf(ctx, "Invalid timeout value '%s', using default", timeoutStr)
 		}
 	}
 

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -120,7 +120,7 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Parse response using local variables
+	// Parse response
 	var responseData map[string]interface{}
 	err = json.Unmarshal(body, &responseData)
 	if err != nil {
@@ -129,56 +129,56 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 
 	log.Debugf(ctx, "DeDi lookup request successful")
 
-	// Extract data using local variables
+	// Extract data field
 	data, ok := responseData["data"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid response format: missing data field")
 	}
 
-	// Extract details field which contains the actual participant data
+	// Extract details field
 	details, ok := data["details"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid response format: missing details field")
 	}
 
-	// Extract values from details field
-	entityName, ok := details["entity_name"].(string)
-	if !ok || entityName == "" {
-		return nil, fmt.Errorf("invalid or missing entity_name in response")
+	// Extract required fields from details
+	keyID, _ := details["key_id"].(string)
+	signingPublicKey, ok := details["signing_public_key"].(string)
+	if !ok || signingPublicKey == "" {
+		return nil, fmt.Errorf("invalid or missing signing_public_key in response")
 	}
-
-	entityURL, ok := details["entity_url"].(string)
-	if !ok || entityURL == "" {
-		return nil, fmt.Errorf("invalid or missing entity_url in response")
+	encrPublicKey, _ := details["encr_public_key"].(string)
+	detailsStatus, ok := details["status"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing status in response")
 	}
+	detailsCreated, _ := details["created"].(string)
+	detailsUpdated, _ := details["updated"].(string)
+	validFromStr, _ := details["valid_from"].(string)
+	validUntilStr, _ := details["valid_until"].(string)
 
-	publicKey, ok := details["publicKey"].(string)
-	if !ok || publicKey == "" {
-		return nil, fmt.Errorf("invalid or missing publicKey in response")
-	}
-
-	// Extract record_name as the subscriber ID (fallback to entity_name)
+	// Extract record_name as subscriber ID
 	recordName, _ := data["record_name"].(string)
 	if recordName == "" {
-		recordName = entityName
+		recordName = subscriberID
 	}
-
-	state, _ := data["state"].(string)
-	createdAt, _ := data["created_at"].(string)
-	updatedAt, _ := data["updated_at"].(string)
 
 	// Convert to Subscription format
 	subscription := model.Subscription{
 		Subscriber: model.Subscriber{
-			SubscriberID: recordName, // Use record_name as subscriber ID
-			URL:          entityURL,
+			SubscriberID: recordName,
+			URL:          req.URL,
 			Domain:       req.Domain,
 			Type:         req.Type,
 		},
-		SigningPublicKey: publicKey,
-		Status:           state,
-		Created:          parseTime(createdAt),
-		Updated:          parseTime(updatedAt),
+		KeyID:            keyID,
+		SigningPublicKey: signingPublicKey,
+		EncrPublicKey:    encrPublicKey,
+		ValidFrom:        parseTime(validFromStr),
+		ValidUntil:       parseTime(validUntilStr),
+		Status:           detailsStatus,
+		Created:          parseTime(detailsCreated),
+		Updated:          parseTime(detailsUpdated),
 	}
 
 	return []model.Subscription{subscription}, nil

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -139,11 +139,14 @@ func TestLookup(t *testing.T) {
 				"data": map[string]interface{}{
 					"record_name": "bap-network",
 					"details": map[string]interface{}{
-						"entity_name": "BAP Network Provider",
-						"entity_url":  "https://bap-network.example.com",
-						"publicKey":   "test-public-key",
-						"keyType":     "ed25519",
-						"keyFormat":   "base64",
+						"key_id":              "b692d295-5425-40f5-af77-d62646841dca",
+						"signing_public_key": "test-public-key",
+						"encr_public_key":    "test-encr-key",
+						"status":             "SUBSCRIBED",
+						"created":            "2023-01-01T00:00:00Z",
+						"updated":            "2023-01-01T00:00:00Z",
+						"valid_from":         "2023-01-01T00:00:00Z",
+						"valid_until":        "2024-01-01T00:00:00Z",
 					},
 					"state":      "live",
 					"created_at": "2023-01-01T00:00:00Z",
@@ -192,8 +195,8 @@ func TestLookup(t *testing.T) {
 		if subscription.SigningPublicKey != "test-public-key" {
 			t.Errorf("Expected signing_public_key test-public-key, got %s", subscription.SigningPublicKey)
 		}
-		if subscription.Status != "live" {
-			t.Errorf("Expected status live, got %s", subscription.Status)
+		if subscription.Status != "SUBSCRIBED" {
+			t.Errorf("Expected status SUBSCRIBED, got %s", subscription.Status)
 		}
 	})
 
@@ -259,13 +262,13 @@ func TestLookup(t *testing.T) {
 	})
 
 	// Test missing required fields
-	t.Run("missing entity_name", func(t *testing.T) {
+	t.Run("missing signing_public_key", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			response := map[string]interface{}{
 				"data": map[string]interface{}{
 					"details": map[string]interface{}{
-						"entity_url": "https://test.example.com",
-						"publicKey":  "test-public-key",
+						"key_id": "test-key-id",
+						"status": "SUBSCRIBED",
 					},
 				},
 			}
@@ -294,7 +297,7 @@ func TestLookup(t *testing.T) {
 		}
 		_, err = client.Lookup(ctx, req)
 		if err == nil {
-			t.Error("Expected error for missing details field, got nil")
+			t.Error("Expected error for missing signing_public_key, got nil")
 		}
 	})
 


### PR DESCRIPTION
Currently, the DeDi plugin in the Onix adapter reads namespace, registry_name, and record_name from the config file to form the lookup URL. This limits the plugin to looking up only a single record_name as per the config.

## Solution
- Remove static `record_name` field from configuration
- Use `bap_id` and `bpp_id` from request body as record_name to form the lookup URL
- Keep `namespace` and `registry_name` in config as they remain static
- Enable dynamic lookup supporting multiple record_names from incoming requests

Issue : https://github.com/Beckn-One/beckn-onix/issues/527
