### PR TITLE
Issue 556 - Add configurable retry logic to dediregistry plugin

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -392,7 +392,34 @@ registry:
 
 ---
 
-#### 2. Key Manager Plugin
+#### 2. Dediregistry Plugin
+
+**Purpose**: Lookup participant information from a Decentralized Discovery (DeDi) registry.
+
+**Configuration**:
+```yaml
+registry:
+  id: dediregistry
+  config:
+    url: "https://dedi-wrapper.example.com/dedi"
+    registryName: "subscribers.beckn.one"
+    timeout: 30
+    retry_max: 3
+    retry_wait_min: 1s
+    retry_wait_max: 5s
+```
+
+**Parameters**:
+- `url`: DeDi wrapper API base URL (Required)
+- `registryName`: Name of the registry (Required)
+- `timeout`: Request timeout in seconds (Optional, default: client default)
+- `retry_max`: Maximum number of retry attempts (Optional, default: 4)
+- `retry_wait_min`: Minimum wait time between retries in duration format (Optional, default: 1s)
+- `retry_wait_max`: Maximum wait time between retries in duration format (Optional, default: 30s)
+
+---
+
+#### 3. Key Manager Plugin
 
 **Purpose**: Manage cryptographic keys for signing and verification.
 

--- a/pkg/plugin/implementation/dediregistry/README.md
+++ b/pkg/plugin/implementation/dediregistry/README.md
@@ -19,6 +19,9 @@ registry:
     url: "https://dedi-wrapper.example.com/dedi"
     registryName: "subscribers.beckn.one"
     timeout: 30
+    retry_max: 3
+    retry_wait_min: 1s
+    retry_wait_max: 5s
 ```
 
 ### Configuration Parameters
@@ -28,6 +31,9 @@ registry:
 | `url` | Yes | DeDi wrapper API base URL (include /dedi path) | - |
 | `registryName` | Yes | Registry name for lookup path | - |
 | `timeout` | No | Request timeout in seconds | Client default |
+| `retry_max` | No | Maximum number of retry attempts | 4 (library default) |
+| `retry_wait_min` | No | Minimum wait time between retries (e.g., "1s", "500ms") | 1s (library default) |
+| `retry_wait_max` | No | Maximum wait time between retries (e.g., "5s") | 30s (library default) |
 
 ## API Integration
 
@@ -88,6 +94,9 @@ modules:
             url: "https://dedi-wrapper.example.com/dedi"
             registryName: "subscribers.beckn.one"
             timeout: 30
+            retry_max: 3
+            retry_wait_min: 1s
+            retry_wait_max: 5s
       steps:
         - validateSign  # Required for registry lookup
         - addRoute

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -15,9 +15,12 @@ import (
 
 // Config holds configuration parameters for the DeDi registry client.
 type Config struct {
-	URL          string `yaml:"url" json:"url"`
-	RegistryName string `yaml:"registryName" json:"registryName"`
-	Timeout      int    `yaml:"timeout" json:"timeout"`
+	URL          string        `yaml:"url" json:"url"`
+	RegistryName string        `yaml:"registryName" json:"registryName"`
+	Timeout      int           `yaml:"timeout" json:"timeout"`
+	RetryMax     int           `yaml:"retry_max" json:"retry_max"`
+	RetryWaitMin time.Duration `yaml:"retry_wait_min" json:"retry_wait_min"`
+	RetryWaitMax time.Duration `yaml:"retry_wait_max" json:"retry_wait_max"`
 }
 
 // DeDiRegistryClient encapsulates the logic for calling the DeDi registry endpoints.
@@ -53,6 +56,17 @@ func New(ctx context.Context, cfg *Config) (*DeDiRegistryClient, func() error, e
 	// Configure timeout if provided
 	if cfg.Timeout > 0 {
 		retryClient.HTTPClient.Timeout = time.Duration(cfg.Timeout) * time.Second
+	}
+
+	// Configure retry settings if provided
+	if cfg.RetryMax > 0 {
+		retryClient.RetryMax = cfg.RetryMax
+	}
+	if cfg.RetryWaitMin > 0 {
+		retryClient.RetryWaitMin = cfg.RetryWaitMin
+	}
+	if cfg.RetryWaitMax > 0 {
+		retryClient.RetryWaitMax = cfg.RetryWaitMax
 	}
 
 	client := &DeDiRegistryClient{

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
@@ -84,6 +85,30 @@ func TestNew(t *testing.T) {
 	if err := closer(); err != nil {
 		t.Errorf("closer() error = %v", err)
 	}
+
+	t.Run("should apply custom retry settings", func(t *testing.T) {
+		cfg := &Config{
+			URL:          "http://test.com",
+			RegistryName: "subscribers.beckn.one",
+			RetryMax:     10,
+			RetryWaitMin: 100 * time.Millisecond,
+			RetryWaitMax: 1 * time.Second,
+		}
+		client, _, err := New(ctx, cfg)
+		if err != nil {
+			t.Fatalf("expected no error, but got: %v", err)
+		}
+
+		if client.client.RetryMax != cfg.RetryMax {
+			t.Errorf("expected RetryMax to be %d, but got %d", cfg.RetryMax, client.client.RetryMax)
+		}
+		if client.client.RetryWaitMin != cfg.RetryWaitMin {
+			t.Errorf("expected RetryWaitMin to be %v, but got %v", cfg.RetryWaitMin, client.client.RetryWaitMin)
+		}
+		if client.client.RetryWaitMax != cfg.RetryWaitMax {
+			t.Errorf("expected RetryWaitMax to be %v, but got %v", cfg.RetryWaitMax, client.client.RetryWaitMax)
+		}
+	})
 }
 
 func TestLookup(t *testing.T) {


### PR DESCRIPTION
### What Changed
Added optional retry configuration parameters to the `dediregistry` plugin to improve reliability when communicating with DeDi registry services.

### Changes Made
- **Plugin Code**: Added `retry_max`, `retry_wait_min`, and `retry_wait_max` configuration fields to the dediregistry plugin, matching the implementation in the registry plugin
- **Tests**: Added test case to verify retry settings are correctly applied
- **Documentation**: Updated CONFIG.md and plugin README.md with retry parameter documentation

### Why This Change
The dediregistry plugin previously lacked retry logic. This change adds configurable exponential backoff retry behavior, making the plugin more resilient to transient failures.

Issue : https://github.com/Beckn-One/beckn-onix/issues/556

### Example Configuration
```yaml
registry:
  id: dediregistry
  config:
    url: "[https://dedi-wrapper.example.com/dedi](https://dedi-wrapper.example.com/dedi)"
    registryName: "subscribers.beckn.one"
    timeout: 30
    retry_max: 3          # Optional
    retry_wait_min: 1s    # Optional
    retry_wait_max: 5s    # Optional
 
   