### PR TITLE
feat(#652): emit onix_plugin_info gauge for loaded plugins per module

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -354,7 +354,7 @@ Metrics are organized by module for better maintainability and encapsulation:
 - `onix_plugin_execution_duration_seconds`, `onix_plugin_errors_total`
 
 #### Node Plugin Info (from `telemetry` package)
-- `onix_plugin_info` – Observable gauge (value always `1`) emitted once per loaded plugin per module at startup. Each loaded plugin becomes its own time series. Labels: `module`, `subscriber_id`, `plugin_type`, `plugin_id`. Covers all plugin slots (`schema_validator`, `sign_validator`, `router`, `registry`, `publisher`, `signer`, `cache`, `transport_wrapper`, `policy_checker`, `key_manager`) and one series per `step` and `middleware` entry. Absent/unconfigured slots emit no series. Enables Network Orchestrators to verify plugin composition across ONIX nodes, including detection of custom or non-standard plugins.
+- `onix_plugin_info` – Observable gauge (value always `1`) emitted once per loaded plugin per module at startup. Each loaded plugin becomes its own time series. Labels: `module`, `plugin_type`, `plugin_id`, and `subscriber_id` (only present when `subscriberId` is set in the handler config — omitted otherwise). Covers all plugin slots (`schema_validator`, `sign_validator`, `router`, `registry`, `publisher`, `signer`, `cache`, `transport_wrapper`, `policy_checker`, `key_manager`) and one series per `step` and `middleware` entry. Absent/unconfigured slots emit no series. Enables Network Orchestrators to verify plugin composition across ONIX nodes, including detection of custom or non-standard plugins. **Note:** the `subscriber_id` column in Grafana will be blank unless `subscriberId` is configured in each module's handler config.
 
 #### Runtime Metrics
 - Go runtime metrics (`go_*`) and Redis instrumentation via `redisotel`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -353,6 +353,9 @@ Metrics are organized by module for better maintainability and encapsulation:
 #### Plugin Metrics (from `telemetry` package)
 - `onix_plugin_execution_duration_seconds`, `onix_plugin_errors_total`
 
+#### Node Plugin Info (from `telemetry` package)
+- `onix_plugin_info` – Observable gauge (value always `1`) emitted once per loaded plugin per module at startup. Each loaded plugin becomes its own time series. Labels: `module`, `subscriber_id`, `plugin_type`, `plugin_id`. Covers all plugin slots (`schema_validator`, `sign_validator`, `router`, `registry`, `publisher`, `signer`, `cache`, `transport_wrapper`, `policy_checker`, `key_manager`) and one series per `step` and `middleware` entry. Absent/unconfigured slots emit no series. Enables Network Orchestrators to verify plugin composition across ONIX nodes, including detection of custom or non-standard plugins.
+
 #### Runtime Metrics
 - Go runtime metrics (`go_*`) and Redis instrumentation via `redisotel`
 
@@ -364,6 +367,7 @@ Each metric includes consistent labels such as `module`, `role`, `action`, `stat
 - Handler metrics: `core/module/handler/handlerMetrics.go`
 - Cache metrics: `pkg/plugin/implementation/cache/cache_metrics.go`
 - Plugin metrics: `pkg/telemetry/pluginMetrics.go`
+- Node plugin info: `pkg/telemetry/nodeInfo.go`
 
 ---
 

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 )
 
 // PluginManager defines an interface for managing plugins dynamically.
@@ -49,6 +50,40 @@ type PluginCfg struct {
 	TransportWrapper *plugin.Config  `yaml:"transportWrapper,omitempty"`
 	Middleware       []plugin.Config `yaml:"middleware,omitempty"`
 	Steps            []plugin.Config
+}
+
+// PluginEntries returns a flat list of all configured plugins in this PluginCfg.
+// Each named slot contributes one entry; Steps and Middleware contribute one
+// entry per item. Update this method whenever a new plugin slot is added to
+// PluginCfg so that the onix_plugin_info gauge stays complete.
+func (p *PluginCfg) PluginEntries() []telemetry.PluginEntry {
+	var entries []telemetry.PluginEntry
+	add := func(pluginType string, c *plugin.Config) {
+		if c != nil && c.ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: pluginType, ID: c.ID})
+		}
+	}
+	add("schema_validator", p.SchemaValidator)
+	add("sign_validator", p.SignValidator)
+	add("router", p.Router)
+	add("registry", p.Registry)
+	add("publisher", p.Publisher)
+	add("signer", p.Signer)
+	add("cache", p.Cache)
+	add("transport_wrapper", p.TransportWrapper)
+	add("policy_checker", p.PolicyChecker)
+	add("key_manager", p.KeyManager)
+	for i := range p.Steps {
+		if p.Steps[i].ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: "step", ID: p.Steps[i].ID})
+		}
+	}
+	for i := range p.Middleware {
+		if p.Middleware[i].ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: "middleware", ID: p.Middleware[i].ID})
+		}
+	}
+	return entries
 }
 
 // HttpClientConfig defines the configuration for the HTTP transport layer.

--- a/core/module/handler/config_test.go
+++ b/core/module/handler/config_test.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
+	"github.com/stretchr/testify/assert"
+)
+
+func cfg(id string) *plugin.Config { return &plugin.Config{ID: id} }
+
+func TestPluginEntries_AllNil(t *testing.T) {
+	p := PluginCfg{}
+	assert.Empty(t, p.PluginEntries(), "all-nil config should return no entries")
+}
+
+func TestPluginEntries_EmptyIDSkipped(t *testing.T) {
+	p := PluginCfg{
+		Router:  &plugin.Config{ID: ""},
+		Signer:  &plugin.Config{ID: ""},
+		Steps:   []plugin.Config{{ID: ""}},
+		Middleware: []plugin.Config{{ID: ""}},
+	}
+	assert.Empty(t, p.PluginEntries(), "configs with empty ID should be skipped")
+}
+
+func TestPluginEntries_AllNamedSlots(t *testing.T) {
+	p := PluginCfg{
+		SchemaValidator:  cfg("schemav2validator"),
+		SignValidator:    cfg("beckn_sign_validator"),
+		Router:           cfg("static_router"),
+		Registry:         cfg("dediregistry"),
+		Publisher:        cfg("kafka"),
+		Signer:           cfg("ed25519_signer"),
+		Cache:            cfg("redis"),
+		TransportWrapper: cfg("http_wrapper"),
+		PolicyChecker:    cfg("opa_policy"),
+		KeyManager:       cfg("beckn_key_mgr"),
+	}
+	entries := p.PluginEntries()
+	assert.Len(t, entries, 10)
+
+	byType := make(map[string]string)
+	for _, e := range entries {
+		byType[e.Type] = e.ID
+	}
+	assert.Equal(t, "schemav2validator", byType["schema_validator"])
+	assert.Equal(t, "beckn_sign_validator", byType["sign_validator"])
+	assert.Equal(t, "static_router", byType["router"])
+	assert.Equal(t, "dediregistry", byType["registry"])
+	assert.Equal(t, "kafka", byType["publisher"])
+	assert.Equal(t, "ed25519_signer", byType["signer"])
+	assert.Equal(t, "redis", byType["cache"])
+	assert.Equal(t, "http_wrapper", byType["transport_wrapper"])
+	assert.Equal(t, "opa_policy", byType["policy_checker"])
+	assert.Equal(t, "beckn_key_mgr", byType["key_manager"])
+}
+
+func TestPluginEntries_StepsAndMiddleware(t *testing.T) {
+	p := PluginCfg{
+		Steps: []plugin.Config{
+			{ID: "step_one"},
+			{ID: ""},
+			{ID: "step_two"},
+		},
+		Middleware: []plugin.Config{
+			{ID: "mw_one"},
+			{ID: "mw_two"},
+		},
+	}
+	entries := p.PluginEntries()
+	assert.Len(t, entries, 4, "empty-ID step should be omitted; 2 steps + 2 middleware = 4")
+
+	var steps, mws []telemetry.PluginEntry
+	for _, e := range entries {
+		switch e.Type {
+		case "step":
+			steps = append(steps, e)
+		case "middleware":
+			mws = append(mws, e)
+		}
+	}
+	assert.Len(t, steps, 2)
+	assert.Len(t, mws, 2)
+	assert.Equal(t, "step_one", steps[0].ID)
+	assert.Equal(t, "step_two", steps[1].ID)
+	assert.Equal(t, "mw_one", mws[0].ID)
+	assert.Equal(t, "mw_two", mws[1].ID)
+}

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -50,10 +50,11 @@ func Register(ctx context.Context, mCfgs []Config, mux *http.ServeMux, mgr handl
 
 		}
 		h = moduleCtxMiddleware(c.Name, h)
-		if c.Handler.SubscriberID == "" {
+		entries := c.Handler.Plugins.PluginEntries()
+		if c.Handler.SubscriberID == "" && len(entries) > 0 {
 			log.Warnf(ctx, "subscriberId not set for module %s: onix_plugin_info will be emitted without subscriber identity; set subscriberId in handler config for full network observability", c.Name)
 		}
-		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, c.Handler.Plugins.PluginEntries()); err != nil {
+		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, entries); err != nil {
 			log.Warnf(ctx, "Failed to register plugin info for module %s: %v", c.Name, err)
 		}
 		log.Debugf(ctx, "Registering handler %s, of type %s @ %s", c.Name, c.Handler.Type, c.Path)

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -8,6 +8,8 @@ import (
 	"github.com/beckn-one/beckn-onix/core/module/handler"
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 )
 
 // Config represents the configuration for a module.
@@ -49,6 +51,9 @@ func Register(ctx context.Context, mCfgs []Config, mux *http.ServeMux, mgr handl
 
 		}
 		h = moduleCtxMiddleware(c.Name, h)
+		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, pluginEntries(&c.Handler)); err != nil {
+			log.Warnf(ctx, "Failed to register plugin info for module %s: %v", c.Name, err)
+		}
 		log.Debugf(ctx, "Registering handler %s, of type %s @ %s", c.Name, c.Handler.Type, c.Path)
 		mux.Handle(c.Path, h)
 	}
@@ -75,6 +80,39 @@ func addMiddleware(ctx context.Context, mgr handler.PluginManager, handler http.
 
 	log.Debugf(ctx, "Middleware chain setup completed")
 	return handler, nil
+}
+
+// pluginEntries builds the list of loaded plugins for a handler config, one
+// entry per configured plugin slot and one per step/middleware item.
+func pluginEntries(cfg *handler.Config) []telemetry.PluginEntry {
+	pc := &cfg.Plugins
+	var entries []telemetry.PluginEntry
+	add := func(pluginType string, c *plugin.Config) {
+		if c != nil && c.ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: pluginType, ID: c.ID})
+		}
+	}
+	add("schema_validator", pc.SchemaValidator)
+	add("sign_validator", pc.SignValidator)
+	add("router", pc.Router)
+	add("registry", pc.Registry)
+	add("publisher", pc.Publisher)
+	add("signer", pc.Signer)
+	add("cache", pc.Cache)
+	add("transport_wrapper", pc.TransportWrapper)
+	add("policy_checker", pc.PolicyChecker)
+	add("key_manager", pc.KeyManager)
+	for i := range pc.Steps {
+		if pc.Steps[i].ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: "step", ID: pc.Steps[i].ID})
+		}
+	}
+	for i := range pc.Middleware {
+		if pc.Middleware[i].ID != "" {
+			entries = append(entries, telemetry.PluginEntry{Type: "middleware", ID: pc.Middleware[i].ID})
+		}
+	}
+	return entries
 }
 
 func moduleCtxMiddleware(moduleName string, next http.Handler) http.Handler {

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -8,7 +8,6 @@ import (
 	"github.com/beckn-one/beckn-onix/core/module/handler"
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
-	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 )
 
@@ -51,7 +50,7 @@ func Register(ctx context.Context, mCfgs []Config, mux *http.ServeMux, mgr handl
 
 		}
 		h = moduleCtxMiddleware(c.Name, h)
-		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, pluginEntries(&c.Handler)); err != nil {
+		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, c.Handler.Plugins.PluginEntries()); err != nil {
 			log.Warnf(ctx, "Failed to register plugin info for module %s: %v", c.Name, err)
 		}
 		log.Debugf(ctx, "Registering handler %s, of type %s @ %s", c.Name, c.Handler.Type, c.Path)
@@ -80,39 +79,6 @@ func addMiddleware(ctx context.Context, mgr handler.PluginManager, handler http.
 
 	log.Debugf(ctx, "Middleware chain setup completed")
 	return handler, nil
-}
-
-// pluginEntries builds the list of loaded plugins for a handler config, one
-// entry per configured plugin slot and one per step/middleware item.
-func pluginEntries(cfg *handler.Config) []telemetry.PluginEntry {
-	pc := &cfg.Plugins
-	var entries []telemetry.PluginEntry
-	add := func(pluginType string, c *plugin.Config) {
-		if c != nil && c.ID != "" {
-			entries = append(entries, telemetry.PluginEntry{Type: pluginType, ID: c.ID})
-		}
-	}
-	add("schema_validator", pc.SchemaValidator)
-	add("sign_validator", pc.SignValidator)
-	add("router", pc.Router)
-	add("registry", pc.Registry)
-	add("publisher", pc.Publisher)
-	add("signer", pc.Signer)
-	add("cache", pc.Cache)
-	add("transport_wrapper", pc.TransportWrapper)
-	add("policy_checker", pc.PolicyChecker)
-	add("key_manager", pc.KeyManager)
-	for i := range pc.Steps {
-		if pc.Steps[i].ID != "" {
-			entries = append(entries, telemetry.PluginEntry{Type: "step", ID: pc.Steps[i].ID})
-		}
-	}
-	for i := range pc.Middleware {
-		if pc.Middleware[i].ID != "" {
-			entries = append(entries, telemetry.PluginEntry{Type: "middleware", ID: pc.Middleware[i].ID})
-		}
-	}
-	return entries
 }
 
 func moduleCtxMiddleware(moduleName string, next http.Handler) http.Handler {

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -50,6 +50,9 @@ func Register(ctx context.Context, mCfgs []Config, mux *http.ServeMux, mgr handl
 
 		}
 		h = moduleCtxMiddleware(c.Name, h)
+		if c.Handler.SubscriberID == "" {
+			log.Warnf(ctx, "subscriberId not set for module %s: onix_plugin_info will be emitted without subscriber identity; set subscriberId in handler config for full network observability", c.Name)
+		}
 		if err := telemetry.RegisterPluginInfo(ctx, c.Name, c.Handler.SubscriberID, c.Handler.Plugins.PluginEntries()); err != nil {
 			log.Warnf(ctx, "Failed to register plugin info for module %s: %v", c.Name, err)
 		}

--- a/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
+++ b/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
@@ -107,14 +107,187 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 11,
+      "title": "Node Plugin Manifest",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Complete plugin composition for every ONIX module on the network. Each row is one loaded plugin. Use this to verify nodes are running expected implementations.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "auto", "filterable": true, "inspect": false },
+          "noValue": "-"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 18 },
+      "id": 12,
+      "options": {
+        "footer": { "enablePagination": true, "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": false, "displayName": "subscriber_id" }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "{__name__=~\"onix.*plugin_info\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Full Plugin Manifest (all nodes)",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": { "names": ["subscriber_id", "module", "plugin_type", "plugin_id", "Value"] }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Value": true },
+            "indexByName": {
+              "subscriber_id": 0,
+              "module": 1,
+              "plugin_type": 2,
+              "plugin_id": 3
+            },
+            "renameByName": {
+              "subscriber_id": "Subscriber",
+              "module": "Module",
+              "plugin_type": "Plugin Type",
+              "plugin_id": "Plugin ID"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Plugins whose ID does not match the known blessed set. Update the regex in the query to reflect your network's approved plugin list.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "orange", "mode": "fixed" },
+          "custom": { "align": "auto", "displayMode": "color-background", "filterable": true, "inspect": false },
+          "noValue": "None — all plugins are standard"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "id": 13,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "{__name__=~\"onix.*plugin_info\", plugin_id!~\"schemav2validator|beckn_sign_validator|static_router|dediregistry|kafka|ed25519_signer|redis|http_wrapper|opa_policy|beckn_key_mgr\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Custom / Non-standard Plugins",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": { "names": ["subscriber_id", "module", "plugin_type", "plugin_id", "Value"] }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Value": true },
+            "renameByName": {
+              "subscriber_id": "Subscriber",
+              "module": "Module",
+              "plugin_type": "Plugin Type",
+              "plugin_id": "Plugin ID"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Modules that are missing the required plugin slot selected in the dropdown above. An empty table means all modules have the slot configured.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "custom": { "align": "auto", "displayMode": "color-background", "filterable": true, "inspect": false },
+          "noValue": "None — all modules have this slot"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [{ "id": "custom.hidden", "value": true }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "id": 14,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\"}) unless group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\", plugin_type=\"$required_plugin_type\"})",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes Missing: $required_plugin_type",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": { "names": ["subscriber_id", "module", "Value"] }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Value": true },
+            "renameByName": {
+              "subscriber_id": "Subscriber",
+              "module": "Module"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
       "id": 6,
       "title": "Network Logs (Beckn Audit)",
       "type": "row"
     },
     {
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 18 },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 37 },
       "id": 7,
       "options": {
         "dedupStrategy": "none",
@@ -138,7 +311,7 @@
     },
     {
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 49 },
       "id": 71,
       "options": { "dedupStrategy": "none", "enableLogDetails": true, "showCommonLabels": true, "showLabels": true, "showTime": true, "sortOrder": "Descend" },
       "targets": [{ "datasource": { "type": "loki", "uid": "loki" }, "expr": "{}", "refId": "A" }],
@@ -146,14 +319,14 @@
       "type": "logs"
     },
     {
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
       "id": 8,
       "title": "Network Traces",
       "type": "row"
     },
     {
       "datasource": { "type": "zipkin", "uid": "zipkin" },
-      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 33 },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 58 },
       "id": 9,
       "options": {
         "dedupStrategy": "none",
@@ -174,10 +347,10 @@
       "type": "traces"
     },
     {
-      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 45 },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 70 },
       "id": 10,
       "options": {
-        "content": "**Network-level observability**: Beckn API spans, audit logs, and HTTP request metrics from the network pipeline.\n\n**No Loki/Zipkin data?** 1) Restart stack after config changes: `docker compose -f network_observability/docker-compose.yml up -d --force-recreate`. 2) Trigger requests to generate audit logs (EmitAuditLogs runs on each request). 3) Use [Zipkin UI](http://localhost:9411) to search traces. 4) In Grafana Explore (Loki), try `{}` or `{service_name=~\".+\"}` to see all logs.",
+        "content": "**Network-level observability**: Beckn API spans, audit logs, and HTTP request metrics from the network pipeline.\n\n**Node Plugin Manifest**: Shows loaded plugins per ONIX module. The *Custom / Non-standard Plugins* panel highlights any `plugin_id` outside the approved list — update the regex in that panel's query to match your network's blessed plugins. The *Nodes Missing* panel uses the `$required_plugin_type` variable (dropdown above) to find modules lacking a specific slot.\n\n**No Loki/Zipkin data?** 1) Restart stack after config changes: `docker compose -f network_observability/docker-compose.yml up -d --force-recreate`. 2) Trigger requests to generate audit logs. 3) Use [Zipkin UI](http://localhost:9411) to search traces.",
         "mode": "markdown"
       },
       "title": "About",
@@ -188,7 +361,35 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": ["onix", "network", "observability"],
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "registry", "value": "registry" },
+        "description": "Plugin slot to check for absence across all modules",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Required plugin type",
+        "multi": false,
+        "name": "required_plugin_type",
+        "options": [
+          { "selected": false, "text": "schema_validator", "value": "schema_validator" },
+          { "selected": false, "text": "sign_validator", "value": "sign_validator" },
+          { "selected": false, "text": "router", "value": "router" },
+          { "selected": true, "text": "registry", "value": "registry" },
+          { "selected": false, "text": "publisher", "value": "publisher" },
+          { "selected": false, "text": "signer", "value": "signer" },
+          { "selected": false, "text": "cache", "value": "cache" },
+          { "selected": false, "text": "transport_wrapper", "value": "transport_wrapper" },
+          { "selected": false, "text": "policy_checker", "value": "policy_checker" },
+          { "selected": false, "text": "key_manager", "value": "key_manager" },
+          { "selected": false, "text": "step", "value": "step" },
+          { "selected": false, "text": "middleware", "value": "middleware" }
+        ],
+        "query": "schema_validator,sign_validator,router,registry,publisher,signer,cache,transport_wrapper,policy_checker,key_manager,step,middleware",
+        "type": "custom"
+      }
+    ]
+  },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "",

--- a/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
+++ b/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
@@ -133,7 +133,7 @@
       "options": {
         "footer": { "enablePagination": true, "show": false },
         "showHeader": true,
-        "sortBy": [{ "desc": false, "displayName": "subscriber_id" }]
+        "sortBy": [{ "desc": false, "displayName": "Subscriber ID" }]
       },
       "targets": [
         {
@@ -147,15 +147,20 @@
       "title": "Full Plugin Manifest (all nodes)",
       "transformations": [
         {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": { "names": ["subscriber_id", "module", "plugin_type", "plugin_id", "Value"] }
-          }
-        },
-        {
           "id": "organize",
           "options": {
-            "excludeByName": { "Value": true },
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "exported_job": true,
+              "instance": true,
+              "job": true,
+              "observability": true,
+              "otel_scope_name": true,
+              "otel_scope_version": true,
+              "service_name": true,
+              "Value": true
+            },
             "indexByName": {
               "subscriber_id": 0,
               "module": 1,
@@ -163,7 +168,7 @@
               "plugin_id": 3
             },
             "renameByName": {
-              "subscriber_id": "Subscriber",
+              "subscriber_id": "Subscriber ID",
               "module": "Module",
               "plugin_type": "Plugin Type",
               "plugin_id": "Plugin ID"
@@ -207,17 +212,28 @@
       "title": "Custom / Non-standard Plugins",
       "transformations": [
         {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": { "names": ["subscriber_id", "module", "plugin_type", "plugin_id", "Value"] }
-          }
-        },
-        {
           "id": "organize",
           "options": {
-            "excludeByName": { "Value": true },
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "exported_job": true,
+              "instance": true,
+              "job": true,
+              "observability": true,
+              "otel_scope_name": true,
+              "otel_scope_version": true,
+              "service_name": true,
+              "Value": true
+            },
+            "indexByName": {
+              "subscriber_id": 0,
+              "module": 1,
+              "plugin_type": 2,
+              "plugin_id": 3
+            },
             "renameByName": {
-              "subscriber_id": "Subscriber",
+              "subscriber_id": "Subscriber ID",
               "module": "Module",
               "plugin_type": "Plugin Type",
               "plugin_id": "Plugin ID"
@@ -252,7 +268,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\"}) unless group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\", plugin_type=\"$required_plugin_type\"})",
+          "expr": "group by (service_name, subscriber_id, module) ({__name__=~\"onix.*plugin_info\"}) unless group by (service_name, subscriber_id, module) ({__name__=~\"onix.*plugin_info\", plugin_type=\"$required_plugin_type\"})",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -261,17 +277,26 @@
       "title": "Nodes Missing: $required_plugin_type",
       "transformations": [
         {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": { "names": ["subscriber_id", "module", "Value"] }
-          }
-        },
-        {
           "id": "organize",
           "options": {
-            "excludeByName": { "Value": true },
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "exported_job": true,
+              "instance": true,
+              "job": true,
+              "observability": true,
+              "otel_scope_name": true,
+              "otel_scope_version": true,
+              "service_name": true,
+              "Value": true
+            },
+            "indexByName": {
+              "subscriber_id": 0,
+              "module": 1
+            },
             "renameByName": {
-              "subscriber_id": "Subscriber",
+              "subscriber_id": "Subscriber ID",
               "module": "Module"
             }
           }

--- a/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
+++ b/install/network-observability/grafana/provisioning/dashboards/json/network/network-observability-dashboard.json
@@ -268,7 +268,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "group by (service_name, subscriber_id, module) ({__name__=~\"onix.*plugin_info\"}) unless group by (service_name, subscriber_id, module) ({__name__=~\"onix.*plugin_info\", plugin_type=\"$required_plugin_type\"})",
+          "expr": "group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\"}) unless group by (subscriber_id, module) ({__name__=~\"onix.*plugin_info\", plugin_type=\"$required_plugin_type\"})",
           "format": "table",
           "instant": true,
           "refId": "A"

--- a/pkg/telemetry/nodeInfo.go
+++ b/pkg/telemetry/nodeInfo.go
@@ -33,12 +33,15 @@ func RegisterPluginInfo(_ context.Context, moduleName, subscriberID string, entr
 	}
 	_, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		for _, e := range entries {
-			o.ObserveInt64(gauge, 1, metric.WithAttributes(
+			attrs := []attribute.KeyValue{
 				AttrModule.String(moduleName),
-				attribute.String("subscriber_id", subscriberID),
 				AttrPluginType.String(e.Type),
 				AttrPluginID.String(e.ID),
-			))
+			}
+			if subscriberID != "" {
+				attrs = append(attrs, attribute.String("subscriber_id", subscriberID))
+			}
+			o.ObserveInt64(gauge, 1, metric.WithAttributes(attrs...))
 		}
 		return nil
 	}, gauge)

--- a/pkg/telemetry/nodeInfo.go
+++ b/pkg/telemetry/nodeInfo.go
@@ -1,0 +1,46 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// PluginEntry describes a single loaded plugin within a module.
+type PluginEntry struct {
+	Type string // e.g. "router", "registry", "step", "middleware"
+	ID   string // plugin implementation ID as configured
+}
+
+// RegisterPluginInfo registers an observable gauge reporting all loaded plugins
+// for a module. Each plugin appears as a separate time series with value 1 and
+// labels {module, subscriber_id, plugin_type, plugin_id}. Safe to call once per
+// module after all plugins are initialized; no-ops when entries is empty.
+func RegisterPluginInfo(_ context.Context, moduleName, subscriberID string, entries []PluginEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	meter := otel.GetMeterProvider().Meter(ScopeName, metric.WithInstrumentationVersion(ScopeVersion))
+	gauge, err := meter.Int64ObservableGauge(
+		"onix_plugin_info",
+		metric.WithDescription("Loaded plugins per ONIX module; value is always 1"),
+		metric.WithUnit("{plugin}"),
+	)
+	if err != nil {
+		return err
+	}
+	_, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		for _, e := range entries {
+			o.ObserveInt64(gauge, 1, metric.WithAttributes(
+				AttrModule.String(moduleName),
+				attribute.String("subscriber_id", subscriberID),
+				AttrPluginType.String(e.Type),
+				AttrPluginID.String(e.ID),
+			))
+		}
+		return nil
+	}, gauge)
+	return err
+}

--- a/pkg/telemetry/nodeInfo_test.go
+++ b/pkg/telemetry/nodeInfo_test.go
@@ -1,0 +1,78 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRegisterPluginInfo_EmptyEntries(t *testing.T) {
+	err := RegisterPluginInfo(context.Background(), "mod", "sub", nil)
+	assert.NoError(t, err, "empty entries should be a no-op")
+}
+
+func TestRegisterPluginInfo_AttributesWithSubscriberID(t *testing.T) {
+	ctx := context.Background()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { mp.Shutdown(ctx) })
+
+	entries := []PluginEntry{
+		{Type: "router", ID: "static_router"},
+		{Type: "signer", ID: "ed25519_signer"},
+	}
+	require.NoError(t, RegisterPluginInfo(ctx, "search", "bap.example.com", entries))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+
+	gauge := rm.ScopeMetrics[0].Metrics[0]
+	assert.Equal(t, "onix_plugin_info", gauge.Name)
+
+	data, ok := gauge.Data.(metricdata.Gauge[int64])
+	require.True(t, ok, "metric data should be Gauge[int64]")
+	assert.Len(t, data.DataPoints, 2)
+
+	for _, dp := range data.DataPoints {
+		attrs := dp.Attributes.ToSlice()
+		attrMap := make(map[string]string, len(attrs))
+		for _, a := range attrs {
+			attrMap[string(a.Key)] = a.Value.AsString()
+		}
+		assert.Equal(t, "search", attrMap["module"])
+		assert.Equal(t, "bap.example.com", attrMap["subscriber_id"])
+		assert.Contains(t, []string{"router", "signer"}, attrMap["plugin_type"])
+		assert.NotEmpty(t, attrMap["plugin_id"])
+	}
+}
+
+func TestRegisterPluginInfo_NoSubscriberID(t *testing.T) {
+	ctx := context.Background()
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { mp.Shutdown(ctx) })
+
+	entries := []PluginEntry{{Type: "router", ID: "static_router"}}
+	require.NoError(t, RegisterPluginInfo(ctx, "search", "", entries))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	data, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Len(t, data.DataPoints, 1)
+
+	for _, attr := range data.DataPoints[0].Attributes.ToSlice() {
+		assert.NotEqual(t, "subscriber_id", string(attr.Key),
+			"subscriber_id attribute must be absent when subscriberID is empty")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `onix_plugin_info` observable gauge — one time series per loaded plugin per module with labels `{subscriber_id, module, plugin_type, plugin_id} = 1`, enabling NFOs to query and verify plugin composition across ONIX nodes
- `PluginEntries()` method added to `PluginCfg` in `handler/config.go`, co-located with the struct so new plugin slots have an obvious place to update
- Startup warning emitted when `subscriberId` is not set in handler config
- New **Node Plugin Manifest** row in the network observability Grafana dashboard with three panels: full manifest table, custom/non-standard plugin detection, and missing required slot detection (with dropdown variable)
- `CONFIG.md` updated with `onix_plugin_info` metric documentation

## Test plan

- [ ] Start the observability stack (`docker compose -f install/network-observability/docker-compose.yml up -d`)
- [ ] Confirm `onix_plugin_info` appears in Prometheus at `http://localhost:9090` with correct `module`, `plugin_type`, `plugin_id` labels
- [ ] Set `subscriberId` in a handler config and confirm `subscriber_id` label is populated
- [ ] Confirm startup warning appears in logs when `subscriberId` is absent
- [ ] Open Grafana Network Observability dashboard and verify the Node Plugin Manifest row renders all three panels
- [ ] Confirm custom step/middleware plugin IDs surface in the Custom/Non-standard Plugins panel

## Related
- Closes #652
- Follow-up: #663 (rename `networkParticipant` → `subscriberId` in simplekeymanager config)