### PR TITLE
Update registry URLs in example configuration files to use beckn.io domain

### DIFF
--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -31,7 +31,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.testnet.beckn.one/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.one/registry/dedi
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -91,7 +91,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.testnet.beckn.one/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.one/registry/dedi
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -31,7 +31,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.testnet.beckn.one/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.one/registry/dedi
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -86,7 +86,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.testnet.beckn.one/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.one/registry/dedi
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3


### PR DESCRIPTION
Updated registry service URLs in example configuration files from
`https://api.testnet.beckn.one/registry` and `https://api.beckn.one/registry` 
to `https://api.dev.beckn.io/registry` and `https://api.beckn.io/registry` respectively