### PR TITLE
fix: remove sync.Once race and fix nil guard on log provider

### DIFF
--- a/core/module/handler/handlerMetrics.go
+++ b/core/module/handler/handlerMetrics.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -15,11 +16,39 @@ type HandlerMetrics struct {
 	RoutingDecisionsTotal     metric.Int64Counter
 }
 
-// GetHandlerMetrics returns fresh HandlerMetrics bound to the current global
-// meter provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
-// deduplicates instruments by name, so there is no double-registration risk.
-func GetHandlerMetrics(ctx context.Context) (*HandlerMetrics, error) {
-	return newHandlerMetrics()
+// handlerMetricsCache caches HandlerMetrics for the current global MeterProvider.
+// Instruments are rebound only when otel.SetMeterProvider changes the provider pointer.
+var handlerMetricsCache struct {
+	mu       sync.RWMutex
+	provider metric.MeterProvider
+	m        *HandlerMetrics
+}
+
+// GetHandlerMetrics returns HandlerMetrics bound to the current global MeterProvider,
+// rebuilding only when the provider has been replaced since the last call.
+func GetHandlerMetrics(_ context.Context) (*HandlerMetrics, error) {
+	current := otel.GetMeterProvider()
+
+	handlerMetricsCache.mu.RLock()
+	if handlerMetricsCache.provider == current && handlerMetricsCache.m != nil {
+		m := handlerMetricsCache.m
+		handlerMetricsCache.mu.RUnlock()
+		return m, nil
+	}
+	handlerMetricsCache.mu.RUnlock()
+
+	handlerMetricsCache.mu.Lock()
+	defer handlerMetricsCache.mu.Unlock()
+	if handlerMetricsCache.provider == current && handlerMetricsCache.m != nil {
+		return handlerMetricsCache.m, nil
+	}
+	m, err := newHandlerMetrics()
+	if err != nil {
+		return nil, err
+	}
+	handlerMetricsCache.provider = current
+	handlerMetricsCache.m = m
+	return m, nil
 }
 
 func newHandlerMetrics() (*HandlerMetrics, error) {

--- a/core/module/handler/handlerMetrics.go
+++ b/core/module/handler/handlerMetrics.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -16,18 +15,11 @@ type HandlerMetrics struct {
 	RoutingDecisionsTotal     metric.Int64Counter
 }
 
-var (
-	handlerMetricsInstance *HandlerMetrics
-	handlerMetricsOnce     sync.Once
-	handlerMetricsErr      error
-)
-
-// GetHandlerMetrics lazily initializes handler metric instruments and returns a cached reference.
+// GetHandlerMetrics returns fresh HandlerMetrics bound to the current global
+// meter provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
+// deduplicates instruments by name, so there is no double-registration risk.
 func GetHandlerMetrics(ctx context.Context) (*HandlerMetrics, error) {
-	handlerMetricsOnce.Do(func() {
-		handlerMetricsInstance, handlerMetricsErr = newHandlerMetrics()
-	})
-	return handlerMetricsInstance, handlerMetricsErr
+	return newHandlerMetrics()
 }
 
 func newHandlerMetrics() (*HandlerMetrics, error) {

--- a/core/module/handler/http_metric.go
+++ b/core/module/handler/http_metric.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"go.opentelemetry.io/otel"
@@ -33,11 +34,42 @@ func newHTTPMetrics() (*HTTPMetrics, error) {
 	return m, nil
 }
 
-// GetHTTPMetrics returns a fresh HTTPMetrics bound to the current global meter
-// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
-// deduplicates instruments by name, so there is no double-registration risk.
-func GetHTTPMetrics(ctx context.Context) (*HTTPMetrics, error) {
-	return newHTTPMetrics()
+// httpMetricsCache caches the HTTPMetrics for the current global MeterProvider.
+// When otel.SetMeterProvider is called (e.g. during startup or test setup) the
+// provider pointer changes, the cache misses, and instruments are rebound once.
+// Fast-path cost on every request: one atomic load + RLock + two pointer compares.
+var httpMetricsCache struct {
+	mu       sync.RWMutex
+	provider metric.MeterProvider
+	m        *HTTPMetrics
+}
+
+// GetHTTPMetrics returns HTTPMetrics bound to the current global MeterProvider,
+// rebuilding only when the provider has been replaced since the last call.
+func GetHTTPMetrics(_ context.Context) (*HTTPMetrics, error) {
+	current := otel.GetMeterProvider()
+
+	httpMetricsCache.mu.RLock()
+	if httpMetricsCache.provider == current && httpMetricsCache.m != nil {
+		m := httpMetricsCache.m
+		httpMetricsCache.mu.RUnlock()
+		return m, nil
+	}
+	httpMetricsCache.mu.RUnlock()
+
+	httpMetricsCache.mu.Lock()
+	defer httpMetricsCache.mu.Unlock()
+	// Double-check after acquiring the write lock.
+	if httpMetricsCache.provider == current && httpMetricsCache.m != nil {
+		return httpMetricsCache.m, nil
+	}
+	m, err := newHTTPMetrics()
+	if err != nil {
+		return nil, err
+	}
+	httpMetricsCache.provider = current
+	httpMetricsCache.m = m
+	return m, nil
 }
 
 // StatusClass returns the HTTP status class string (e.g. 200 -> "2xx").

--- a/core/module/handler/http_metric.go
+++ b/core/module/handler/http_metric.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"go.opentelemetry.io/otel"
@@ -17,14 +16,7 @@ type HTTPMetrics struct {
 	HttpRequestCount metric.Int64Counter
 }
 
-var (
-	httpMetricsInstance *HTTPMetrics
-	httpMetricsOnce     sync.Once
-	httpMetricsErr      error
-)
-
 func newHTTPMetrics() (*HTTPMetrics, error) {
-
 	meter := otel.GetMeterProvider().Meter(telemetry.ScopeName,
 		metric.WithInstrumentationVersion(telemetry.ScopeVersion))
 	m := &HTTPMetrics{}
@@ -41,11 +33,11 @@ func newHTTPMetrics() (*HTTPMetrics, error) {
 	return m, nil
 }
 
+// GetHTTPMetrics returns a fresh HTTPMetrics bound to the current global meter
+// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
+// deduplicates instruments by name, so there is no double-registration risk.
 func GetHTTPMetrics(ctx context.Context) (*HTTPMetrics, error) {
-	httpMetricsOnce.Do(func() {
-		httpMetricsInstance, httpMetricsErr = newHTTPMetrics()
-	})
-	return httpMetricsInstance, httpMetricsErr
+	return newHTTPMetrics()
 }
 
 // StatusClass returns the HTTP status class string (e.g. 200 -> "2xx").

--- a/core/module/handler/step_metrics.go
+++ b/core/module/handler/step_metrics.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"go.opentelemetry.io/otel"
@@ -17,18 +16,11 @@ type StepMetrics struct {
 	StepErrorsTotal       metric.Int64Counter
 }
 
-var (
-	stepMetricsInstance *StepMetrics
-	stepMetricsOnce     sync.Once
-	stepMetricsErr      error
-)
-
-// GetStepMetrics lazily initializes step metric instruments and returns a cached reference.
+// GetStepMetrics returns fresh StepMetrics bound to the current global meter
+// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
+// deduplicates instruments by name, so there is no double-registration risk.
 func GetStepMetrics(ctx context.Context) (*StepMetrics, error) {
-	stepMetricsOnce.Do(func() {
-		stepMetricsInstance, stepMetricsErr = newStepMetrics()
-	})
-	return stepMetricsInstance, stepMetricsErr
+	return newStepMetrics()
 }
 
 func newStepMetrics() (*StepMetrics, error) {

--- a/core/module/handler/step_metrics.go
+++ b/core/module/handler/step_metrics.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"go.opentelemetry.io/otel"
@@ -16,11 +17,39 @@ type StepMetrics struct {
 	StepErrorsTotal       metric.Int64Counter
 }
 
-// GetStepMetrics returns fresh StepMetrics bound to the current global meter
-// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
-// deduplicates instruments by name, so there is no double-registration risk.
-func GetStepMetrics(ctx context.Context) (*StepMetrics, error) {
-	return newStepMetrics()
+// stepMetricsCache caches StepMetrics for the current global MeterProvider.
+// Instruments are rebound only when otel.SetMeterProvider changes the provider pointer.
+var stepMetricsCache struct {
+	mu       sync.RWMutex
+	provider metric.MeterProvider
+	m        *StepMetrics
+}
+
+// GetStepMetrics returns StepMetrics bound to the current global MeterProvider,
+// rebuilding only when the provider has been replaced since the last call.
+func GetStepMetrics(_ context.Context) (*StepMetrics, error) {
+	current := otel.GetMeterProvider()
+
+	stepMetricsCache.mu.RLock()
+	if stepMetricsCache.provider == current && stepMetricsCache.m != nil {
+		m := stepMetricsCache.m
+		stepMetricsCache.mu.RUnlock()
+		return m, nil
+	}
+	stepMetricsCache.mu.RUnlock()
+
+	stepMetricsCache.mu.Lock()
+	defer stepMetricsCache.mu.Unlock()
+	if stepMetricsCache.provider == current && stepMetricsCache.m != nil {
+		return stepMetricsCache.m, nil
+	}
+	m, err := newStepMetrics()
+	if err != nil {
+		return nil, err
+	}
+	stepMetricsCache.provider = current
+	stepMetricsCache.m = m
+	return m, nil
 }
 
 func newStepMetrics() (*StepMetrics, error) {

--- a/core/module/handler/step_metrics_test.go
+++ b/core/module/handler/step_metrics_test.go
@@ -39,18 +39,38 @@ func TestGetStepMetrics_ConcurrentAccess(t *testing.T) {
 	require.NoError(t, err)
 	defer provider.Shutdown(context.Background())
 
-	// Test that GetStepMetrics is safe for concurrent access
-	// and returns the same instance (singleton pattern)
+	// Since sync.Once was removed, each call returns a fresh *StepMetrics wrapping
+	// the same underlying OTel instruments (the SDK deduplicates by name).
+	// Verify both calls succeed and return fully-initialized instruments.
 	metrics1, err1 := GetStepMetrics(ctx)
 	require.NoError(t, err1)
 	require.NotNil(t, metrics1)
+	assert.NotNil(t, metrics1.StepExecutionDuration)
+	assert.NotNil(t, metrics1.StepExecutionTotal)
+	assert.NotNil(t, metrics1.StepErrorsTotal)
 
 	metrics2, err2 := GetStepMetrics(ctx)
 	require.NoError(t, err2)
 	require.NotNil(t, metrics2)
+	assert.NotNil(t, metrics2.StepExecutionDuration)
+	assert.NotNil(t, metrics2.StepExecutionTotal)
+	assert.NotNil(t, metrics2.StepErrorsTotal)
 
-	// Should return the same instance
-	assert.Equal(t, metrics1, metrics2, "GetStepMetrics should return the same instance")
+	// Verify concurrent access is safe — 20 goroutines each calling GetStepMetrics
+	// while simultaneously recording on the returned instruments.
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m, err := GetStepMetrics(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, m)
+			m.StepExecutionTotal.Add(ctx, 1,
+				metric.WithAttributes(telemetry.AttrStep.String("concurrent"), telemetry.AttrModule.String("test")))
+		}()
+	}
+	wg.Wait()
 }
 
 func TestGetStepMetrics_WithoutProvider(t *testing.T) {

--- a/pkg/plugin/implementation/cache/cache_metrics.go
+++ b/pkg/plugin/implementation/cache/cache_metrics.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -15,11 +16,40 @@ type CacheMetrics struct {
 	CacheMissesTotal     metric.Int64Counter
 }
 
-// GetCacheMetrics returns fresh CacheMetrics bound to the current global meter
-// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
-// deduplicates instruments by name, so there is no double-registration risk.
-func GetCacheMetrics(ctx context.Context) (*CacheMetrics, error) {
-	return newCacheMetrics()
+// cacheMetricsCache caches the CacheMetrics for the current global MeterProvider.
+// Instruments are rebound only when otel.SetMeterProvider changes the provider pointer.
+var cacheMetricsCache struct {
+	mu       sync.RWMutex
+	provider metric.MeterProvider
+	m        *CacheMetrics
+}
+
+// GetCacheMetrics returns CacheMetrics bound to the current global MeterProvider,
+// rebuilding only when the provider has been replaced since the last call.
+func GetCacheMetrics(_ context.Context) (*CacheMetrics, error) {
+	current := otel.GetMeterProvider()
+
+	cacheMetricsCache.mu.RLock()
+	if cacheMetricsCache.provider == current && cacheMetricsCache.m != nil {
+		m := cacheMetricsCache.m
+		cacheMetricsCache.mu.RUnlock()
+		return m, nil
+	}
+	cacheMetricsCache.mu.RUnlock()
+
+	cacheMetricsCache.mu.Lock()
+	defer cacheMetricsCache.mu.Unlock()
+	// Double-check after acquiring the write lock.
+	if cacheMetricsCache.provider == current && cacheMetricsCache.m != nil {
+		return cacheMetricsCache.m, nil
+	}
+	m, err := newCacheMetrics()
+	if err != nil {
+		return nil, err
+	}
+	cacheMetricsCache.provider = current
+	cacheMetricsCache.m = m
+	return m, nil
 }
 
 func newCacheMetrics() (*CacheMetrics, error) {

--- a/pkg/plugin/implementation/cache/cache_metrics.go
+++ b/pkg/plugin/implementation/cache/cache_metrics.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -13,21 +12,14 @@ import (
 type CacheMetrics struct {
 	CacheOperationsTotal metric.Int64Counter
 	CacheHitsTotal       metric.Int64Counter
-	CacheMissesTotal    metric.Int64Counter
+	CacheMissesTotal     metric.Int64Counter
 }
 
-var (
-	cacheMetricsInstance *CacheMetrics
-	cacheMetricsOnce     sync.Once
-	cacheMetricsErr      error
-)
-
-// GetCacheMetrics lazily initializes cache metric instruments and returns a cached reference.
+// GetCacheMetrics returns fresh CacheMetrics bound to the current global meter
+// provider. otel.GetMeterProvider() is safe to call repeatedly; the SDK
+// deduplicates instruments by name, so there is no double-registration risk.
 func GetCacheMetrics(ctx context.Context) (*CacheMetrics, error) {
-	cacheMetricsOnce.Do(func() {
-		cacheMetricsInstance, cacheMetricsErr = newCacheMetrics()
-	})
-	return cacheMetricsInstance, cacheMetricsErr
+	return newCacheMetrics()
 }
 
 func newCacheMetrics() (*CacheMetrics, error) {

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -173,6 +173,7 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 		processor := logsdk.NewBatchProcessor(logExporter)
 		logProvider = logsdk.NewLoggerProvider(logsdk.WithProcessor(processor), logsdk.WithResource(resAudit))
 		global.SetLoggerProvider(logProvider)
+		telemetry.SetLogsEnabled(true)
 	}
 
 	return &telemetry.Provider{

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -198,6 +198,9 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 				if err := logProvider.Shutdown(shutdownCtx); err != nil {
 					errs = append(errs, fmt.Errorf("logs shutdown: %w", err))
 				}
+				// Clear the flag so EmitAuditLogs does not emit through the
+				// now-closed provider if telemetry is restarted with logs disabled.
+				telemetry.SetLogsEnabled(false)
 			}
 			if len(errs) > 0 {
 				return fmt.Errorf("shutdown errors: %v", errs)

--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -16,9 +16,12 @@ import (
 const auditLoggerName = "Beckn_ONIX"
 
 func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
-	// global.GetLoggerProvider() always returns a no-op provider (never nil).
-	// Use the logEnabled flag set by otelsetup to detect whether a real provider
-	// has been registered; warn once and drop if logging was not configured.
+	// global.GetLoggerProvider() always returns a no-op provider (never nil),
+	// so a nil-check on the provider is ineffective. Instead we rely on the
+	// logEnabled atomic flag, which otelsetup sets to true after calling
+	// global.SetLoggerProvider with a real SDK provider. If logging was not
+	// configured, we warn and return early rather than silently dropping records
+	// into the no-op provider.
 	if !LogsEnabled() {
 		logger.Warnf(ctx, "failed to emit audit logs, logs disabled")
 		return

--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -16,12 +16,15 @@ import (
 const auditLoggerName = "Beckn_ONIX"
 
 func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
-
-	provider := global.GetLoggerProvider()
-	if provider == nil {
+	// global.GetLoggerProvider() always returns a no-op provider (never nil).
+	// Use the logEnabled flag set by otelsetup to detect whether a real provider
+	// has been registered; warn once and drop if logging was not configured.
+	if !LogsEnabled() {
 		logger.Warnf(ctx, "failed to emit audit logs, logs disabled")
 		return
 	}
+
+	provider := global.GetLoggerProvider()
 
 	sum := sha256.Sum256(body)
 	auditBody := selectAuditPayload(ctx, body)

--- a/pkg/telemetry/audit_test.go
+++ b/pkg/telemetry/audit_test.go
@@ -1,0 +1,87 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/log"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsEnabled_DefaultFalse(t *testing.T) {
+	// Ensure the flag starts false in a clean state.
+	// We save and restore to avoid polluting other tests.
+	original := LogsEnabled()
+	t.Cleanup(func() { SetLogsEnabled(original) })
+
+	SetLogsEnabled(false)
+	assert.False(t, LogsEnabled(), "LogsEnabled should be false after SetLogsEnabled(false)")
+}
+
+func TestLogsEnabled_SetTrue(t *testing.T) {
+	original := LogsEnabled()
+	t.Cleanup(func() { SetLogsEnabled(original) })
+
+	SetLogsEnabled(true)
+	assert.True(t, LogsEnabled(), "LogsEnabled should be true after SetLogsEnabled(true)")
+}
+
+func TestEmitAuditLogs_Disabled(t *testing.T) {
+	original := LogsEnabled()
+	t.Cleanup(func() { SetLogsEnabled(original) })
+
+	SetLogsEnabled(false)
+
+	// Should return early without panicking.
+	require.NotPanics(t, func() {
+		EmitAuditLogs(context.Background(), []byte(`{"message":"test"}`))
+	}, "EmitAuditLogs should not panic when logs are disabled")
+}
+
+func TestEmitAuditLogs_Enabled(t *testing.T) {
+	ctx := context.Background()
+	provider, exporter, err := NewTestProviderWithLogs(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(ctx)
+
+	require.True(t, LogsEnabled(), "LogsEnabled should be true after NewTestProviderWithLogs")
+
+	require.NotPanics(t, func() {
+		EmitAuditLogs(ctx, []byte(`{"message":"audit-test"}`), log.String("extra_key", "extra_value"))
+	}, "EmitAuditLogs should not panic when logs are enabled")
+
+	// One log record must be emitted regardless of how selectAuditPayload
+	// transforms the body (no matching audit rules → empty body string is fine).
+	records := exporter.Records()
+	require.Len(t, records, 1, "exactly one log record should be emitted")
+
+	// Verify the standard attributes set by EmitAuditLogs are present.
+	var hasChecksum, hasLogUUID, hasExtraKey bool
+	records[0].WalkAttributes(func(kv log.KeyValue) bool {
+		switch kv.Key {
+		case "checkSum":
+			hasChecksum = true
+		case "log_uuid":
+			hasLogUUID = true
+		case "extra_key":
+			hasExtraKey = true
+		}
+		return true
+	})
+	assert.True(t, hasChecksum, "audit record should include checkSum attribute")
+	assert.True(t, hasLogUUID, "audit record should include log_uuid attribute")
+	assert.True(t, hasExtraKey, "audit record should include caller-supplied extra_key attribute")
+}
+
+func TestNewTestProviderWithLogs_ShutdownResetsFlag(t *testing.T) {
+	ctx := context.Background()
+	provider, _, err := NewTestProviderWithLogs(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, LogsEnabled(), "LogsEnabled should be true while provider is active")
+
+	require.NoError(t, provider.Shutdown(ctx))
+	assert.False(t, LogsEnabled(), "LogsEnabled should be false after provider shutdown")
+}

--- a/pkg/telemetry/pluginMetrics.go
+++ b/pkg/telemetry/pluginMetrics.go
@@ -72,11 +72,39 @@ func GetNetworkMetricsConfig() (granularity, frequency string) {
 	return networkMetricsGranularity, networkMetricsFrequency
 }
 
-// GetMetrics returns fresh Metrics bound to the current global meter provider.
-// otel.GetMeterProvider() is safe to call repeatedly; the SDK deduplicates
-// instruments by name, so there is no double-registration risk.
-func GetMetrics(ctx context.Context) (*Metrics, error) {
-	return newMetrics()
+// pluginMetricsCache caches Metrics for the current global MeterProvider.
+// Instruments are rebound only when otel.SetMeterProvider changes the provider pointer.
+var pluginMetricsCache struct {
+	mu       sync.RWMutex
+	provider metric.MeterProvider
+	m        *Metrics
+}
+
+// GetMetrics returns Metrics bound to the current global MeterProvider,
+// rebuilding only when the provider has been replaced since the last call.
+func GetMetrics(_ context.Context) (*Metrics, error) {
+	current := otel.GetMeterProvider()
+
+	pluginMetricsCache.mu.RLock()
+	if pluginMetricsCache.provider == current && pluginMetricsCache.m != nil {
+		m := pluginMetricsCache.m
+		pluginMetricsCache.mu.RUnlock()
+		return m, nil
+	}
+	pluginMetricsCache.mu.RUnlock()
+
+	pluginMetricsCache.mu.Lock()
+	defer pluginMetricsCache.mu.Unlock()
+	if pluginMetricsCache.provider == current && pluginMetricsCache.m != nil {
+		return pluginMetricsCache.m, nil
+	}
+	m, err := newMetrics()
+	if err != nil {
+		return nil, err
+	}
+	pluginMetricsCache.provider = current
+	pluginMetricsCache.m = m
+	return m, nil
 }
 
 func newMetrics() (*Metrics, error) {

--- a/pkg/telemetry/pluginMetrics.go
+++ b/pkg/telemetry/pluginMetrics.go
@@ -22,12 +22,6 @@ type Metrics struct {
 	PluginErrorsTotal       metric.Int64Counter
 }
 
-var (
-	metricsInstance *Metrics
-	metricsOnce     sync.Once
-	metricsErr      error
-)
-
 // Attribute keys shared across instruments.
 var (
 	AttrModule               = attribute.Key("module")
@@ -78,12 +72,11 @@ func GetNetworkMetricsConfig() (granularity, frequency string) {
 	return networkMetricsGranularity, networkMetricsFrequency
 }
 
-// GetMetrics lazily initializes instruments and returns a cached reference.
+// GetMetrics returns fresh Metrics bound to the current global meter provider.
+// otel.GetMeterProvider() is safe to call repeatedly; the SDK deduplicates
+// instruments by name, so there is no double-registration risk.
 func GetMetrics(ctx context.Context) (*Metrics, error) {
-	metricsOnce.Do(func() {
-		metricsInstance, metricsErr = newMetrics()
-	})
-	return metricsInstance, metricsErr
+	return newMetrics()
 }
 
 func newMetrics() (*Metrics, error) {

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -12,6 +13,22 @@ const (
 	ScopeName    = "beckn-onix"
 	ScopeVersion = "v2.0.0"
 )
+
+// logEnabled is set to true by otelsetup when a real log provider is registered.
+// global.GetLoggerProvider() always returns a no-op provider (never nil), so we
+// use this flag to distinguish "logs configured" from "logs disabled".
+var logEnabled atomic.Bool
+
+// SetLogsEnabled marks whether a real OTel log provider has been registered.
+// It must be called by otelsetup after calling global.SetLoggerProvider.
+func SetLogsEnabled(enabled bool) {
+	logEnabled.Store(enabled)
+}
+
+// LogsEnabled reports whether a real OTel log provider is active.
+func LogsEnabled() bool {
+	return logEnabled.Load()
+}
 
 // Provider holds references to telemetry components that need coordinated shutdown.
 type Provider struct {

--- a/pkg/telemetry/test_helper.go
+++ b/pkg/telemetry/test_helper.go
@@ -2,11 +2,14 @@ package telemetry
 
 import (
 	"context"
+	"sync"
 
 	clientprom "github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/log/global"
+	logsdk "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -51,6 +54,70 @@ func NewTestProvider(ctx context.Context) (*Provider, error) {
 			return meterProvider.Shutdown(ctx)
 		},
 	}, nil
+}
+
+// RecordingLogExporter is a simple in-memory log exporter for testing.
+// It collects emitted log records so test assertions can inspect them.
+type RecordingLogExporter struct {
+	mu      sync.Mutex
+	records []logsdk.Record
+}
+
+func (e *RecordingLogExporter) Export(_ context.Context, records []logsdk.Record) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, r := range records {
+		e.records = append(e.records, r.Clone())
+	}
+	return nil
+}
+
+func (e *RecordingLogExporter) Shutdown(_ context.Context) error  { return nil }
+func (e *RecordingLogExporter) ForceFlush(_ context.Context) error { return nil }
+
+// Records returns a snapshot of all collected log records.
+func (e *RecordingLogExporter) Records() []logsdk.Record {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]logsdk.Record, len(e.records))
+	copy(out, e.records)
+	return out
+}
+
+// NewTestProviderWithLogs creates a telemetry provider with metrics and an
+// in-memory log recorder. It sets SetLogsEnabled(true) so EmitAuditLogs
+// routes through the provider. The returned RecordingLogExporter lets tests
+// assert on the emitted log records. Shutdown resets the logs-enabled flag.
+func NewTestProviderWithLogs(ctx context.Context) (*Provider, *RecordingLogExporter, error) {
+	provider, err := NewTestProvider(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	exporter := &RecordingLogExporter{}
+	processor := logsdk.NewSimpleProcessor(exporter)
+	logProvider := logsdk.NewLoggerProvider(logsdk.WithProcessor(processor))
+	global.SetLoggerProvider(logProvider)
+	SetLogsEnabled(true)
+
+	return &Provider{
+		MeterProvider: provider.MeterProvider,
+		LogProvider:   logProvider,
+		Shutdown: func(shutdownCtx context.Context) error {
+			SetLogsEnabled(false)
+			var errs []error
+			if err := logProvider.Shutdown(shutdownCtx); err != nil {
+				errs = append(errs, err)
+			}
+			if err := provider.MeterProvider.Shutdown(shutdownCtx); err != nil {
+				errs = append(errs, err)
+			}
+			if len(errs) > 0 {
+				return errs[0]
+			}
+			return nil
+		},
+	}, exporter, nil
 }
 
 // NewTestProviderWithTrace creates a telemetry provider with both metrics and


### PR DESCRIPTION
## Summary

### Issue #616 — Metric instrument caching: from sync.Once to provider-identity cache

**Root cause:** The original `sync.Once` singletons for all five metric getters fired exactly once. If a request or constructor ran before `otelsetup` registered the real `MeterProvider`, the no-op instruments were cached permanently with no escape hatch.

**First fix attempt (removed):** Drop `sync.Once` and call `newXxx()` on every `Get*Metrics` invocation, relying on the OTel SDK's name-based deduplication. This eliminated the permanent trap but introduced a new problem: per-request and per-operation allocation on the hot paths (`ServeHTTP` calls `GetHTTPMetrics` twice per request; every cache op calls `GetCacheMetrics`).

**Final fix — provider-identity cache:** Each of the five metric getters now holds a package-level cache struct `{ sync.RWMutex, MeterProvider, *Metrics }`. On every call:

1. **Fast path (RLock):** if `otel.GetMeterProvider()` returns the same pointer as the cached provider, return cached instruments immediately. Cost: one atomic load + pointer compare — negligible at any RPS.
2. **Slow path (write lock, double-checked):** rebuild `newXxx()` only when `otel.SetMeterProvider` has been called since the last build, then update the cached pointer and instruments.

**Why this is not sync.Once:** `sync.Once` fires exactly once — stale no-op instruments are cached forever. The provider-identity check invalidates the cache whenever the provider pointer changes. A call racing with `otel.SetMeterProvider` binds to whichever provider it observes; the very next call after the real provider is registered rebinds correctly. There is no permanent trap.

All five getters follow the identical pattern for consistency — including construction-time getters (`GetStepMetrics`, `GetHandlerMetrics`, `GetMetrics`) — so a constructor that runs before the real provider is set will self-heal on the next call rather than leaving the owning struct permanently bound to no-op instruments.

### Issue #617 — Ineffective nil guard on log provider

`global.GetLoggerProvider()` never returns nil — it always returns a no-op provider when no real provider is registered, making the previous `if provider == nil` check dead code.

**Fix:** Introduced a package-level `atomic.Bool` (`telemetry.SetLogsEnabled`) that `otelsetup` sets to `true` only after successfully wiring the real log provider via `global.SetLoggerProvider`. `EmitAuditLogs` gates on `LogsEnabled()` instead of the nil check, and `otelsetup`'s shutdown closure resets it to `false` after tearing down the log provider — preventing emission through a closed provider if telemetry is restarted with logs disabled.

### Test improvements

- `pkg/telemetry/test_helper.go`: Added `RecordingLogExporter` (in-memory log recorder) and `NewTestProviderWithLogs` helper that wires a real SDK log provider, sets `SetLogsEnabled(true)`, and resets the flag on `Shutdown`.
- `pkg/telemetry/audit_test.go` (new): Tests for `LogsEnabled` toggle, `EmitAuditLogs` early-return when disabled, record emission and attribute presence when enabled, and flag reset on provider shutdown.
- `core/module/handler/step_metrics_test.go`: Fixed `TestGetStepMetrics_ConcurrentAccess` — removed stale same-pointer assertion left over from the `sync.Once` era; replaced with per-instrument non-nil checks and a 20-goroutine concurrent stress test.

## Test plan

- [ ] `go test -race ./core/module/handler/... ./pkg/telemetry/...` — all pass, no races detected
- [ ] `go build ./pkg/plugin/implementation/otelsetup` — clean build
- [ ] `go.mod` remains at `go 1.24.6` — no version bump