### PR TITLE
Issue 569 - Remove payload byte array from error logs to improve readability

### DIFF
--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -85,7 +85,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Execute processing steps.
 	for _, step := range h.steps {
 		if err := step.Run(ctx); err != nil {
-			log.Errorf(ctx, err, "%T.run(%v):%v", step, ctx, err)
+			log.Errorf(ctx, err, "%T.run():%v", step, err)
 			response.SendNack(ctx, w, err)
 			return
 		}


### PR DESCRIPTION
## Problem
When errors occurred during request processing, logs were printing the entire StepContext struct including the request body as a byte array , making logs extremely difficult to read and debug.

## Solution
Removed the `ctx` parameter from the error log format string in `stdHandler.go` (line 88). The context is still passed as the first parameter to `log.Errorf()`, which automatically extracts and logs important metadata (transaction_id, message_id, subscriber_id, module_id).

## Changes
- **File**: `core/module/handler/stdHandler.go`
- **Line**: 88
- **Before**: `log.Errorf(ctx, err, "%T.run(%v):%v", step, ctx, err)`
- **After**: `log.Errorf(ctx, err, "%T.run():%v", step, err)`

Issue : https://github.com/Beckn-One/beckn-onix/issues/569
