### PR TITLE
Issue 565 - Add retry configuration to  configs files.

### DIFF
--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -34,6 +34,9 @@ modules:
             url: http://34.14.173.68:8080/dedi
             registryName: subscribers.beckn.one
             timeout: 10
+            retry_max: 3
+            retry_wait_min: 100ms
+            retry_wait_max: 500ms
         keyManager:
           id: simplekeymanager
           config:
@@ -83,6 +86,9 @@ modules:
             url: http://34.14.173.68:8080/dedi
             registryName: subscribers.beckn.one
             timeout: 10
+            retry_max: 3
+            retry_wait_min: 100ms
+            retry_wait_max: 500ms
         keyManager:
           id: simplekeymanager
           config:

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -34,6 +34,9 @@ modules:
             url: http://34.14.173.68:8080/dedi
             registryName: subscribers.beckn.one
             timeout: 10
+            retry_max: 3
+            retry_wait_min: 100ms
+            retry_wait_max: 500ms
         keyManager:
           id: simplekeymanager
           config:
@@ -78,6 +81,9 @@ modules:
             url: http://34.14.173.68:8080/dedi
             registryName: subscribers.beckn.one
             timeout: 10
+            retry_max: 3
+            retry_wait_min: 100ms
+            retry_wait_max: 500ms
         keyManager:
           id: simplekeymanager
           config:


### PR DESCRIPTION
Updated [config/local-beckn-one-bap.yaml) and [config/local-beckn-one-bpp.yaml] to include retry parameters for dediregistry plugin.

Issue : https://github.com/Beckn-One/beckn-onix/issues/565

**Changes:**
- Added retry config :
  ```yaml
  retry_max: 3
  retry_wait_min: 100ms
  retry_wait_max: 500ms