### PR TITLE
feat(#682): validateCounterSign step — Caller-side ACK counter-signature validation

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -509,15 +509,23 @@ modules:
 ##### `steps`
 **Type**: `array` of `string`  
 **Required**: Yes  
-**Description**: Ordered list of processing steps to execute for each request.  
-**Common Steps**:
-- `validateSign` - Validate digital signature
-- `addRoute` - Determine routing destination
-- `validateSchema` - Validate against JSON schema
-- `sign` - Sign outgoing request
-- `publish` - Publish to message queue
-- `counterSign` - Generate a counter-signature and embed it in the ACK response (`counter_sign` field inside `ack`). Required for Beckn v2.0.0 LTS receiver handlers. No-op for requests with `context.version != "2.0.0"`. Must be placed after all steps that can NACK (e.g. `validateSign`, `validateSchema`) so that counter-signatures are only computed for requests that will be acknowledged. Requires `signer` and `keyManager` plugins to be configured.
-- `checkPolicy` - Evaluate request against configured policy rules
+**Description**: Ordered list of processing steps to execute for each request.
+
+Each entry names a step that participates in the handler pipeline. A step can participate in one or both of two phases:
+
+- **Request phase** — runs on the inbound request before it is forwarded or published. All steps run this phase in the order listed.
+- **Response phase** — runs on the upstream response (proxied ACK) before it is returned to the caller. Only steps that opt into this phase run it; they do so automatically based on their implementation, with no extra configuration required. The order follows their position in the `steps` list.
+
+This means a single entry in `steps` can do work on both the request and the response. `counterSign`, for example, signs the request body during the request phase and injects the resulting `counter_sign` into the ACK during the response phase — both triggered by the single `counterSign` entry.
+
+**Available Steps**:
+- `validateSign` — Validate the digital signature on the inbound request. Request phase only.
+- `addRoute` — Determine the routing destination for the request. Request phase only.
+- `validateSchema` — Validate the request body against the configured JSON schema. Request phase only.
+- `sign` — Sign the outgoing request with the subscriber's private key. Request phase only. Requires `signer` and `keyManager` plugins.
+- `checkPolicy` — Evaluate the request against configured OPA policy rules. Request phase only. Requires `policyChecker` plugin.
+- `counterSign` — **(Beckn v2.0.0 LTS, Receiver handlers only)** Signs the inbound request body and embeds the result as `counter_sign` inside the ACK `ack` object. Participates in both phases: request phase computes the signature; response phase injects it into the proxied ACK when the downstream app responds. No-op for `context.version != "2.0.0"`. Must be placed after all steps that can NACK (e.g. `validateSign`, `validateSchema`) so counter-signatures are only computed for requests that pass validation. Requires `signer` and `keyManager` plugins.
+- `validateCounterSign` — **(Beckn v2.0.0 LTS, Caller handlers only)** Validates the `counter_sign` field in the ACK response received from the receiver. Participates in the response phase only (the request phase is a no-op). Reads `message.ack.counter_sign` from the upstream ACK, looks up the receiver's public key via the key manager, and verifies the signature against the original outbound request body. Returns a sign-validation error if `counter_sign` is absent or the signature is invalid. No-op for `context.version != "2.0.0"`. Requires `signValidator` and `keyManager` plugins.
 
 **Example**:
 ```yaml

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -169,4 +169,5 @@ modules:
         - addRoute
         - sign
         - validateSchema
+        - validateCounterSign
   

--- a/config/onix-bpp/adapter.yaml
+++ b/config/onix-bpp/adapter.yaml
@@ -120,3 +120,4 @@ modules:
         - validateSchema
         - addRoute
         - sign
+        - validateCounterSign

--- a/config/onix/adapter.yaml
+++ b/config/onix/adapter.yaml
@@ -131,6 +131,7 @@ modules:
         - checkPolicy
         - addRoute
         - sign
+        - validateCounterSign
   - name: bppTxnReciever
     path: /bpp/reciever/
     handler:
@@ -245,3 +246,4 @@ modules:
         - checkPolicy
         - addRoute
         - sign
+        - validateCounterSign

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -185,6 +185,13 @@ func (h *stdHandler) stepCtx(r *http.Request, rh http.Header) (*model.StepContex
 	body := bodyBuffer.Bytes()
 	subID := h.subID(r.Context())
 	protocolVersion := extractProtocolVersion(body)
+	// Log the first 512 bytes of the body so protocol-version extraction failures
+	// can be diagnosed without enabling full request logging.
+	if len(body) > 512 {
+		log.Debugf(r.Context(), "stepCtx: extracted protocol version %q from body (truncated): %.512s", protocolVersion, body)
+	} else {
+		log.Debugf(r.Context(), "stepCtx: extracted protocol version %q from body: %s", protocolVersion, body)
+	}
 	// Store the protocol version in the Go context so downstream functions that
 	// only receive a context.Context (e.g. response.SendNack) can read it.
 	ctx := context.WithValue(r.Context(), model.ContextKeyProtocolVersion, protocolVersion)

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -256,9 +255,6 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		Director:  director,
 		Transport: httpClient.Transport,
 		ModifyResponse: func(resp *http.Response) error {
-			if err := injectCounterSign(ctx, resp); err != nil {
-				return err
-			}
 			for _, rs := range responseSteps {
 				if err := rs.RunOnResponse(ctx, resp); err != nil {
 					return err
@@ -273,46 +269,6 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 	}
 
 	proxy.ServeHTTP(w, r)
-}
-
-// injectCounterSign reads the downstream app's ACK response body, injects the
-// counter_sign field when a counter-signature has been computed (v2.0.0 LTS),
-// and rewrites the response body. It is a no-op when CounterSign is empty.
-func injectCounterSign(ctx *model.StepContext, resp *http.Response) error {
-	if ctx.CounterSign == "" {
-		return nil
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return fmt.Errorf("counter-sign inject: failed to read response body: %w", err)
-	}
-
-	// Parse the ACK envelope and inject counter_sign.
-	var envelope struct {
-		Message struct {
-			Ack model.Ack `json:"ack"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		// Not a JSON ACK body — restore original and skip injection.
-		log.Warnf(ctx, "counter-sign inject: response is not a JSON ACK, skipping: %v", err)
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return nil
-	}
-
-	envelope.Message.Ack.CounterSign = ctx.CounterSign
-	modified, err := json.Marshal(envelope)
-	if err != nil {
-		return fmt.Errorf("counter-sign inject: failed to marshal modified ACK: %w", err)
-	}
-
-	resp.Body = io.NopCloser(bytes.NewReader(modified))
-	resp.ContentLength = int64(len(modified))
-	resp.Header.Set("Content-Length", strconv.Itoa(len(modified)))
-	log.Debugf(ctx, "CounterSignature injected into proxied ACK response")
-	return nil
 }
 
 // loadPlugin is a generic function to load and validate plugins.

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -31,6 +31,7 @@ import (
 type stdHandler struct {
 	signer           definition.Signer
 	steps            []definition.Step
+	responseSteps    []definition.ResponseStep
 	signValidator    definition.SignValidator
 	cache            definition.Cache
 	registry         definition.RegistryLookup
@@ -77,10 +78,11 @@ func newHTTPClient(cfg *HttpClientConfig, wrapper definition.TransportWrapper) *
 // NewStdHandler initializes a new processor with plugins and steps.
 func NewStdHandler(ctx context.Context, mgr PluginManager, cfg *Config, moduleName string) (http.Handler, error) {
 	h := &stdHandler{
-		steps:        []definition.Step{},
-		SubscriberID: cfg.SubscriberID,
-		role:         cfg.Role,
-		moduleName:   moduleName,
+		steps:         []definition.Step{},
+		responseSteps: []definition.ResponseStep{},
+		SubscriberID:  cfg.SubscriberID,
+		role:          cfg.Role,
+		moduleName:    moduleName,
 	}
 	// Initialize plugins.
 	if err := h.initPlugins(ctx, mgr, &cfg.Plugins); err != nil {
@@ -171,7 +173,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle routing based on the defined route type.
-	route(stepCtx, r, wrapped, h.publisher, h.httpClient)
+	route(stepCtx, r, wrapped, h.publisher, h.httpClient, h.responseSteps)
 }
 
 // stepCtx creates a new StepContext for processing an HTTP request.
@@ -210,12 +212,12 @@ func (h *stdHandler) subID(ctx context.Context) string {
 var proxyFunc = proxy
 
 // route handles request forwarding or message publishing based on the routing type.
-func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client) {
+func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client, responseSteps []definition.ResponseStep) {
 	log.Debugf(ctx, "Routing to ctx.Route to %#v", ctx.Route)
 	switch ctx.Route.TargetType {
 	case "url":
 		log.Infof(ctx.Context, "Forwarding request to URL: %s", ctx.Route.URL)
-		proxyFunc(ctx, r, w, httpClient)
+		proxyFunc(ctx, r, w, httpClient, responseSteps)
 		return
 	case "publisher":
 		if pb == nil {
@@ -239,7 +241,7 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 	}
 	response.SendAck(w, ctx.CounterSign)
 }
-func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client) {
+func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep) {
 	target := ctx.Route.URL
 	r.Header.Set("X-Forwarded-Host", r.Host)
 
@@ -254,7 +256,19 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		Director:  director,
 		Transport: httpClient.Transport,
 		ModifyResponse: func(resp *http.Response) error {
-			return injectCounterSign(ctx, resp)
+			if err := injectCounterSign(ctx, resp); err != nil {
+				return err
+			}
+			for _, rs := range responseSteps {
+				if err := rs.RunOnResponse(ctx, resp); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			log.Errorf(ctx, err, "proxy: upstream or response-step error: %v", err)
+			response.SendNack(ctx, rw, err)
 		},
 	}
 
@@ -408,6 +422,8 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newCheckPolicyStep(h.policyChecker)
 		case "counterSign":
 			s, err = newCounterSignStep(h.signer, h.km)
+		case "validateCounterSign":
+			s, err = newValidateCounterSignStep(h.signValidator, h.km)
 		default:
 			if customStep, exists := steps[step]; exists {
 				s = customStep
@@ -418,6 +434,12 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 
 		if err != nil {
 			return err
+		}
+		// Collect response-phase steps before instrumentation wrapping.
+		// The InstrumentedStep wrapper only covers Run(); RunOnResponse() is
+		// called directly on the original step.
+		if rs, ok := s.(definition.ResponseStep); ok {
+			h.responseSteps = append(h.responseSteps, rs)
 		}
 		instrumentedStep, wrapErr := NewInstrumentedStep(s, step, h.moduleName)
 		if wrapErr != nil {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,33 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
+
+// mockSignValidator is a configurable SignValidator for testing.
+type mockSignValidator struct {
+	err error
+}
+
+func (m *mockSignValidator) Validate(_ context.Context, _ []byte, _, _ string) error {
+	return m.err
+}
+
+// mockKeyManager is a configurable KeyManager for testing.
+type mockKeyManager struct {
+	signingPublicKey string
+	err              error
+}
+
+func (m *mockKeyManager) GenerateKeyset() (*model.Keyset, error)             { return nil, nil }
+func (m *mockKeyManager) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error {
+	return nil
+}
+func (m *mockKeyManager) Keyset(_ context.Context, _ string) (*model.Keyset, error) {
+	return nil, nil
+}
+func (m *mockKeyManager) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) {
+	return m.signingPublicKey, "", m.err
+}
+func (m *mockKeyManager) DeleteKeyset(_ context.Context, _ string) error { return nil }
 
 // noopPluginManager satisfies PluginManager with nil plugins (unused loaders are never invoked when config is omitted).
 type noopPluginManager struct{}
@@ -362,6 +391,117 @@ func TestCounterSignStepRunOnResponse(t *testing.T) {
 			got, _ := io.ReadAll(resp.Body)
 			if string(got) != tt.wantBody {
 				t.Errorf("body = %s, want %s", got, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestValidateCounterSignStepRunOnResponse(t *testing.T) {
+	const validSign = `Signature keyId="bpp.example.com|key-1|ed25519",algorithm="ed25519",created="1700000000",expires="1700000300",headers="(created) (expires) digest",signature="abc123"`
+
+	ltsCtx := func() *model.StepContext {
+		return &model.StepContext{
+			Context:         context.Background(),
+			ProtocolVersion: model.ProtocolVersionLTS,
+			Body:            []byte(`{"context":{"version":"2.0.0"}}`),
+		}
+	}
+
+	ackWith := func(counterSign string) string {
+		if counterSign == "" {
+			return `{"message":{"ack":{"status":"ACK"}}}`
+		}
+		// Use json.Marshal to correctly escape quotes inside the signature string.
+		escaped, _ := json.Marshal(counterSign)
+		return `{"message":{"ack":{"status":"ACK","counter_sign":` + string(escaped) + `}}}`
+	}
+
+	tests := []struct {
+		name        string
+		ctx         *model.StepContext
+		respBody    string
+		validator   *mockSignValidator
+		km          *mockKeyManager
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "no-op for non-LTS protocol version",
+			ctx:      &model.StepContext{Context: context.Background(), ProtocolVersion: "1.1.0"},
+			respBody: `{"message":{"ack":{"status":"ACK"}}}`,
+			// validator and km are nil — would panic if called, proving they are not reached
+		},
+		{
+			name:      "valid counter_sign passes validation",
+			ctx:       ltsCtx(),
+			respBody:  ackWith(validSign),
+			validator: &mockSignValidator{err: nil},
+			km:        &mockKeyManager{signingPublicKey: "some-public-key"},
+		},
+		{
+			name:        "missing counter_sign returns sign validation error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(""),
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "counter_sign missing",
+		},
+		{
+			name:        "malformed counter_sign header returns parse error",
+			ctx:         ltsCtx(),
+			respBody:    `{"message":{"ack":{"status":"ACK","counter_sign":"BadHeader"}}}`,
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "failed to parse counter_sign",
+		},
+		{
+			name:        "key lookup failure returns error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(validSign),
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{err: fmt.Errorf("registry unavailable")},
+			wantErr:     true,
+			errContains: "failed to look up public key",
+		},
+		{
+			name:        "signature validation failure returns sign validation error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(validSign),
+			validator:   &mockSignValidator{err: fmt.Errorf("signature mismatch")},
+			km:          &mockKeyManager{signingPublicKey: "some-public-key"},
+			wantErr:     true,
+			errContains: "counter-sign validation failed",
+		},
+		{
+			name:        "non-JSON response body returns error",
+			ctx:         ltsCtx(),
+			respBody:    `not-json`,
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "not a valid ACK",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &validateCounterSignStep{
+				validator: tt.validator,
+				km:        tt.km,
+			}
+			resp := &http.Response{
+				Header: http.Header{},
+				Body:   io.NopCloser(bytes.NewBufferString(tt.respBody)),
+			}
+
+			err := step.RunOnResponse(tt.ctx, resp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("RunOnResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.errContains)
 			}
 		})
 	}

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -312,7 +312,7 @@ func TestStepCtx_ProtocolVersion(t *testing.T) {
 	}
 }
 
-func TestInjectCounterSign(t *testing.T) {
+func TestCounterSignStepRunOnResponse(t *testing.T) {
 	const testSign = `Signature keyId="bpp.example.com|key-1|ed25519",signature="abc123"`
 
 	tests := []struct {
@@ -353,9 +353,10 @@ func TestInjectCounterSign(t *testing.T) {
 				Body:   io.NopCloser(bytes.NewBufferString(tt.respBody)),
 			}
 
-			err := injectCounterSign(ctx, resp)
+			step := &counterSignStep{}
+			err := step.RunOnResponse(ctx, resp)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("injectCounterSign() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("counterSignStep.RunOnResponse() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			got, _ := io.ReadAll(resp.Body)

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,7 +338,9 @@ func newCounterSignStep(signer definition.Signer, km definition.KeyManager) (def
 	return &counterSignStep{signer: signer, km: km}, nil
 }
 
-// Run executes the counter-sign step.
+// Run executes the counter-sign step. It signs the inbound request body and
+// stores the resulting auth-header string in ctx.CounterSign for injection
+// into the ACK response. For protocol versions other than "2.0.0" this is a no-op.
 func (s *counterSignStep) Run(ctx *model.StepContext) error {
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
 		return nil // no-op for legacy protocol versions
@@ -375,6 +378,45 @@ func (s *counterSignStep) Run(ctx *model.StepContext) error {
 		log.Debugf(ctx, "CounterSignature generated for subscriber: %s", ctx.SubID)
 	}
 
+	return nil
+}
+
+// RunOnResponse injects the counter_sign computed in Run into the upstream ACK
+// response body. It is a no-op when CounterSign is empty (i.e. non-LTS requests
+// or paths where the ACK was already sent directly without proxying).
+func (s *counterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	if ctx.CounterSign == "" {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to read response body: %w", err)
+	}
+
+	var envelope struct {
+		Message struct {
+			Ack model.Ack `json:"ack"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		// Not a JSON ACK body — restore original and skip injection.
+		log.Warnf(ctx, "counter-sign inject: response is not a JSON ACK, skipping: %v", err)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return nil
+	}
+
+	envelope.Message.Ack.CounterSign = ctx.CounterSign
+	modified, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to marshal modified ACK: %w", err)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(modified))
+	resp.ContentLength = int64(len(modified))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(modified)))
+	log.Debugf(ctx, "CounterSignature injected into proxied ACK response")
 	return nil
 }
 

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -342,7 +342,9 @@ func newCounterSignStep(signer definition.Signer, km definition.KeyManager) (def
 // stores the resulting auth-header string in ctx.CounterSign for injection
 // into the ACK response. For protocol versions other than "2.0.0" this is a no-op.
 func (s *counterSignStep) Run(ctx *model.StepContext) error {
+	log.Debugf(ctx, "counterSign: Run called with protocol version %q", ctx.ProtocolVersion)
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		log.Debugf(ctx, "counterSign: skipping — not LTS protocol version")
 		return nil // no-op for legacy protocol versions
 	}
 	if len(ctx.SubID) == 0 {
@@ -385,6 +387,7 @@ func (s *counterSignStep) Run(ctx *model.StepContext) error {
 // response body. It is a no-op when CounterSign is empty (i.e. non-LTS requests
 // or paths where the ACK was already sent directly without proxying).
 func (s *counterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	log.Debugf(ctx, "counterSign: RunOnResponse called, CounterSign present=%v", ctx.CounterSign != "")
 	if ctx.CounterSign == "" {
 		return nil
 	}
@@ -465,7 +468,9 @@ func (s *validateCounterSignStep) Run(_ *model.StepContext) error {
 // RunOnResponse reads the upstream ACK, extracts counter_sign, and validates it.
 // ctx.Body is the original outbound request body that the receiver signed.
 func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	log.Debugf(ctx, "validateCounterSign: RunOnResponse called with protocol version %q", ctx.ProtocolVersion)
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		log.Debugf(ctx, "validateCounterSign: skipping — not LTS protocol version")
 		return nil
 	}
 
@@ -487,6 +492,7 @@ func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *ht
 	}
 
 	counterSign := envelope.Message.Ack.CounterSign
+	log.Debugf(ctx, "validateCounterSign: ACK parsed, counter_sign present=%v", counterSign != "")
 	if counterSign == "" {
 		return model.NewSignValidationErr(fmt.Errorf("counter_sign missing in ACK response"))
 	}

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -1,9 +1,12 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -389,4 +392,80 @@ func newCheckPolicyStep(policyChecker definition.PolicyChecker) (definition.Step
 
 func (s *checkPolicyStep) Run(ctx *model.StepContext) error {
 	return s.checker.CheckPolicy(ctx)
+}
+
+// validateCounterSignStep validates the counter_sign field in the upstream ACK
+// response on Caller-side handlers. It implements both Step (no-op Run, since
+// there is nothing to do on the inbound request) and ResponseStep (RunOnResponse,
+// which reads the ACK body and verifies the counter-signature).
+// For protocol versions other than "2.0.0" this step is a no-op.
+type validateCounterSignStep struct {
+	validator definition.SignValidator
+	km        definition.KeyManager
+}
+
+// newValidateCounterSignStep initialises and returns a new validateCounterSign step.
+func newValidateCounterSignStep(signValidator definition.SignValidator, km definition.KeyManager) (definition.Step, error) {
+	if signValidator == nil {
+		return nil, fmt.Errorf("invalid config: SignValidator plugin not configured")
+	}
+	if km == nil {
+		return nil, fmt.Errorf("invalid config: KeyManager plugin not configured")
+	}
+	return &validateCounterSignStep{validator: signValidator, km: km}, nil
+}
+
+// Run is a no-op — all work is deferred to RunOnResponse.
+func (s *validateCounterSignStep) Run(_ *model.StepContext) error {
+	return nil
+}
+
+// RunOnResponse reads the upstream ACK, extracts counter_sign, and validates it.
+// ctx.Body is the original outbound request body that the receiver signed.
+func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("counter-sign validate: failed to read response body: %w", err)
+	}
+	// Always restore the body so downstream handlers can read it.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	var envelope struct {
+		Message struct {
+			Ack model.Ack `json:"ack"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("counter-sign validate: response is not a valid ACK: %w", err)
+	}
+
+	counterSign := envelope.Message.Ack.CounterSign
+	if counterSign == "" {
+		return model.NewSignValidationErr(fmt.Errorf("counter_sign missing in ACK response"))
+	}
+
+	return s.validateCounterSign(ctx, counterSign)
+}
+
+// validateCounterSign parses the counter_sign header value, looks up the
+// receiver's public key, and verifies the signature against ctx.Body.
+func (s *validateCounterSignStep) validateCounterSign(ctx *model.StepContext, counterSign string) error {
+	headerVals, err := parseHeader(counterSign)
+	if err != nil {
+		return model.NewSignValidationErr(fmt.Errorf("counter-sign validate: failed to parse counter_sign: %w", err))
+	}
+	publicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
+	if err != nil {
+		return fmt.Errorf("counter-sign validate: failed to look up public key for %s: %w", headerVals.SubscriberID, err)
+	}
+	if err := s.validator.Validate(ctx, ctx.Body, counterSign, publicKey); err != nil {
+		return model.NewSignValidationErr(fmt.Errorf("counter-sign validation failed: %w", err))
+	}
+	log.Debugf(ctx, "CounterSignature validated for subscriber: %s", headerVals.SubscriberID)
+	return nil
 }

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -61,13 +61,15 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 
 	// run step with context that contains the step span
 	stepCtx := &model.StepContext{
-		Context:    spanCtx,
-		Request:    ctx.Request,
-		Body:       ctx.Body,
-		Role:       ctx.Role,
-		SubID:      ctx.SubID,
-		RespHeader: ctx.RespHeader,
-		Route:      ctx.Route,
+		Context:         spanCtx,
+		Request:         ctx.Request,
+		Body:            ctx.Body,
+		Role:            ctx.Role,
+		SubID:           ctx.SubID,
+		RespHeader:      ctx.RespHeader,
+		Route:           ctx.Route,
+		ProtocolVersion: ctx.ProtocolVersion,
+		CounterSign:     ctx.CounterSign,
 	}
 
 	start := time.Now()
@@ -100,6 +102,8 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 	if stepCtx.Route != nil {
 		ctx.Route = stepCtx.Route
 	}
+	// Propagate fields that steps may write during Run.
+	ctx.CounterSign = stepCtx.CounterSign
 	ctx.WithContext(stepCtx.Context)
 	return err
 }

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -59,21 +59,14 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 	spanCtx, span := tracer.Start(ctx.Context, stepName)
 	defer span.End()
 
-	// run step with context that contains the step span
-	stepCtx := &model.StepContext{
-		Context:         spanCtx,
-		Request:         ctx.Request,
-		Body:            ctx.Body,
-		Role:            ctx.Role,
-		SubID:           ctx.SubID,
-		RespHeader:      ctx.RespHeader,
-		Route:           ctx.Route,
-		ProtocolVersion: ctx.ProtocolVersion,
-		CounterSign:     ctx.CounterSign,
-	}
+	// Shallow-copy the entire StepContext so new fields are carried in
+	// automatically, then replace only the embedded context with the span context.
+	// This prevents silent breakage when new fields are added to StepContext.
+	stepCtx := *ctx
+	stepCtx.Context = spanCtx
 
 	start := time.Now()
-	err := is.step.Run(stepCtx)
+	err := is.step.Run(&stepCtx)
 	duration := time.Since(start).Seconds()
 
 	attrs := []attribute.KeyValue{
@@ -99,10 +92,11 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 		log.Errorf(stepCtx.Context, err, "Step %s failed", is.stepName)
 	}
 
+	// Write back fields that steps are permitted to mutate during Run.
+	// ProtocolVersion is read-only — steps must not change it.
 	if stepCtx.Route != nil {
 		ctx.Route = stepCtx.Route
 	}
-	// Propagate fields that steps may write during Run.
 	ctx.CounterSign = stepCtx.CounterSign
 	ctx.WithContext(stepCtx.Context)
 	return err

--- a/pkg/plugin/definition/step.go
+++ b/pkg/plugin/definition/step.go
@@ -2,12 +2,22 @@ package definition
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
+// Step processes the inbound request before routing.
 type Step interface {
 	Run(ctx *model.StepContext) error
+}
+
+// ResponseStep processes the upstream response before it is forwarded to the caller.
+// A step may implement Step, ResponseStep, or both depending on which phase it needs.
+// Steps implementing ResponseStep are automatically registered for response-phase
+// invocation by the handler — no separate configuration is required.
+type ResponseStep interface {
+	RunOnResponse(ctx *model.StepContext, resp *http.Response) error
 }
 
 type StepProvider interface {


### PR DESCRIPTION
## What this PR does

Closes #682.

Implements the Caller-side half of bilateral non-repudiation for Beckn Protocol v2.0.0 LTS. The Receiver side (generating `counter_sign` in the ACK) was implemented in #651. This PR validates that signature on the Caller side before the ACK is returned to the calling application.

See the design discussion on #682 and #651 for full reasoning on why this belongs in ONIX rather than the application layer, the choice of the `ResponseStep` interface over a closure approach, and how the `ModifyResponse` hook is used to intercept proxied ACK responses.

---

## Dependency chain

This PR sits at the top of a stacked set of changes. Each must be reviewed and merged in order:

| Branch | Issue | What it adds |
|---|---|---|
| `feat/proto-v2-foundation` | — | `ProtocolVersion` field in `StepContext`; `ProtocolVersionLTS = "2.0.0"` constant; version-gating pattern used by all LTS steps |
| `feat/proto-v2-counter-signature` | #651 | `counterSign` step on Receiver handlers — signs the inbound request body and injects `counter_sign` into the ACK response |
| `feat/proto-v2-counter-sign-validation` ← **this PR** | #682 | `validateCounterSign` step on Caller handlers — validates `counter_sign` in the ACK received from the Receiver |

---

## Changes in this PR

### 1. `ResponseStep` interface (`pkg/plugin/definition/step.go`)

A new interface symmetric to `Step`:

```go
type ResponseStep interface {
    RunOnResponse(ctx *model.StepContext, resp *http.Response) error
}
```

A step may implement `Step`, `ResponseStep`, or both. Steps that implement `ResponseStep` are automatically registered for response-phase invocation by the handler — no extra config entry required. See the design rationale in the comment on #682.

### 2. `validateCounterSignStep` (`core/module/handler/step.go`)

New step implementing both interfaces:
- `Run()` — no-op (nothing to do on the outbound request)
- `RunOnResponse()` — reads `message.ack.counter_sign` from the upstream ACK, looks up the receiver's public key via `KeyManager`, validates the signature against the original request body via `SignValidator`. Returns `NewSignValidationErr` if `counter_sign` is absent or the signature is invalid. No-op for `context.version != "2.0.0"`.

### 3. `counterSignStep` promoted to `ResponseStep` (`core/module/handler/step.go`)

The ad-hoc `injectCounterSign()` function (added in #651) has been moved into `counterSignStep.RunOnResponse()`. The `ModifyResponse` closure in `proxy()` now iterates all `responseSteps` uniformly — no special-cased calls remain.

### 4. Handler wiring (`core/module/handler/stdHandler.go`)

- `stdHandler` gains `responseSteps []definition.ResponseStep`
- `initSteps` type-asserts each step against `ResponseStep` after construction and collects implementors into `h.responseSteps`. This happens before `InstrumentedStep` wrapping — the original step is registered for response phase.
- `proxy()` iterates `responseSteps` in `ModifyResponse`. An `ErrorHandler` is added so validation failures return a proper NACK instead of a bare 502.

### 5. Bug fix: `InstrumentedStep` field propagation (`core/module/handler/step_instrumentor.go`)

Discovered during end-to-end testing. `InstrumentedStep` was constructing a fresh `StepContext` for the wrapped step but omitting `ProtocolVersion` (added in the foundation PR) and `CounterSign` (added in #651). This silently caused every LTS-gated step to see `ProtocolVersion: ""` and discarded any `CounterSign` value written by `counterSignStep` — whenever OTel was active.

Fixed by replacing the explicit field-by-field struct literal with a shallow copy:

```go
stepCtx := *ctx          // all fields carried in automatically
stepCtx.Context = spanCtx // only override with OTel span context
```

Write-back remains explicit for mutable fields (`Route`, `CounterSign`). This also prevents the same class of bug from occurring when new fields are added to `StepContext` in future.

### 6. Config updates

`validateCounterSign` added to all Caller handler `steps:` arrays:
- `config/local-beckn-one-bap.yaml` — `bapTxnCaller`
- `config/onix/adapter.yaml` — `bapTxnCaller`, `bppTxnCaller`
- `config/onix-bpp/adapter.yaml` — `bppTxnCaller`

### 7. Documentation (`CONFIG.md`)

The `steps:` section now explains dual-phase step execution — that a single config entry can participate in both request and response phases — with `counterSign` and `validateCounterSign` as concrete examples.

---

## How to test end-to-end

### Prerequisites

Before testing, ensure the following config changes are in place in your environment (these are **not** in this PR — they depend on your deployment config):

| Handler | Needs adding |
|---|---|
| BAP Receiver (`/bap/receiver/`) | `signer` plugin + `counterSign` step |
| BAP Caller (`/bap/caller/`) | `signValidator` plugin (step already added by this PR) |
| BPP Receiver (`/bpp/receiver/`) | `signer` plugin + `counterSign` step |
| BPP Caller (`/bpp/caller/`) | `signValidator` plugin (step already added by this PR) |

### Test 1 — Forward call (select): BAP Caller → BPP Receiver

```bash
curl -X POST http://localhost:8081/bap/caller/ \
  -H "Content-Type: application/json" \
  -d '{
    "context": { "domain": "retail", "version": "2.0.0",
                 "transaction_id": "txn-001", "message_id": "msg-001", "action": "select" },
    "message": { "order": {} }
  }'
```

**Expected**: ACK with `message.ack.counter_sign` populated.  
**BPP Receiver logs**: `counterSign: Run called with protocol version "2.0.0"` → `CounterSignature generated` → `CounterSignature injected into proxied ACK response`  
**BAP Caller logs**: `validateCounterSign: RunOnResponse called` → `CounterSignature validated for subscriber: ...`

### Test 2 — Callback (on_select): BPP Caller → BAP Receiver

Same flow in the reverse direction. BAP Receiver generates `counter_sign`; BPP Caller validates it.

### Test 3 — Legacy version (backward compat)

Same requests with `"version": "1.1.0"`. `counter_sign` must NOT appear in the ACK, and no validation error should occur on the Caller side.

### Test 4 — Tampered / missing counter_sign

Send a v2.0.0 request and intercept the ACK to remove or corrupt `counter_sign`. The Caller should return a NACK with a sign-validation error.

### Key log lines to observe

| Log message | Source | Means |
|---|---|---|
| `counterSign: Run called with protocol version "2.0.0"` | Receiver | Step is running, version correctly detected |
| `CounterSignature generated for subscriber: ...` | Receiver | Signing succeeded |
| `counterSign: RunOnResponse called, CounterSign present=true` | Receiver | About to inject into proxied ACK |
| `CounterSignature injected into proxied ACK response` | Receiver | ACK modified successfully |
| `validateCounterSign: RunOnResponse called with protocol version "2.0.0"` | Caller | Validation step running |
| `validateCounterSign: ACK parsed, counter_sign present=true` | Caller | Found counter_sign in ACK |
| `CounterSignature validated for subscriber: ...` | Caller | Validation passed |

---

## Test coverage

Unit tests added in `core/module/handler/stdHandler_test.go`:
- `TestValidateCounterSignStepRunOnResponse` — 7 cases: non-LTS no-op, valid signature, missing `counter_sign`, malformed header, key lookup failure, signature mismatch, non-JSON response body
- `TestCounterSignStepRunOnResponse` — injection into ACK (updated from the refactored ad-hoc function)