### PR TITLE
docs: update config.MD guidance to explain allowed network IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ beckn-adapter
 .env
 .env.*
 test_request.json
+
+.codex

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -578,15 +578,16 @@ registry:
 
 #### 2. Dediregistry Plugin
 
-**Purpose**: Lookup participant information from a Decentralized Discovery (DeDi) registry.
+**Purpose**: Lookup participant information from a Decentralized Directory (DeDi) registry.
 
 **Configuration**:
 ```yaml
 registry:
   id: dediregistry
   config:
-    url: "https://dedi-wrapper.example.com/dedi"
+    url: "https://fabric.nfh.global/registry/dedi"
     registryName: "subscribers.beckn.one"
+    allowedNetworkIDs: "commerce-network.org/prod,local-commerce.org/production"
     timeout: 30
     retry_max: 3
     retry_wait_min: 1s
@@ -594,8 +595,9 @@ registry:
 ```
 
 **Parameters**:
-- `url`: DeDi wrapper API base URL (Required)
-- `registryName`: Name of the registry (Required)
+- `url`: DeDi wrapper API base URL including the `/dedi` path (Required)
+- `registryName`: Registry name used in the lookup path. Keep this value as `subscribers.beckn.one` so lookups include all cached registries. Use `allowedNetworkIDs` if you want lookup to be restricted within one or more networks. (Required)
+- `allowedNetworkIDs`: Comma-separated list of allowed network IDs used to restrict lookup results to specific networks. See [Beckn network setup documentation](https://docs.beckn.io/creating-an-open-network/setting-up-the-network-environment#registering-the-network-on-beckn-fabric) for more on network IDs. (Optional)
 - `timeout`: Request timeout in seconds (Optional, default: client default)
 - `retry_max`: Maximum number of retry attempts (Optional, default: 4)
 - `retry_wait_min`: Minimum wait time between retries in duration format (Optional, default: 1s)

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -595,7 +595,7 @@ registry:
 ```
 
 **Parameters**:
-- `url`: DeDi wrapper API base URL including the `/dedi` path (Required)
+- `url`: Beckn registry base URL including the `/dedi` path (Required)
 - `registryName`: Registry name used in the lookup path. Keep this value as `subscribers.beckn.one` so lookups include all cached registries. Use `allowedNetworkIDs` if you want lookup to be restricted within one or more networks. (Required)
 - `allowedNetworkIDs`: Comma-separated list of allowed network IDs used to restrict lookup results to specific networks. See [Beckn network setup documentation](https://docs.beckn.io/creating-an-open-network/setting-up-the-network-environment#registering-the-network-on-beckn-fabric) for more on network IDs. (Optional)
 - `timeout`: Request timeout in seconds (Optional, default: client default)


### PR DESCRIPTION
## Summary
Updates the `dediregistry` section in `CONFIG.md` to better reflect the intended configuration usage.

## Changes
- Added `allowedNetworkIDs` to the sample `dediregistry` configuration
- Documented `allowedNetworkIDs` in the parameter list
- Added a link to Beckn documentation for understanding network IDs
- Clarified that `url` must include the `/dedi` path
- Clarified that `registryName` should be kept as `subscribers.beckn.one` so all cached registries are included in lookup
- Added guidance to use `allowedNetworkIDs` when lookup needs to be restricted to specific networks

## Why
`CONFIG.md` is intended to be a configuration reference. The `dediregistry` section was missing one supported config field and did not clearly explain two important configuration expectations:
- the required URL shape
- the intended usage of `registryName` versus network-based restriction through `allowedNetworkIDs`

## Testing
- Documentation-only change
- No code or runtime behavior changed

Fixes #667 