### PR TITLE
feat(#604): unified audit pipeline with PII masking and field selection

### DIFF
--- a/config/audit-fields.yaml
+++ b/config/audit-fields.yaml
@@ -1,89 +1,91 @@
-auditRules:
+# Audit logging configuration for ONIX.
+#
+# mode: full       — emit the entire payload; apply PII masking where configured.
+# mode: selective  — emit only the fields listed under selectedFields, then mask PII.
+#
+# The two-stage pipeline runs in a single pass over the payload:
+#   1. Key-name masking  (maskRules)   — checked first, O(1) per field
+#   2. Path-override masking           — for fields needing path-level precision
+#   3. Field selection / dropping      — only active in selective mode
+#
+mode: full
+
+# Named masking patterns — define HOW a value is masked.
+# Referenced by name from maskRules and pathOverrides.
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+  phone:
+    maskType: last4
+  sensitive:
+    maskType: replace
+    mask: "[REDACTED]"
+  account:
+    maskType: last4
+
+# maskRules — driven by field name, not payload path.
+# A field is masked wherever it appears in the payload, regardless of nesting depth.
+# This makes rules portable across Beckn domains, actions, and schema versions.
+maskRules:
+  - keys: [email, emailAddress, supportEmail, providerEmail]
+    pattern: email
+
+  - keys: [phone, telephone, mobile, supportPhone, providerPhone]
+    pattern: phone
+
+  - keys: [displayName, fullName, accountHolderName]
+    pattern: sensitive
+
+  - keys: [accountNumber, vpa]
+    pattern: account
+
+  - keys: [paymentURL, txnRef, paidAt]
+    pattern: sensitive
+
+# pathOverrides — use sparingly.
+# These bind masking to a specific dot-path and are harder to maintain as schemas
+# evolve. Prefer maskRules (key-name matching) wherever possible.
+pathOverrides: []
+
+# selectedFields — only applied when mode: selective.
+# Lists the dot-paths to include in the audit log per action.
+# "default" is the fallback for any action not explicitly listed.
+# Field names use camelCase to match the current Beckn payload schema.
+selectedFields:
   default:
-    - context.transaction_id
-    - context.message_id
+    - context.transactionId
+    - context.messageId
     - context.action
     - context.domain
-    - context.bap_id
-    - context.bpp_id
-
-  discover:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.filters
-    - message.spatial
-
-  select:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.order.beckn:buyer.beckn:id
-    - message.order.beckn:seller
-    - message.order.beckn:orderItems.beckn:acceptedOffer.beckn:id
-    - message.order.beckn:orderAttributes
-
-  init:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.order.beckn:id
-    - message.order.beckn:buyer.beckn:id
-    - message.order.beckn:orderValue.value
-    - message.order.beckn:payment.beckn:paymentStatus
+    - context.bapId
+    - context.bppId
 
   confirm:
-    - context.transaction_id
-    - context.message_id
+    - context.transactionId
+    - context.messageId
     - context.action
-    - context.timestamp
-    - message.order.beckn:id
-    - message.order.beckn:orderStatus
-    - message.order.beckn:buyer.beckn:id
-    - message.order.beckn:payment.beckn:txnRef
-    - message.order.beckn:payment.beckn:paymentStatus
+    - context.domain
+    - context.bapId
+    - context.bppId
+    - message.order.id
+    - message.order.status
+    - message.order.payment.status
+
+  init:
+    - context.transactionId
+    - context.messageId
+    - context.action
+    - context.domain
+    - context.bapId
+    - context.bppId
+    - message.order.id
+    - message.order.value
 
   update:
-    - context.transaction_id
-    - context.message_id
+    - context.transactionId
+    - context.messageId
     - context.action
-    - context.timestamp
-    - message.order.beckn:id
-    - message.order.beckn:orderStatus
-    - message.order.beckn:fulfillment.beckn:deliveryAttributes.sessionStatus
-
-  track:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.order.beckn:id
-
-  cancel:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.order.beckn:id
-    - message.order.beckn:orderStatus
-    - message.order.beckn:buyer.beckn:id
-
-  rating:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.id
-    - message.value
-    - message.category
-
-  support:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.ref_id
-    - message.ref_type
+    - context.domain
+    - message.order.id
+    - message.order.status

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -87,6 +87,17 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-beckn-one-routing-BAPReceiver.yaml
+        checkPolicy:
+          id: opapolicychecker
+          config:
+            # Policy source configuration.
+            # type: url | file | dir | bundle
+            # location: path or URL to policy source
+            # query: OPA query path to evaluate (required)
+            type: file
+            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
+            query: "data.policy.result"
+            refreshIntervalSeconds: "300"
         middleware:
           - id: reqpreprocessor
             config:
@@ -94,6 +105,7 @@ modules:
               role: bap
       steps:
         - validateSign
+        - checkPolicy
         - addRoute
         - validateSchema
   
@@ -147,12 +159,20 @@ modules:
             routingConfig: ./config/local-beckn-one-routing-BAPCaller.yaml
         signer:
           id: signer
+        checkPolicy:
+          id: opapolicychecker
+          config:
+            type: file
+            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
+            query: "data.policy.result"
+            refreshIntervalSeconds: "300"
         middleware:
           - id: reqpreprocessor
             config:
               contextKeys: transaction_id,message_id
               role: bap
       steps:
+        - checkPolicy
         - addRoute
         - sign
         - validateSchema

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -33,7 +33,8 @@ plugins:
       enableTracing: "true"
       enableLogs: "true"
       timeInterval: "5"
-      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      auditFieldsConfig: "/app/config/audit-fields.yaml" # this can be git url
+      cacheTTL: "3600"
 
 modules:
   - name: bapTxnReceiver
@@ -73,7 +74,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -86,17 +87,6 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-beckn-one-routing-BAPReceiver.yaml
-        checkPolicy:
-          id: opapolicychecker
-          config:
-            # Policy source configuration.
-            # type: url | file | dir | bundle
-            # location: path or URL to policy source
-            # query: OPA query path to evaluate (required)
-            type: file
-            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
-            query: "data.policy.result"
-            refreshIntervalSeconds: "300"
         middleware:
           - id: reqpreprocessor
             config:
@@ -104,7 +94,6 @@ modules:
               role: bap
       steps:
         - validateSign
-        - checkPolicy
         - addRoute
         - validateSchema
   
@@ -145,7 +134,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -163,15 +152,7 @@ modules:
             config:
               contextKeys: transaction_id,message_id
               role: bap
-        checkPolicy:
-          id: opapolicychecker
-          config:
-            type: file
-            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
-            query: "data.policy.result"
-            refreshIntervalSeconds: "300"
       steps:
-        - checkPolicy
         - addRoute
         - sign
         - validateSchema

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -74,7 +74,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -146,7 +146,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -159,6 +159,11 @@ modules:
             routingConfig: ./config/local-beckn-one-routing-BAPCaller.yaml
         signer:
           id: signer
+        middleware:
+          - id: reqpreprocessor
+            config:
+              contextKeys: transaction_id,message_id
+              role: bap
         checkPolicy:
           id: opapolicychecker
           config:
@@ -166,11 +171,6 @@ modules:
             location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
             query: "data.policy.result"
             refreshIntervalSeconds: "300"
-        middleware:
-          - id: reqpreprocessor
-            config:
-              contextKeys: transaction_id,message_id
-              role: bap
       steps:
         - checkPolicy
         - addRoute

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -85,8 +85,20 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-beckn-one-routing-BPPReceiver.yaml
+        checkPolicy:
+          id: opapolicychecker
+          config:
+            # Policy source configuration.
+            # type: url | file | dir | bundle
+            # location: path or URL to policy source
+            # query: OPA query path to evaluate (required)
+            type: file
+            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
+            query: "data.policy.result"
+            refreshIntervalSeconds: "300"
       steps:
         - validateSign
+        - checkPolicy
         - addRoute
         - validateSchema
   
@@ -140,12 +152,20 @@ modules:
             routingConfig: ./config/local-beckn-one-routing-BPPCaller.yaml
         signer:
           id: signer
+        checkPolicy:
+          id: opapolicychecker
+          config:
+            type: file
+            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
+            query: "data.policy.result"
+            refreshIntervalSeconds: "300"
         middleware:
           - id: reqpreprocessor
             config:
               contextKeys: transaction_id,message_id
-              role: bpp          
+              role: bpp
       steps:
+        - checkPolicy
         - addRoute
         - sign
         - validateSchema

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -72,7 +72,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -139,7 +139,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -152,6 +152,11 @@ modules:
             routingConfig: ./config/local-beckn-one-routing-BPPCaller.yaml
         signer:
           id: signer
+        middleware:
+          - id: reqpreprocessor
+            config:
+              contextKeys: transaction_id,message_id
+              role: bpp
         checkPolicy:
           id: opapolicychecker
           config:
@@ -159,11 +164,6 @@ modules:
             location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
             query: "data.policy.result"
             refreshIntervalSeconds: "300"
-        middleware:
-          - id: reqpreprocessor
-            config:
-              contextKeys: transaction_id,message_id
-              role: bpp
       steps:
         - checkPolicy
         - addRoute

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -32,7 +32,8 @@ plugins:
       enableTracing: "true"
       enableLogs: "true"
       timeInterval: "5"
-      auditFieldsConfig: "/app/config/audit-fields.yaml"
+      auditFieldsConfig: "/app/config/audit-fields.yaml" # this can be git url
+      cacheTTL: "3600"
 modules:
   - name: bppTxnReceiver
     path: /bpp/receiver/
@@ -71,7 +72,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -84,20 +85,8 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-beckn-one-routing-BPPReceiver.yaml
-        checkPolicy:
-          id: opapolicychecker
-          config:
-            # Policy source configuration.
-            # type: url | file | dir | bundle
-            # location: path or URL to policy source
-            # query: OPA query path to evaluate (required)
-            type: file
-            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
-            query: "data.policy.result"
-            refreshIntervalSeconds: "300"
       steps:
         - validateSign
-        - checkPolicy
         - addRoute
         - validateSchema
   
@@ -138,7 +127,7 @@ modules:
           id: schemav2validator
           config:
             type: url
-            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/api/beckn.yaml
             cacheTTL: "3600"
             extendedSchema_enabled: "true"
             extendedSchema_cacheTTL: "86400"
@@ -156,15 +145,7 @@ modules:
             config:
               contextKeys: transaction_id,message_id
               role: bpp          
-        checkPolicy:
-          id: opapolicychecker
-          config:
-            type: file
-            location: ./pkg/plugin/implementation/opapolicychecker/testdata/example.rego
-            query: "data.policy.result"
-            refreshIntervalSeconds: "300"
       steps:
-        - checkPolicy
         - addRoute
         - sign
         - validateSchema

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -35,7 +35,6 @@ type stdHandler struct {
 	registry         definition.RegistryLookup
 	km               definition.KeyManager
 	schemaValidator  definition.SchemaValidator
-	policyChecker    definition.PolicyChecker
 	router           definition.Router
 	publisher        definition.Publisher
 	transportWrapper definition.TransportWrapper
@@ -144,19 +143,19 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Request(r.Context(), r, stepCtx.Body)
 
 	defer func() {
-		span.SetAttributes(attribute.Int("http.response.status_code", wrapped.statusCode), attribute.String("observedTimeUnixNano", strconv.FormatInt(time.Now().UnixNano(), 10)))
+		span.SetAttributes(attribute.Int("http.response.status_code", wrapped.statusCode), attribute.String("http.request.error", errString(err)), attribute.String("observedTimeUnixNano", strconv.FormatInt(time.Now().UnixNano(), 10)))
 		if wrapped.statusCode < 200 || wrapped.statusCode >= 400 {
 			span.SetStatus(codes.Error, "status code is invalid")
 		}
 
 		body := stepCtx.Body
-		telemetry.EmitAuditLogs(r.Context(), body, auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.response.error", errString(err)))
+		telemetry.EmitAuditLogs(r.Context(), body, auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
 		span.End()
 	}()
 
 	// Execute processing steps.
 	for _, step := range h.steps {
-		if err := step.Run(stepCtx); err != nil {
+		if err = step.Run(stepCtx); err != nil {
 			log.Errorf(stepCtx, err, "%T.run():%v", step, err)
 			response.SendNack(stepCtx, wrapped, err)
 			return
@@ -319,9 +318,6 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 	if h.transportWrapper, err = loadPlugin(ctx, "TransportWrapper", cfg.TransportWrapper, mgr.TransportWrapper); err != nil {
 		return err
 	}
-	if h.policyChecker, err = loadPlugin(ctx, "PolicyChecker", cfg.PolicyChecker, mgr.PolicyChecker); err != nil {
-		return err
-	}
 
 	log.Debugf(ctx, "All required plugins successfully loaded for stdHandler")
 	return nil
@@ -354,8 +350,6 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newValidateSchemaStep(h.schemaValidator)
 		case "addRoute":
 			s, err = newAddRouteStep(h.router)
-		case "checkPolicy":
-			s, err = newCheckPolicyStep(h.policyChecker)
 		default:
 			if customStep, exists := steps[step]; exists {
 				s = customStep

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -35,6 +35,7 @@ type stdHandler struct {
 	registry         definition.RegistryLookup
 	km               definition.KeyManager
 	schemaValidator  definition.SchemaValidator
+	policyChecker    definition.PolicyChecker
 	router           definition.Router
 	publisher        definition.Publisher
 	transportWrapper definition.TransportWrapper
@@ -318,6 +319,9 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 	if h.transportWrapper, err = loadPlugin(ctx, "TransportWrapper", cfg.TransportWrapper, mgr.TransportWrapper); err != nil {
 		return err
 	}
+	if h.policyChecker, err = loadPlugin(ctx, "PolicyChecker", cfg.PolicyChecker, mgr.PolicyChecker); err != nil {
+		return err
+	}
 
 	log.Debugf(ctx, "All required plugins successfully loaded for stdHandler")
 	return nil
@@ -350,6 +354,8 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newValidateSchemaStep(h.schemaValidator)
 		case "addRoute":
 			s, err = newAddRouteStep(h.router)
+		case "checkPolicy":
+			s, err = newCheckPolicyStep(h.policyChecker)
 		default:
 			if customStep, exists := steps[step]; exists {
 				s = customStep

--- a/install/network-observability/loki/loki-config.yml
+++ b/install/network-observability/loki/loki-config.yml
@@ -1,5 +1,7 @@
 # Loki config for network-level audit logs (OTLP ingestion)
 # OTLP requires allow_structured_metadata for Loki 3.x
+# otlp_config maps resource attributes to Loki stream labels — without this
+# Loki has no labels and rejects the log stream.
 
 auth_enabled: false
 
@@ -20,6 +22,17 @@ common:
 
 limits_config:
   allow_structured_metadata: true
+  # Map OTel resource attributes to Loki stream labels.
+  # At least one index_label is required for Loki to accept a log stream.
+  # eid distinguishes AUDIT / METRIC / API signal types from otelsetup.
+  otlp_config:
+    resource_attributes:
+      attributes_config:
+        - action: index_label
+          attributes:
+            - service.name
+            - environment
+            - eid
 
 schema_config:
   configs:

--- a/install/network-observability/otel-collector-network/config.yaml
+++ b/install/network-observability/otel-collector-network/config.yaml
@@ -38,6 +38,10 @@ exporters:
     endpoint: http://loki:3100/otlp
     compression: gzip
 
+  # Prints log records to collector stdout — use `docker logs otel-collector-network` to verify flow.
+  debug:
+    verbosity: normal
+
 service:
   pipelines:
     metrics:
@@ -53,7 +57,7 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/loki]
+      exporters: [otlphttp/loki, debug]
 
   telemetry:
     logs:

--- a/pkg/plugin/implementation/otelsetup/cmd/plugin.go
+++ b/pkg/plugin/implementation/otelsetup/cmd/plugin.go
@@ -99,11 +99,18 @@ func (m metricsProvider) New(ctx context.Context, config map[string]string) (*te
 
 	}
 
+	// Parse cacheTTL as in
+	if cacheTTLStr, ok := config["cacheTTL"]; ok && cacheTTLStr != "" {
+		telemetryConfig.CacheTTL, err = strconv.ParseInt(cacheTTLStr, 10, 64)
+		if err != nil {
+			log.Warnf(ctx, "Invalid cacheTTL value: %s, defaulting to 3600 second ", cacheTTLStr)
+			telemetryConfig.CacheTTL = 3600
+		}
+	}
+	var stopAuditRefresh func()
 	// to set fields for audit logs
 	if v, ok := config["auditFieldsConfig"]; ok && v != "" {
-		if err := telemetry.LoadAuditFieldRules(ctx, v); err != nil {
-			log.Warnf(ctx, "Failed to load audit field rules: %v", err)
-		}
+		stopAuditRefresh = telemetry.StartAuditFieldsRefresh(ctx, v, telemetryConfig.CacheTTL)
 	}
 
 	//to set network level matric frequency and granularity
@@ -126,6 +133,9 @@ func (m metricsProvider) New(ctx context.Context, config map[string]string) (*te
 	var closer func() error
 	if provider != nil && provider.Shutdown != nil {
 		closer = func() error {
+			if stopAuditRefresh != nil {
+				stopAuditRefresh()
+			}
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			return provider.Shutdown(shutdownCtx)

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -174,6 +174,7 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 		processor := logsdk.NewBatchProcessor(logExporter)
 		logProvider = logsdk.NewLoggerProvider(logsdk.WithProcessor(processor), logsdk.WithResource(resAudit))
 		global.SetLoggerProvider(logProvider)
+		telemetry.SetLogsEnabled(true)
 	}
 
 	return &telemetry.Provider{
@@ -195,6 +196,7 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 			}
 
 			if logProvider != nil {
+				telemetry.SetLogsEnabled(false)
 				if err := logProvider.Shutdown(shutdownCtx); err != nil {
 					errs = append(errs, fmt.Errorf("logs shutdown: %w", err))
 				}

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -43,6 +43,7 @@ type Config struct {
 	AuditFieldsConfig string `yaml:"auditFieldsConfig"`
 	Producer          string `yaml:"producer"`
 	ProducerType      string `yaml:"producerType"`
+	CacheTTL          int64  `yaml:"cacheTTL"`
 }
 
 // DefaultConfig returns sensible defaults for telemetry configuration.
@@ -173,7 +174,6 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 		processor := logsdk.NewBatchProcessor(logExporter)
 		logProvider = logsdk.NewLoggerProvider(logsdk.WithProcessor(processor), logsdk.WithResource(resAudit))
 		global.SetLoggerProvider(logProvider)
-		telemetry.SetLogsEnabled(true)
 	}
 
 	return &telemetry.Provider{
@@ -198,9 +198,6 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 				if err := logProvider.Shutdown(shutdownCtx); err != nil {
 					errs = append(errs, fmt.Errorf("logs shutdown: %w", err))
 				}
-				// Clear the flag so EmitAuditLogs does not emit through the
-				// now-closed provider if telemetry is restarted with logs disabled.
-				telemetry.SetLogsEnabled(false)
 			}
 			if len(errs) > 0 {
 				return fmt.Errorf("shutdown errors: %v", errs)

--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -30,7 +30,7 @@ func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
 	provider := global.GetLoggerProvider()
 
 	sum := sha256.Sum256(body)
-	auditBody := selectAuditPayload(ctx, body)
+	auditBody := ProcessAuditPayload(ctx, body)
 	auditlog := provider.Logger(auditLoggerName)
 	record := log.Record{}
 	record.SetBody(log.StringValue(string(auditBody)))

--- a/pkg/telemetry/audit_fields.go
+++ b/pkg/telemetry/audit_fields.go
@@ -4,178 +4,366 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"gopkg.in/yaml.v3"
 )
 
-type auditFieldsRules struct {
-	AuditRules map[string][]string `yaml:"auditRules"`
+// ── YAML config structs ──────────────────────────────────────────────────────
+
+type patternDef struct {
+	MaskType string `yaml:"maskType"` // "replace" (default) or "last4"
+	Mask     string `yaml:"mask"`     // literal replacement for maskType "replace"
+}
+
+type maskRule struct {
+	Keys    []string `yaml:"keys"`
+	Pattern string   `yaml:"pattern"`
+}
+
+type pathOverrideDef struct {
+	Path    string `yaml:"path"`
+	Pattern string `yaml:"pattern"`
+}
+
+type auditConfig struct {
+	Mode           string                `yaml:"mode"`           // "full" | "selective"
+	Patterns       map[string]patternDef `yaml:"patterns"`
+	MaskRules      []maskRule            `yaml:"maskRules"`
+	PathOverrides  []pathOverrideDef     `yaml:"pathOverrides"`
+	SelectedFields map[string][]string   `yaml:"selectedFields"` // action → field paths; "default" is the fallback
+}
+
+// ── Compiled config ──────────────────────────────────────────────────────────
+
+// CompiledPattern is the ready-to-apply masking rule for a named pattern.
+type CompiledPattern struct {
+	MaskType string // "replace" or "last4"
+	Mask     string // literal mask for MaskType "replace"
+}
+
+// CompiledConfig is the compiled, query-ready form of auditConfig.
+// All lookups are O(1) map operations so the per-request cost is minimal.
+type CompiledConfig struct {
+	mode          string                         // "full" or "selective"
+	keyToPattern  map[string]*CompiledPattern    // field name → pattern (from maskRules)
+	pathOverrides map[string]*CompiledPattern    // full dot-path → pattern
+	keepPaths     map[string]map[string]struct{} // action → set of paths to keep/traverse (selective only)
 }
 
 var (
-	auditRules      = map[string][]string{}
-	auditRulesMutex sync.RWMutex
+	compiledCfg   *CompiledConfig
+	compiledCfgMu sync.RWMutex
 )
 
-func LoadAuditFieldRules(ctx context.Context, configPath string) error {
+// GetCompiledConfig returns the current compiled audit configuration.
+func GetCompiledConfig() *CompiledConfig {
+	compiledCfgMu.RLock()
+	defer compiledCfgMu.RUnlock()
+	return compiledCfg
+}
 
-	if strings.TrimSpace(configPath) == "" {
-		err := fmt.Errorf("config file path is empty")
-		log.Error(ctx, err, "there are no audit rules defined")
+// ── Config loading ───────────────────────────────────────────────────────────
+
+func loadAuditConfig(ctx context.Context, source string) error {
+	src := strings.TrimSpace(source)
+	if src == "" {
+		err := fmt.Errorf("auditFieldsConfig source is empty")
+		log.Error(ctx, err, "")
 		return err
 	}
 
-	data, err := os.ReadFile(configPath)
+	data, err := fetchSource(ctx, src)
 	if err != nil {
-		log.Error(ctx, err, "failed to read audit rules file")
 		return err
 	}
 
-	var config auditFieldsRules
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		log.Error(ctx, err, "failed to parse audit rules file")
+	var cfg auditConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		log.Error(ctx, err, "failed to parse audit config YAML")
 		return err
 	}
 
-	if config.AuditRules == nil {
-		log.Warn(ctx, "audit rules are not defined")
-		config.AuditRules = map[string][]string{}
+	compiled, err := compile(ctx, &cfg)
+	if err != nil {
+		return err
 	}
 
-	auditRulesMutex.Lock()
-	auditRules = config.AuditRules
-	auditRulesMutex.Unlock()
-	log.Info(ctx, "audit rules loaded")
+	compiledCfgMu.Lock()
+	compiledCfg = compiled
+	compiledCfgMu.Unlock()
+
+	log.Info(ctx, "audit config loaded")
 	return nil
 }
 
-func selectAuditPayload(ctx context.Context, body []byte) []byte {
+// fetchSource reads audit config bytes from either an HTTP(S) URL or a local
+// file path. HTTP fetches are bounded by a 10-second context timeout.
+func fetchSource(ctx context.Context, src string) ([]byte, error) {
+	u, err := url.Parse(src)
+	if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+		reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, src, nil)
+		if err != nil {
+			log.Error(ctx, err, "failed to build audit config HTTP request")
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Error(ctx, err, "failed to fetch audit config from URL")
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			err := fmt.Errorf("unexpected HTTP status %d fetching audit config from %s", resp.StatusCode, src)
+			log.Error(ctx, err, "")
+			return nil, err
+		}
+		return io.ReadAll(resp.Body)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		log.Error(ctx, err, "failed to read audit config file")
+	}
+	return data, err
+}
+
+// compile validates the raw auditConfig and produces a CompiledConfig with
+// all lookups pre-built for O(1) access during request processing.
+func compile(ctx context.Context, cfg *auditConfig) (*CompiledConfig, error) {
+	// Resolve named patterns.
+	patterns := make(map[string]*CompiledPattern, len(cfg.Patterns))
+	for name, def := range cfg.Patterns {
+		mt := def.MaskType
+		if mt == "" {
+			mt = "replace"
+		}
+		patterns[name] = &CompiledPattern{MaskType: mt, Mask: def.Mask}
+	}
+
+	// Build field-name → pattern map from maskRules.
+	keyToPattern := make(map[string]*CompiledPattern)
+	for _, rule := range cfg.MaskRules {
+		p, ok := patterns[rule.Pattern]
+		if !ok {
+			err := fmt.Errorf("maskRule references unknown pattern %q", rule.Pattern)
+			log.Error(ctx, err, "")
+			return nil, err
+		}
+		for _, key := range rule.Keys {
+			keyToPattern[key] = p
+		}
+	}
+
+	// Build full-path → pattern map from pathOverrides.
+	pathOverrides := make(map[string]*CompiledPattern, len(cfg.PathOverrides))
+	for _, po := range cfg.PathOverrides {
+		p, ok := patterns[po.Pattern]
+		if !ok {
+			err := fmt.Errorf("pathOverride %q references unknown pattern %q", po.Path, po.Pattern)
+			log.Error(ctx, err, "")
+			return nil, err
+		}
+		pathOverrides[po.Path] = p
+	}
+
+	// Resolve and validate mode.
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode == "" {
+		mode = "full"
+	}
+	if mode != "full" && mode != "selective" {
+		err := fmt.Errorf("unknown audit mode %q — must be 'full' or 'selective'", mode)
+		log.Error(ctx, err, "")
+		return nil, err
+	}
+
+	// Pre-compute keepPaths for selective mode.
+	// Each entry expands the listed dot-paths into an exact+ancestor path set
+	// so the walker can decide keep/drop in O(1) per node without any scanning.
+	var keepPaths map[string]map[string]struct{}
+	if mode == "selective" {
+		keepPaths = make(map[string]map[string]struct{}, len(cfg.SelectedFields))
+		for action, fields := range cfg.SelectedFields {
+			keepPaths[action] = buildKeepSet(fields)
+		}
+	}
+
+	return &CompiledConfig{
+		mode:          mode,
+		keyToPattern:  keyToPattern,
+		pathOverrides: pathOverrides,
+		keepPaths:     keepPaths,
+	}, nil
+}
+
+// buildKeepSet expands dot-paths into a set containing each path AND all its
+// ancestor paths, so the walker knows which intermediate nodes to traverse.
+//
+// Example: "context.transactionId" → {"context", "context.transactionId"}
+func buildKeepSet(fields []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(fields)*3)
+	for _, f := range fields {
+		set[f] = struct{}{}
+		parts := strings.Split(f, ".")
+		for i := 1; i < len(parts); i++ {
+			set[strings.Join(parts[:i], ".")] = struct{}{}
+		}
+	}
+	return set
+}
+
+// ── Payload processing (single pass) ────────────────────────────────────────
+
+// ProcessAuditPayload applies field selection and PII masking in a single
+// tree traversal. Both concerns are handled together so the payload is walked
+// exactly once regardless of how many maskRules or selectedFields are configured.
+//
+// Error handling is conservative: any parse or marshal failure returns the
+// original body unchanged so the audit log entry is never silently dropped.
+func ProcessAuditPayload(ctx context.Context, body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+
+	cfg := GetCompiledConfig()
+	if cfg == nil {
+		return body
+	}
 
 	var root map[string]interface{}
 	if err := json.Unmarshal(body, &root); err != nil {
-		log.Warn(ctx, "failed to unmarshal audit payload ")
-		return nil
+		log.Warn(ctx, "audit: failed to unmarshal payload, emitting as-is")
+		return body
 	}
 
-	action := ""
-	if c, ok := root["context"].(map[string]interface{}); ok {
-		if v, ok := c["action"].(string); ok {
-			action = strings.TrimSpace(v)
+	// Determine the per-action keep set for selective mode.
+	// For full mode keepSet stays nil and the walker skips the drop step.
+	var keepSet map[string]struct{}
+	if cfg.mode == "selective" {
+		action := extractAction(root)
+		keepSet = cfg.keepPaths[action]
+		if keepSet == nil {
+			keepSet = cfg.keepPaths["default"]
 		}
 	}
 
-	fields := getFieldForAction(ctx, action)
-	if len(fields) == 0 {
-		return nil
-	}
+	walkMap(root, "", cfg, keepSet)
 
-	out := map[string]interface{}{}
-	for _, field := range fields {
-		parts := strings.Split(field, ".")
-		partial, ok := projectPath(root, parts)
-		if !ok {
+	out, err := json.Marshal(root)
+	if err != nil {
+		log.Warn(ctx, "audit: failed to marshal processed payload, emitting as-is")
+		return body
+	}
+	return out
+}
+
+// extractAction reads context.action from the unmarshalled root without
+// allocating a new map — just a single type assertion per level.
+func extractAction(root map[string]interface{}) string {
+	ctxNode, ok := root["context"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	action, _ := ctxNode["action"].(string)
+	return strings.TrimSpace(action)
+}
+
+// walkMap processes a JSON object node in-place. Priority order per key:
+//  1. Key-name masking  (O(1) map lookup — checked first for lowest latency)
+//  2. Path-override masking
+//  3. Selective-mode field dropping
+//  4. Recurse into nested objects / arrays
+func walkMap(node map[string]interface{}, prefix string, cfg *CompiledConfig, keepSet map[string]struct{}) {
+	for key := range node {
+		fullPath := prefix + key
+
+		// 1. Key-name masking — field name is sufficient signal; no path needed.
+		if pattern, ok := cfg.keyToPattern[key]; ok {
+			node[key] = applyMask(node[key], pattern)
 			continue
 		}
-		merged := deepMerge(out, partial)
-		if m, ok := merged.(map[string]interface{}); ok {
-			out = m
+
+		// 2. Path-override masking — for fields that need path-level precision.
+		if pattern, ok := cfg.pathOverrides[fullPath]; ok {
+			node[key] = applyMask(node[key], pattern)
+			continue
 		}
-	}
 
-	body, err := json.Marshal(out)
-	if err != nil {
-		log.Warn(ctx, "failed to marshal audit payload")
-		return nil
-	}
-	return body
-}
-
-func getFieldForAction(ctx context.Context, action string) []string {
-	auditRulesMutex.RLock()
-	defer auditRulesMutex.RUnlock()
-
-	if action != "" {
-		if fields, ok := auditRules[action]; ok && len(fields) > 0 {
-			return fields
-		}
-	}
-
-	log.Warn(ctx, "audit rules are not defined for this action send default")
-	return auditRules["default"]
-}
-
-func projectPath(cur interface{}, parts []string) (interface{}, bool) {
-	if len(parts) == 0 {
-		return cur, true
-	}
-
-	switch node := cur.(type) {
-	case map[string]interface{}:
-		next, ok := node[parts[0]]
-		if !ok {
-			return nil, false
-		}
-		child, ok := projectPath(next, parts[1:])
-		if !ok {
-			return nil, false
-		}
-		return map[string]interface{}{parts[0]: child}, true
-
-	case []interface{}:
-		out := make([]interface{}, 0, len(node))
-		found := false
-
-		for _, n := range node {
-			child, ok := projectPath(n, parts)
-			if ok {
-				out = append(out, child)
-				found = true
+		// 3. Selective mode: drop any path that is not in the keep set.
+		if keepSet != nil {
+			if _, keep := keepSet[fullPath]; !keep {
+				delete(node, key)
+				continue
 			}
 		}
-		if !found {
-			return nil, false
-		}
-		return out, true
 
-	default:
-		return nil, false
+		// 4. Recurse into nested structures.
+		switch child := node[key].(type) {
+		case map[string]interface{}:
+			walkMap(child, fullPath+".", cfg, keepSet)
+		case []interface{}:
+			walkSlice(child, fullPath+".", cfg, keepSet)
+		}
 	}
 }
-func deepMerge(dst, src interface{}) interface{} {
-	if dst == nil {
-		return src
+
+// walkSlice processes each element of a JSON array, forwarding the same
+// path prefix so field names inside array elements are matched correctly.
+func walkSlice(arr []interface{}, prefix string, cfg *CompiledConfig, keepSet map[string]struct{}) {
+	for _, elem := range arr {
+		switch child := elem.(type) {
+		case map[string]interface{}:
+			walkMap(child, prefix, cfg, keepSet)
+		case []interface{}:
+			walkSlice(child, prefix, cfg, keepSet)
+		}
+	}
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+// LoadAuditConfig loads audit config from a local file path or HTTP(S) URL.
+func LoadAuditConfig(ctx context.Context, source string) error {
+	return loadAuditConfig(ctx, source)
+}
+
+// StartAuditFieldsRefresh loads the config immediately, then reloads it every
+// intervalSec seconds from the same source. Returns a stop function.
+func StartAuditFieldsRefresh(ctx context.Context, source string, intervalSec int64) func() {
+	if intervalSec <= 0 {
+		intervalSec = 3600
+	}
+	if err := loadAuditConfig(ctx, source); err != nil {
+		log.Warn(ctx, "audit: initial config load failed")
 	}
 
-	dm, dok := dst.(map[string]interface{})
-	sm, sok := src.(map[string]interface{})
-	if dok && sok {
-		for k, sv := range sm {
-			if dv, ok := dm[k]; ok {
-				dm[k] = deepMerge(dv, sv)
-			} else {
-				dm[k] = sv
+	ticker := time.NewTicker(time.Duration(intervalSec) * time.Second)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				reloadCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				if err := loadAuditConfig(reloadCtx, source); err != nil {
+					log.Warn(reloadCtx, "audit: config reload failed")
+				}
+				cancel()
 			}
 		}
-		return dm
-	}
+	}()
 
-	da, dok := dst.([]interface{})
-	sa, sok := src.([]interface{})
-	if dok && sok {
-		if len(da) < len(sa) {
-			ext := make([]interface{}, len(sa)-len(da))
-			da = append(da, ext...)
-		}
-
-		for i := range sa {
-			da[i] = deepMerge(da[i], sa[i])
-		}
-		return da
-	}
-
-	return src
+	return func() { close(done) }
 }

--- a/pkg/telemetry/audit_fields_test.go
+++ b/pkg/telemetry/audit_fields_test.go
@@ -3,516 +3,513 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"path/filepath"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Test projectPath
-
-func TestProjectPath_EmptyParts(t *testing.T) {
-	root := map[string]interface{}{"a": "v"}
-	got, ok := projectPath(root, nil)
-	require.True(t, ok)
-	assert.Equal(t, root, got)
-
-	got, ok = projectPath(root, []string{})
-	require.True(t, ok)
-	assert.Equal(t, root, got)
-}
-
-func TestProjectPath_MapSingleLevel(t *testing.T) {
-	root := map[string]interface{}{"context": map[string]interface{}{"action": "search"}}
-	got, ok := projectPath(root, []string{"context"})
-	require.True(t, ok)
-	assert.Equal(t, map[string]interface{}{"context": map[string]interface{}{"action": "search"}}, got)
-}
-
-func TestProjectPath_MapNested(t *testing.T) {
-	root := map[string]interface{}{
-		"context": map[string]interface{}{
-			"action": "select",
-			"transaction_id": "tx-1",
-		},
-	}
-	got, ok := projectPath(root, []string{"context", "action"})
-	require.True(t, ok)
-	assert.Equal(t, map[string]interface{}{"context": map[string]interface{}{"action": "select"}}, got)
-}
-
-func TestProjectPath_MissingKey(t *testing.T) {
-	root := map[string]interface{}{"context": map[string]interface{}{"action": "search"}}
-	got, ok := projectPath(root, []string{"context", "missing"})
-	require.False(t, ok)
-	assert.Nil(t, got)
-}
-
-func TestProjectPath_ArrayTraverseAndProject(t *testing.T) {
-	root := map[string]interface{}{
-		"message": map[string]interface{}{
-			"order": map[string]interface{}{
-				"beckn:orderItems": []interface{}{
-					map[string]interface{}{"beckn:orderedItem": "item-1"},
-					map[string]interface{}{"beckn:orderedItem": "item-2"},
-				},
-			},
-		},
-	}
-	parts := []string{"message", "order", "beckn:orderItems", "beckn:orderedItem"}
-	got, ok := projectPath(root, parts)
-	require.True(t, ok)
-
-	expected := map[string]interface{}{
-		"message": map[string]interface{}{
-			"order": map[string]interface{}{
-				"beckn:orderItems": []interface{}{
-					map[string]interface{}{"beckn:orderedItem": "item-1"},
-					map[string]interface{}{"beckn:orderedItem": "item-2"},
-				},
-			},
-		},
-	}
-	assert.Equal(t, expected, got)
-}
-
-func TestProjectPath_NonMapOrSlice(t *testing.T) {
-	_, ok := projectPath("string", []string{"a"})
-	require.False(t, ok)
-
-	_, ok = projectPath(42, []string{"a"})
-	require.False(t, ok)
-}
-
-func TestProjectPath_EmptyArray(t *testing.T) {
-	root := map[string]interface{}{"items": []interface{}{}}
-	got, ok := projectPath(root, []string{"items", "id"})
-	require.False(t, ok)
-	assert.Nil(t, got)
-}
-
-// Test deepMerge
-
-func TestDeepMerge_NilDst(t *testing.T) {
-	src := map[string]interface{}{"a": 1}
-	got := deepMerge(nil, src)
-	assert.Equal(t, src, got)
-}
-
-func TestDeepMerge_MapIntoMap(t *testing.T) {
-	dst := map[string]interface{}{"a": 1, "b": 2}
-	src := map[string]interface{}{"b": 20, "c": 3}
-	got := deepMerge(dst, src)
-	assert.Equal(t, map[string]interface{}{"a": 1, "b": 20, "c": 3}, got)
-}
-
-func TestDeepMerge_MapNested(t *testing.T) {
-	dst := map[string]interface{}{
-		"context": map[string]interface{}{"action": "search", "domain": "retail"},
-	}
-	src := map[string]interface{}{
-		"context": map[string]interface{}{"action": "search", "transaction_id": "tx-1"},
-	}
-	got := deepMerge(dst, src)
-	ctx, ok := got.(map[string]interface{})["context"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "search", ctx["action"])
-	assert.Equal(t, "retail", ctx["domain"])
-	assert.Equal(t, "tx-1", ctx["transaction_id"])
-}
-
-func TestDeepMerge_ArrayIntoArray(t *testing.T) {
-	dst := []interface{}{
-		map[string]interface{}{"id": "a"},
-		map[string]interface{}{"id": "b"},
-	}
-	src := []interface{}{
-		map[string]interface{}{"id": "a", "name": "A"},
-		map[string]interface{}{"id": "b", "name": "B"},
-	}
-	got := deepMerge(dst, src)
-	sl, ok := got.([]interface{})
-	require.True(t, ok)
-	require.Len(t, sl, 2)
-	assert.Equal(t, map[string]interface{}{"id": "a", "name": "A"}, sl[0])
-	assert.Equal(t, map[string]interface{}{"id": "b", "name": "B"}, sl[1])
-}
-
-func TestDeepMerge_ArraySrcLonger(t *testing.T) {
-	dst := []interface{}{map[string]interface{}{"a": 1}}
-	src := []interface{}{
-		map[string]interface{}{"a": 1},
-		map[string]interface{}{"a": 2},
-	}
-	got := deepMerge(dst, src)
-	sl, ok := got.([]interface{})
-	require.True(t, ok)
-	require.Len(t, sl, 2)
-}
-
-func TestDeepMerge_ScalarSrc(t *testing.T) {
-	dst := map[string]interface{}{"a": 1}
-	src := "overwrite"
-	got := deepMerge(dst, src)
-	assert.Equal(t, "overwrite", got)
-}
-
-// Test getFieldForAction and selectAuditPayload (require loaded rules via temp file)
-
-func writeAuditRulesFile(t *testing.T, content string) string {
+// resetConfig clears the package-level compiled config between tests so they
+// do not interfere with each other through shared global state.
+func resetConfig(t *testing.T) {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "audit-fields.yaml")
-	err := os.WriteFile(path, []byte(content), 0600)
-	require.NoError(t, err)
-	return path
+	compiledCfgMu.Lock()
+	compiledCfg = nil
+	compiledCfgMu.Unlock()
 }
 
-func TestGetFieldForAction_ActionMatch(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default:
-    - context.transaction_id
-    - context.action
-  search:
-    - context.action
-    - context.timestamp
-  select:
-    - context.action
-    - message.order
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	fields := getFieldForAction(ctx, "search")
-	assert.Equal(t, []string{"context.action", "context.timestamp"}, fields)
-
-	fields = getFieldForAction(ctx, "select")
-	assert.Equal(t, []string{"context.action", "message.order"}, fields)
+// serveYAML starts a test HTTP server that returns the given YAML string.
+func serveYAML(t *testing.T, yaml string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(yaml))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
 }
 
-func TestGetFieldForAction_FallbackToDefault(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default:
-    - context.transaction_id
-    - context.message_id
-  search:
-    - context.action
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	fields := getFieldForAction(ctx, "unknown_action")
-	assert.Equal(t, []string{"context.transaction_id", "context.message_id"}, fields)
-
-	fields = getFieldForAction(ctx, "")
-	assert.Equal(t, []string{"context.transaction_id", "context.message_id"}, fields)
-}
-
-func TestGetFieldForAction_EmptyDefault(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default: []
-  search:
-    - context.action
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	fields := getFieldForAction(ctx, "other")
-	assert.Empty(t, fields)
-}
-
-func TestSelectAuditPayload_InvalidJSON(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default:
-    - context.action
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	got := selectAuditPayload(ctx, []byte("not json"))
-	assert.Nil(t, got)
-}
-
-func TestSelectAuditPayload_NoRulesLoaded(t *testing.T) {
-	ctx := context.Background()
-	// use a fresh context without loading any rules; auditRules may be from previous test
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default: []
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	body := []byte(`{"context":{"action":"search"}}`)
-	got := selectAuditPayload(ctx, body)
-	assert.Nil(t, got)
-}
-
-func TestSelectAuditPayload_ContextAndActionOnly(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-`)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	body := []byte(`{
-		"context": {
-			"action": "search",
-			"transaction_id": "tx-1",
-			"message_id": "msg-1",
-			"domain": "retail"
-		},
-		"message": {"intent": "buy"}
-	}`)
-	got := selectAuditPayload(ctx, body)
-	require.NotNil(t, got)
-
+// unmarshalJSON is a test helper that unmarshals JSON bytes and fails the test on error.
+func unmarshalJSON(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
 	var out map[string]interface{}
-	require.NoError(t, json.Unmarshal(got, &out))
-	ctxMap, ok := out["context"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "search", ctxMap["action"])
-	assert.Equal(t, "tx-1", ctxMap["transaction_id"])
-	assert.Equal(t, "msg-1", ctxMap["message_id"])
-	_, hasMessage := out["message"]
-	assert.False(t, hasMessage)
+	require.NoError(t, json.Unmarshal(data, &out))
+	return out
 }
 
-func TestSelectAuditPayload_ActionSpecificRules(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default:
-    - context.action
-  search:
-    - context.action
-    - context.timestamp
-    - message.intent
+// ── LoadAuditConfig ──────────────────────────────────────────────────────────
+
+func TestLoadAuditConfig_FullMode(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+maskRules:
+  - keys: [email]
+    pattern: email
+pathOverrides: []
 `)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
-
-	body := []byte(`{
-		"context": {"action": "search", "timestamp": "2024-01-15T10:30:00Z", "domain": "retail"},
-		"message": {"intent": {"item": {"id": "x"}}}
-	}`)
-	got := selectAuditPayload(ctx, body)
-	require.NotNil(t, got)
-
-	var out map[string]interface{}
-	require.NoError(t, json.Unmarshal(got, &out))
-	ctxMap := out["context"].(map[string]interface{})
-	assert.Equal(t, "search", ctxMap["action"])
-	assert.Equal(t, "2024-01-15T10:30:00Z", ctxMap["timestamp"])
-	msg := out["message"].(map[string]interface{})
-	assert.NotNil(t, msg["intent"])
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+	cfg := GetCompiledConfig()
+	require.NotNil(t, cfg)
+	assert.Equal(t, "full", cfg.mode)
+	assert.NotNil(t, cfg.keyToPattern["email"])
+	assert.Nil(t, cfg.keepPaths, "keepPaths must be nil for full mode")
 }
 
-func TestSelectAuditPayload_ArrayFieldProjection(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
+func TestLoadAuditConfig_SelectiveMode(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns: {}
+maskRules: []
+selectedFields:
   default:
+    - context.transactionId
     - context.action
-  select:
-    - context.transaction_id
-    - context.action
-    - message.order.beckn:orderItems.beckn:orderedItem
 `)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+	cfg := GetCompiledConfig()
+	require.NotNil(t, cfg)
+	assert.Equal(t, "selective", cfg.mode)
+	require.NotNil(t, cfg.keepPaths["default"])
+	_, hasExact := cfg.keepPaths["default"]["context.transactionId"]
+	_, hasAnc := cfg.keepPaths["default"]["context"]
+	assert.True(t, hasExact, "exact path must be in keep set")
+	assert.True(t, hasAnc, "ancestor path must be in keep set")
+}
+
+func TestLoadAuditConfig_DefaultsToFull(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+patterns: {}
+maskRules: []
+`) // no mode field
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+	assert.Equal(t, "full", GetCompiledConfig().mode)
+}
+
+func TestLoadAuditConfig_UnknownMode(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: verbose
+patterns: {}
+maskRules: []
+`)
+	require.Error(t, LoadAuditConfig(context.Background(), url))
+}
+
+func TestLoadAuditConfig_MaskRuleUnknownPattern(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns: {}
+maskRules:
+  - keys: [email]
+    pattern: nonexistent
+`)
+	require.Error(t, LoadAuditConfig(context.Background(), url))
+}
+
+func TestLoadAuditConfig_PathOverrideUnknownPattern(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns: {}
+maskRules: []
+pathOverrides:
+  - path: context.someField
+    pattern: nonexistent
+`)
+	require.Error(t, LoadAuditConfig(context.Background(), url))
+}
+
+func TestLoadAuditConfig_EmptySource(t *testing.T) {
+	resetConfig(t)
+	require.Error(t, LoadAuditConfig(context.Background(), ""))
+}
+
+// ── ProcessAuditPayload — full mode ─────────────────────────────────────────
+
+func TestProcessAuditPayload_FullMode_MasksEmailByKeyName(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+maskRules:
+  - keys: [email, supportEmail]
+    pattern: email
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
 
 	body := []byte(`{
-		"context": {"action": "select", "transaction_id": "tx-2"},
+		"context": {"action": "confirm", "transactionId": "txn-1"},
 		"message": {
 			"order": {
-				"beckn:orderItems": [
-					{"beckn:orderedItem": "item-A", "other": "x"},
-					{"beckn:orderedItem": "item-B", "other": "y"}
+				"buyer": {"email": "buyer@example.com", "id": "u1"},
+				"support": {"supportEmail": "help@acme.com", "phone": "9999"}
+			}
+		}
+	}`)
+
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+
+	order := out["message"].(map[string]interface{})["order"].(map[string]interface{})
+	buyer := order["buyer"].(map[string]interface{})
+	support := order["support"].(map[string]interface{})
+
+	assert.Equal(t, "***@***.***", buyer["email"], "buyer.email should be masked")
+	assert.Equal(t, "u1", buyer["id"], "buyer.id should be unchanged")
+	assert.Equal(t, "***@***.***", support["supportEmail"], "support.supportEmail should be masked")
+	assert.Equal(t, "9999", support["phone"], "phone is not in maskRules — should be unchanged")
+	assert.Equal(t, "txn-1", out["context"].(map[string]interface{})["transactionId"])
+}
+
+func TestProcessAuditPayload_FullMode_MasksPhoneLast4(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  phone:
+    maskType: last4
+maskRules:
+  - keys: [phone, telephone]
+    pattern: phone
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	body := []byte(`{"message":{"buyer":{"telephone":"+91-9876543210","id":"u1"}}}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+
+	buyer := out["message"].(map[string]interface{})["buyer"].(map[string]interface{})
+	assert.Equal(t, "**********3210", buyer["telephone"])
+	assert.Equal(t, "u1", buyer["id"])
+}
+
+func TestProcessAuditPayload_FullMode_MasksAcrossDepths(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  sensitive:
+    maskType: replace
+    mask: "[REDACTED]"
+maskRules:
+  - keys: [email]
+    pattern: sensitive
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	// email appears at different depths — both must be masked.
+	body := []byte(`{
+		"a": {"email": "a@a.com"},
+		"b": {"c": {"email": "b@b.com"}},
+		"d": {"e": {"f": {"email": "c@c.com"}}}
+	}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+
+	assert.Equal(t, "[REDACTED]", out["a"].(map[string]interface{})["email"])
+	assert.Equal(t, "[REDACTED]", out["b"].(map[string]interface{})["c"].(map[string]interface{})["email"])
+	assert.Equal(t, "[REDACTED]", out["d"].(map[string]interface{})["e"].(map[string]interface{})["f"].(map[string]interface{})["email"])
+}
+
+func TestProcessAuditPayload_FullMode_ArrayTraversal(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+maskRules:
+  - keys: [email]
+    pattern: email
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	body := []byte(`{
+		"message": {
+			"order": {
+				"items": [
+					{"buyer": {"email": "a@b.com", "id": "u1"}},
+					{"buyer": {"email": "c@d.com", "id": "u2"}}
 				]
 			}
 		}
 	}`)
-	got := selectAuditPayload(ctx, body)
-	require.NotNil(t, got)
 
-	var out map[string]interface{}
-	require.NoError(t, json.Unmarshal(got, &out))
-	ctxMap := out["context"].(map[string]interface{})
-	assert.Equal(t, "select", ctxMap["action"])
-	assert.Equal(t, "tx-2", ctxMap["transaction_id"])
-
-	order := out["message"].(map[string]interface{})["order"].(map[string]interface{})
-	items := order["beckn:orderItems"].([]interface{})
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	items := out["message"].(map[string]interface{})["order"].(map[string]interface{})["items"].([]interface{})
 	require.Len(t, items, 2)
-	assert.Equal(t, map[string]interface{}{"beckn:orderedItem": "item-A"}, items[0])
-	assert.Equal(t, map[string]interface{}{"beckn:orderedItem": "item-B"}, items[1])
+
+	for i, item := range items {
+		buyer := item.(map[string]interface{})["buyer"].(map[string]interface{})
+		assert.Equal(t, "***@***.***", buyer["email"], "email in item %d should be masked", i)
+		assert.NotEqual(t, "***@***.***", buyer["id"], "id in item %d should not be masked", i)
+	}
 }
 
-// TestSelectAuditPayload_SelectOrderExample uses a full select request payload and
-// select audit rules to verify that only configured fields are projected into the
-// audit log body. The request mirrors a real select with context, message.order,
-// beckn:orderItems (array), beckn:acceptedOffer, and beckn:orderAttributes.
-// Rules include array traversal (e.g. message.order.beckn:orderItems.beckn:orderedItem
-// projects that field from each array element) and nested paths like
-// message.order.beckn:orderItems.beckn:acceptedOffer.beckn:price.value.
-func TestSelectAuditPayload_SelectOrderExample(t *testing.T) {
-	ctx := context.Background()
-	path := writeAuditRulesFile(t, `
-auditRules:
-  default: []
-  select:
-    - context.transaction_id
-    - context.message_id
-    - context.action
-    - context.timestamp
-    - message.order
-    - message.order.beckn:seller
-    - message.order.beckn:buyer
-    - message.order.beckn:buyer.beckn:id
-    - message.order.beckn:orderItems
-    - message.order.beckn:orderItems.beckn:orderedItem
-    - message.order.beckn:orderItems.beckn:acceptedOffer
-    - message.order.beckn:orderItems.beckn:acceptedOffer.beckn:id
-    - message.order.beckn:orderItems.beckn:acceptedOffer.beckn:price
-    - message.order.beckn:orderItems.beckn:acceptedOffer.beckn:price.value
-    - message.order.beckn:orderAttributes
-    - message.order.beckn:orderAttributes.preferences
-    - message.order.beckn:orderAttributes.preferences.startTime
+func TestProcessAuditPayload_FullMode_PathOverride(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  sensitive:
+    maskType: replace
+    mask: "[REDACTED]"
+maskRules: []
+pathOverrides:
+  - path: context.internalRef
+    pattern: sensitive
 `)
-	require.NoError(t, LoadAuditFieldRules(ctx, path))
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
 
-	// Full select request example: context (version, action, domain, timestamp, ids, URIs, ttl)
-	// and message.order with orderStatus, seller, buyer, orderItems array (orderedItem, quantity,
-	// acceptedOffer with id, descriptor, items, provider, price), orderAttributes (buyerFinderFee, preferences).
+	body := []byte(`{"context":{"action":"confirm","internalRef":"ref-secret-42"},"message":{}}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+
+	ctx := out["context"].(map[string]interface{})
+	assert.Equal(t, "[REDACTED]", ctx["internalRef"])
+	assert.Equal(t, "confirm", ctx["action"], "action should be unchanged")
+}
+
+// ── ProcessAuditPayload — selective mode ────────────────────────────────────
+
+func TestProcessAuditPayload_SelectiveMode_DropUnlistedFields(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns: {}
+maskRules: []
+selectedFields:
+  default:
+    - context.transactionId
+    - context.action
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
 	body := []byte(`{
-  "context": {
-    "version": "1.0.0",
-    "action": "select",
-    "domain": "ev_charging",
-    "timestamp": "2024-01-15T10:30:00Z",
-    "message_id": "bb9f86db-9a3d-4e9c-8c11-81c8f1a7b901",
-    "transaction_id": "2b4d69aa-22e4-4c78-9f56-5a7b9e2b2002",
-    "bap_id": "bap.example.com",
-    "bap_uri": "https://bap.example.com",
-    "ttl": "PT30S",
-    "bpp_id": "bpp.example.com",
-    "bpp_uri": "https://bpp.example.com"
-  },
-  "message": {
-    "order": {
-      "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
-      "@type": "beckn:Order",
-      "beckn:orderStatus": "CREATED",
-      "beckn:seller": "ecopower-charging",
-      "beckn:buyer": {
-        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
-        "@type": "beckn:Buyer",
-        "beckn:id": "user-123",
-        "beckn:role": "BUYER",
-        "beckn:displayName": "Ravi Kumar",
-        "beckn:telephone": "+91-9876543210",
-        "beckn:email": "ravi.kumar@example.com",
-        "beckn:taxID": "GSTIN29ABCDE1234F1Z5"
-      },
-      "beckn:orderItems": [
-        {
-          "beckn:orderedItem": "IND*ecopower-charging*cs-01*IN*ECO*BTM*01*CCS2*A*CCS2-A",
-          "beckn:quantity": {
-            "unitText": "Kilowatt Hour",
-            "unitCode": "KWH",
-            "unitQuantity": 2.5
-          },
-          "beckn:acceptedOffer": {
-            "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/core/v2/context.jsonld",
-            "@type": "beckn:Offer",
-            "beckn:id": "offer-ccs2-60kw-kwh",
-            "beckn:descriptor": {
-              "@type": "beckn:Descriptor",
-              "schema:name": "Per-kWh Tariff - CCS2 60kW"
-            },
-            "beckn:items": [
-              "IND*ecopower-charging*cs-01*IN*ECO*BTM*01*CCS2*A*CCS2-A"
-            ],
-            "beckn:provider": "ecopower-charging",
-            "beckn:price": {
-              "currency": "INR",
-              "value": 45.0,
-              "applicableQuantity": {
-                "unitText": "Kilowatt Hour",
-                "unitCode": "KWH",
-                "unitQuantity": 1
-              }
-            }
-          }
-        }
-      ],
-      "beckn:orderAttributes": {
-        "@context": "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/main/schema/EvChargingSession/v1/context.jsonld",
-        "@type": "ChargingSession",
-        "buyerFinderFee": {
-          "feeType": "PERCENTAGE",
-          "feeValue": 2.5
-        },
-        "preferences": {
-          "startTime": "2026-01-04T08:00:00+05:30",
-          "endTime": "2026-01-04T20:00:00+05:30"
-        }
-      }
-    }
-  }
-}`)
-	got := selectAuditPayload(ctx, body)
-	require.NotNil(t, got, "selectAuditPayload should return projected body for select action")
+		"context": {
+			"transactionId": "txn-1",
+			"messageId": "msg-1",
+			"action": "confirm",
+			"domain": "retail"
+		},
+		"message": {"order": {"id": "ord-1"}}
+	}`)
 
-	var out map[string]interface{}
-	require.NoError(t, json.Unmarshal(got, &out))
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	ctx := out["context"].(map[string]interface{})
 
-	// Context: only transaction_id, message_id, action, timestamp
-	ctxMap, ok := out["context"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "select", ctxMap["action"])
-	assert.Equal(t, "2b4d69aa-22e4-4c78-9f56-5a7b9e2b2002", ctxMap["transaction_id"])
-	assert.Equal(t, "bb9f86db-9a3d-4e9c-8c11-81c8f1a7b901", ctxMap["message_id"])
-	assert.Equal(t, "2024-01-15T10:30:00Z", ctxMap["timestamp"])
-	_, hasBapID := ctxMap["bap_id"]
-	assert.False(t, hasBapID, "context should not include bap_id when not in audit rules")
+	assert.Equal(t, "txn-1", ctx["transactionId"], "transactionId must be kept")
+	assert.Equal(t, "confirm", ctx["action"], "action must be kept")
+	assert.Nil(t, ctx["messageId"], "messageId is not selected — must be dropped")
+	assert.Nil(t, ctx["domain"], "domain is not selected — must be dropped")
+	assert.Nil(t, out["message"], "message is not selected — must be dropped")
+}
 
-	// message.order: full order merged with projected array fields
-	msg, ok := out["message"].(map[string]interface{})
-	require.True(t, ok)
-	order, ok := msg["order"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "ecopower-charging", order["beckn:seller"])
-	buyer, ok := order["beckn:buyer"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "user-123", buyer["beckn:id"])
+func TestProcessAuditPayload_SelectiveMode_PerActionOverridesDefault(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns: {}
+maskRules: []
+selectedFields:
+  default:
+    - context.transactionId
+    - context.action
+  confirm:
+    - context.transactionId
+    - context.action
+    - message.order.id
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
 
-	// beckn:orderItems: array with projected fields from each element (beckn:orderedItem, beckn:acceptedOffer with id, price, price.value)
-	items, ok := order["beckn:orderItems"].([]interface{})
-	require.True(t, ok)
-	require.Len(t, items, 1)
-	item0, ok := items[0].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "IND*ecopower-charging*cs-01*IN*ECO*BTM*01*CCS2*A*CCS2-A", item0["beckn:orderedItem"])
-	acceptedOffer, ok := item0["beckn:acceptedOffer"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "offer-ccs2-60kw-kwh", acceptedOffer["beckn:id"])
-	price, ok := acceptedOffer["beckn:price"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, 45.0, price["value"])
+	body := []byte(`{
+		"context": {"transactionId": "txn-1", "action": "confirm", "domain": "retail"},
+		"message": {"order": {"id": "ord-99", "status": "ACTIVE"}}
+	}`)
 
-	// beckn:orderAttributes: only preferences and preferences.startTime
-	orderAttrs, ok := order["beckn:orderAttributes"].(map[string]interface{})
-	require.True(t, ok)
-	prefs, ok := orderAttrs["preferences"].(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, "2026-01-04T08:00:00+05:30", prefs["startTime"])
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	order := out["message"].(map[string]interface{})["order"].(map[string]interface{})
+
+	assert.Equal(t, "ord-99", order["id"], "message.order.id is in confirm list — must be kept")
+	assert.Nil(t, order["status"], "message.order.status is not in confirm list — must be dropped")
+	assert.Nil(t, out["context"].(map[string]interface{})["domain"])
+}
+
+func TestProcessAuditPayload_SelectiveMode_FallsBackToDefault(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns: {}
+maskRules: []
+selectedFields:
+  default:
+    - context.transactionId
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	// action is "search" — not listed in selectedFields, so default applies.
+	body := []byte(`{"context":{"transactionId":"txn-1","action":"search","domain":"ev"}}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	ctx := out["context"].(map[string]interface{})
+
+	assert.Equal(t, "txn-1", ctx["transactionId"])
+	assert.Nil(t, ctx["action"], "action not in default list — must be dropped")
+	assert.Nil(t, ctx["domain"])
+}
+
+func TestProcessAuditPayload_SelectiveMode_NoSelectedFieldsPassThrough(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns: {}
+maskRules: []
+`) // no selectedFields — keep set is nil → pass through
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	body := []byte(`{"context":{"transactionId":"txn-1","action":"search"}}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	ctx := out["context"].(map[string]interface{})
+
+	assert.Equal(t, "txn-1", ctx["transactionId"], "no selectedFields → full pass-through")
+	assert.Equal(t, "search", ctx["action"])
+}
+
+func TestProcessAuditPayload_SelectiveMode_MaskingAppliedAfterSelection(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: selective
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+maskRules:
+  - keys: [email]
+    pattern: email
+selectedFields:
+  default:
+    - context.transactionId
+    - message.buyer.email
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	body := []byte(`{
+		"context": {"transactionId": "txn-1", "action": "init", "domain": "retail"},
+		"message": {
+			"buyer": {"email": "secret@example.com", "name": "Alice"},
+			"order": {"id": "ord-1"}
+		}
+	}`)
+
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	ctx := out["context"].(map[string]interface{})
+	buyer := out["message"].(map[string]interface{})["buyer"].(map[string]interface{})
+
+	assert.Equal(t, "txn-1", ctx["transactionId"])
+	assert.Nil(t, ctx["domain"], "domain not selected — must be dropped")
+	// email is selected AND in maskRules — key-name masking fires before selection check
+	assert.Equal(t, "***@***.***", buyer["email"])
+	assert.Nil(t, buyer["name"], "name not in selectedFields — must be dropped")
+	assert.Nil(t, out["message"].(map[string]interface{})["order"], "order not in selectedFields — must be dropped")
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+func TestProcessAuditPayload_NilBodyReturnsNil(t *testing.T) {
+	resetConfig(t)
+	assert.Equal(t, []byte(nil), ProcessAuditPayload(context.Background(), nil))
+}
+
+func TestProcessAuditPayload_EmptyBodyReturnsEmpty(t *testing.T) {
+	resetConfig(t)
+	assert.Equal(t, []byte{}, ProcessAuditPayload(context.Background(), []byte{}))
+}
+
+func TestProcessAuditPayload_NoConfigPassThrough(t *testing.T) {
+	resetConfig(t)
+	body := []byte(`{"context":{"action":"search"}}`)
+	assert.Equal(t, body, ProcessAuditPayload(context.Background(), body))
+}
+
+func TestProcessAuditPayload_InvalidJSONReturnsOriginal(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  sensitive:
+    maskType: replace
+    mask: "[REDACTED]"
+maskRules:
+  - keys: [name]
+    pattern: sensitive
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	body := []byte("not valid json")
+	// Should return the original body, not nil or panic.
+	assert.Equal(t, body, ProcessAuditPayload(context.Background(), body))
+}
+
+func TestProcessAuditPayload_MissingPathIsNoOp(t *testing.T) {
+	resetConfig(t)
+	url := serveYAML(t, `
+mode: full
+patterns:
+  email:
+    maskType: replace
+    mask: "***@***.***"
+maskRules:
+  - keys: [email]
+    pattern: email
+`)
+	require.NoError(t, LoadAuditConfig(context.Background(), url))
+
+	// Payload has no email field — should come through untouched.
+	body := []byte(`{"context":{"action":"search"},"message":{"id":"m1"}}`)
+	out := unmarshalJSON(t, ProcessAuditPayload(context.Background(), body))
+	assert.Equal(t, "search", out["context"].(map[string]interface{})["action"])
+	assert.Equal(t, "m1", out["message"].(map[string]interface{})["id"])
+}
+
+// ── applyMask / maskLast4 unit tests ────────────────────────────────────────
+
+func TestMaskLast4(t *testing.T) {
+	assert.Equal(t, "***", maskLast4("abc"))
+	assert.Equal(t, "****", maskLast4("abcd"))
+	assert.Equal(t, "*bcde", maskLast4("abcde"))
+	assert.Equal(t, "**********3210", maskLast4("+91-9876543210"))
+}
+
+func TestApplyMask_NilPatternReturnsDefault(t *testing.T) {
+	assert.Equal(t, defaultMask, applyMask("anything", nil))
+}
+
+func TestApplyMask_Replace(t *testing.T) {
+	p := &CompiledPattern{MaskType: "replace", Mask: "***@***.***"}
+	assert.Equal(t, "***@***.***", applyMask("real@email.com", p))
+}
+
+func TestApplyMask_ReplaceEmptyMaskFallsBackToDefault(t *testing.T) {
+	p := &CompiledPattern{MaskType: "replace", Mask: ""}
+	assert.Equal(t, defaultMask, applyMask("value", p))
+}
+
+func TestApplyMask_Last4(t *testing.T) {
+	p := &CompiledPattern{MaskType: "last4"}
+	assert.Equal(t, "**3456", applyMask("123456", p))
+}
+
+func TestApplyMask_NonStringValue(t *testing.T) {
+	p := &CompiledPattern{MaskType: "replace", Mask: "[REDACTED]"}
+	assert.Equal(t, "[REDACTED]", applyMask(42, p))
+	assert.Equal(t, "[REDACTED]", applyMask(true, p))
 }

--- a/pkg/telemetry/pii_mask.go
+++ b/pkg/telemetry/pii_mask.go
@@ -1,0 +1,45 @@
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+)
+
+const defaultMask = "[MASKED]"
+
+// applyMask replaces val using the pattern's mask type:
+//   - "replace": substitutes the entire value with the pattern's literal mask string.
+//   - "last4":   keeps the last 4 characters, replaces everything before with '*'.
+//
+// Non-string values are converted to their string representation before masking.
+// A nil pattern returns the default mask "[MASKED]".
+func applyMask(val interface{}, pattern *CompiledPattern) interface{} {
+	if pattern == nil {
+		return defaultMask
+	}
+
+	s, ok := val.(string)
+	if !ok {
+		s = fmt.Sprintf("%v", val)
+	}
+
+	switch pattern.MaskType {
+	case "last4":
+		return maskLast4(s)
+	default: // "replace"
+		if pattern.Mask != "" {
+			return pattern.Mask
+		}
+		return defaultMask
+	}
+}
+
+// maskLast4 keeps the last 4 runes of s and replaces everything before with '*'.
+// Strings of 4 characters or fewer are fully replaced with '*'.
+func maskLast4(s string) string {
+	runes := []rune(s)
+	if len(runes) <= 4 {
+		return strings.Repeat("*", len(runes))
+	}
+	return strings.Repeat("*", len(runes)-4) + string(runes[len(runes)-4:])
+}


### PR DESCRIPTION
Closes #604

## Summary

- **Unified single-pass audit pipeline**: replaces the old `LoadAuditFieldRules`/`selectAuditPayload` with a single tree walk that applies PII masking and field selection simultaneously — optimized for latency
- **Dual-mode support**: `mode: full` emits the entire payload with PII masked; `mode: selective` emits only configured fields with PII masked
- **Key-name masking**: named pattern library (`email`, `phone`, `sensitive`, `account`) bound to field names via `maskRules` — portable across all Beckn domains and schema versions without path coupling
- **Hot-reload**: `StartAuditFieldsRefresh` goroutine reloads `audit-fields.yaml` at configurable `cacheTTL` interval without restart
- **`SetLogsEnabled` wiring fix**: `otelsetup` plugin now correctly sets the logs-enabled flag after registering the SDK log provider, fixing the "logs disabled" error that silently dropped all audit logs
- **Loki OTLP ingestion**: added `otlp_config` stream label mappings so Loki 3.x accepts OTLP pushes from otel-collector-network
- **Observability improvements in `stdHandler`**: adds `sender.id`, `receiver.id` to audit log attributes; fixes `http.request.error` attribute naming; fixes error capture scope for deferred span

## Files changed

| Area | File | Change |
|---|---|---|
| Core pipeline | `pkg/telemetry/audit_fields.go` | Complete rewrite — unified single-pass walk |
| PII masking | `pkg/telemetry/pii_mask.go` | New — `applyMask`, `maskLast4` helpers |
| Audit emit | `pkg/telemetry/audit.go` | `selectAuditPayload` → `ProcessAuditPayload` |
| Tests | `pkg/telemetry/audit_fields_test.go` | Full rewrite — 28 tests |
| Config | `config/audit-fields.yaml` | New schema: `mode`, `patterns`, `maskRules`, `pathOverrides`, `selectedFields` |
| Plugin | `otelsetup/otelsetup.go` | `CacheTTL` field; `SetLogsEnabled` lifecycle fix |
| Plugin | `otelsetup/cmd/plugin.go` | `cacheTTL` parsing; `StartAuditFieldsRefresh` wiring |
| Handler | `core/module/handler/stdHandler.go` | `sender.id`/`receiver.id` attrs; error attribute rename; error scope fix |
| Local configs | `config/local-beckn-one-bap.yaml`, `local-beckn-one-bpp.yaml` | Added `cacheTTL: "3600"` |
| Infra | `install/network-observability/loki/loki-config.yml` | `otlp_config` stream labels for Loki 3.x OTLP ingestion |
| Infra | `install/network-observability/otel-collector-network/config.yaml` | `debug` exporter on logs pipeline |

## Test plan

- [ ] `go test ./pkg/telemetry/...` passes
- [ ] Start stack with `docker compose -f install/network-observability/docker-compose-local.yml up -d`
- [ ] Trigger BAP/BPP requests and verify audit logs appear in Grafana under the network observability dashboard
- [ ] Verify PII fields (`email`, `phone`, `accountNumber`) are masked in Loki log entries
- [ ] Verify `mode: selective` emits only configured fields per action