### PR TITLE
Added Go utility to generate keys

### DIFF
--- a/install/generate-ed25519-keys.go
+++ b/install/generate-ed25519-keys.go
@@ -1,0 +1,30 @@
+package main
+
+/*
+To run this code and generate a new Ed25519 key pair, use the following command:
+go run install/generate-ed25519-keys.go
+*/
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"log"
+)
+
+func main() {
+	// Generate a new Ed25519 key pair using rand.Reader as default
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		log.Fatal("Failed to generate key pair:", err)
+	}
+
+	// The private key contains both seed and public key (64 bytes total)
+	// We need to extract just the seed (first 32 bytes)
+	seed := privateKey[:ed25519.SeedSize]
+
+	fmt.Println("=== Ed25519 Key Pair ===")
+	fmt.Printf("signingPrivateKey: %s\n", base64.StdEncoding.EncodeToString(seed))
+	fmt.Printf("signingPublicKey: %s\n", base64.StdEncoding.EncodeToString(publicKey))
+
+}


### PR DESCRIPTION
Added a simple Go file (`install/generate-ed25519-keys.go`) that, when run, generates a new `Ed25519` key pair using Go’s standard library and prints both keys to the console in a readable format.

Example usage:
```bash
go run cmd/keygen/main.go
```

Expected output:
```bash
=== Ed25519 Key Pair ===
signingPrivateKey: su506vhlHX8M+iHizPQbftg8ukS4WQo2RMXKd1LBPSg=
signingPublicKey: 9HWSPfFTnU+UD8blgGPdqVz8wuVo9YXKVlLCjZwiUTs=

```

Closes issue #546 