### PR TITLE
fix(#657): standardise parent_id attribute name and clarify network collector comment

### DIFF
--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -405,7 +405,12 @@ func setBecknAttr(span trace.Span, r *http.Request, h *stdHandler) {
 		attrs = append(attrs, attribute.String("message_id", mesID))
 	}
 	if parentID, ok := r.Context().Value(model.ContextKeyParentID).(string); ok && parentID != "" {
-		attrs = append(attrs, attribute.String("parentSpanId", parentID))
+		// Attribute name matches audit.go ("parent_id") and the context key name so that
+		// cross-signal queries in Loki/Jaeger can join on a single consistent key.
+		// Previously named "parentSpanId" (camelCase), which was inconsistent and
+		// misleadingly implied an OTel span-parentage relationship; the value is the
+		// Beckn network identity of this adapter (role:subscriberID:pod), not a span ID.
+		attrs = append(attrs, attribute.String("parent_id", parentID))
 	}
 	if r.Host != "" {
 		attrs = append(attrs, attribute.String("server.address", r.Host))

--- a/install/network-observability/otel-collector-network/config.yaml
+++ b/install/network-observability/otel-collector-network/config.yaml
@@ -9,8 +9,14 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 processors:
-  # Map Beckn transaction_id -> trace_id and message_id -> span_id for UI correlation.
-  # UUID format: remove hyphens for trace_id (32 hex chars); first 16 hex chars for span_id.
+  # Map Beckn transaction_id -> trace_id for UI correlation in Zipkin/Jaeger.
+  # UUID format: remove hyphens to get 32 hex chars required by TraceID().
+  #
+  # Note: message_id is intentionally NOT mapped to span_id. At network level this
+  # collector receives one span from each node (BAP, BPP) for the same Beckn message,
+  # so multiple spans share the same message_id. Overwriting span_id with message_id
+  # would assign identical span IDs to distinct spans, corrupting the trace. message_id
+  # is already available as a span attribute and can be searched as a tag in Zipkin/Jaeger.
   transform/beckn_ids:
     error_mode: ignore
     trace_statements:


### PR DESCRIPTION
Closes #657

## Summary

- **Rename `parentSpanId` → `parent_id` in spans** (`core/module/handler/stdHandler.go`): The span attribute was camelCase while the same value was emitted as `parent_id` in audit logs. Both carry the Beckn network identity of the adapter (`role:subscriberID:pod`), not an OTel span ID. The inconsistent name silently broke cross-signal correlation queries in Loki/Jaeger when joining on `parent_id`. Renamed to match the audit log attribute, context key name, and existing snake_case convention (`transaction_id`, `message_id`).

- **Remove misleading comment in `otel-collector-network/config.yaml`**: The comment promised a `message_id → span_id` OTTL mapping alongside `transaction_id → trace_id`. At network level, this collector receives one span per node (BAP, BPP) for the same Beckn message — both spans carry the same `message_id`. Overwriting `span_id` with `message_id` would assign identical span IDs to distinct spans and corrupt the trace. The mapping is intentionally absent. `message_id` is already emitted as a span attribute and is searchable as a tag in Zipkin/Jaeger without any further mapping.

## Test plan

- [x] Verify span attribute `parent_id` appears in Jaeger for a BAP→BPP flow (previously `parentSpanId`)
- [x] Confirm cross-signal query on `parent_id` joins spans and audit logs correctly in Loki
- [x] Confirm no OTTL errors in `otel-collector-network` logs after config change