### PR TITLE
Issue 551 - fix: ensure script exits on plugin build failure

### DIFF
--- a/install/build-plugins.sh
+++ b/install/build-plugins.sh
@@ -31,6 +31,7 @@ for plugin in "${plugins[@]}"; do
         echo "✓ Successfully built $plugin plugin"
     else
         echo "✗ Failed to build $plugin plugin"
+        exit 1
     fi
 done
 


### PR DESCRIPTION
1.Added exit 1 in the error handling block when any plugin build fails

2.Script now stops immediately on first compilation error and returns non-zero exit code

3.Prevents Docker builds from succeeding with broken plugins





Issue : https://github.com/Beckn-One/beckn-onix/issues/551