### PR TITLE
feat(proto-v2): Beckn Protocol v2.0.0 LTS transport — counter-signature, LTS error shape, ProtocolVersion gating

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -516,6 +516,8 @@ modules:
 - `validateSchema` - Validate against JSON schema
 - `sign` - Sign outgoing request
 - `publish` - Publish to message queue
+- `counterSign` - Generate a counter-signature and embed it in the ACK response (`counter_sign` field inside `ack`). Required for Beckn v2.0.0 LTS receiver handlers. No-op for requests with `context.version != "2.0.0"`. Must be placed after all steps that can NACK (e.g. `validateSign`, `validateSchema`) so that counter-signatures are only computed for requests that will be acknowledged. Requires `signer` and `keyManager` plugins to be configured.
+- `checkPolicy` - Evaluate request against configured policy rules
 
 **Example**:
 ```yaml

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -509,15 +509,23 @@ modules:
 ##### `steps`
 **Type**: `array` of `string`  
 **Required**: Yes  
-**Description**: Ordered list of processing steps to execute for each request.  
-**Common Steps**:
-- `validateSign` - Validate digital signature
-- `addRoute` - Determine routing destination
-- `validateSchema` - Validate against JSON schema
-- `sign` - Sign outgoing request
-- `publish` - Publish to message queue
-- `counterSign` - Generate a counter-signature and embed it in the ACK response (`counter_sign` field inside `ack`). Required for Beckn v2.0.0 LTS receiver handlers. No-op for requests with `context.version != "2.0.0"`. Must be placed after all steps that can NACK (e.g. `validateSign`, `validateSchema`) so that counter-signatures are only computed for requests that will be acknowledged. Requires `signer` and `keyManager` plugins to be configured.
-- `checkPolicy` - Evaluate request against configured policy rules
+**Description**: Ordered list of processing steps to execute for each request.
+
+Each entry names a step that participates in the handler pipeline. A step can participate in one or both of two phases:
+
+- **Request phase** — runs on the inbound request before it is forwarded or published. All steps run this phase in the order listed.
+- **Response phase** — runs on the upstream response (proxied ACK) before it is returned to the caller. Only steps that opt into this phase run it; they do so automatically based on their implementation, with no extra configuration required. The order follows their position in the `steps` list.
+
+This means a single entry in `steps` can do work on both the request and the response. `counterSign`, for example, signs the request body during the request phase and injects the resulting `counter_sign` into the ACK during the response phase — both triggered by the single `counterSign` entry.
+
+**Available Steps**:
+- `validateSign` — Validate the digital signature on the inbound request. Request phase only.
+- `addRoute` — Determine the routing destination for the request. Request phase only.
+- `validateSchema` — Validate the request body against the configured JSON schema. Request phase only.
+- `sign` — Sign the outgoing request with the subscriber's private key. Request phase only. Requires `signer` and `keyManager` plugins.
+- `checkPolicy` — Evaluate the request against configured OPA policy rules. Request phase only. Requires `policyChecker` plugin.
+- `counterSign` — **(Beckn v2.0.0 LTS, Receiver handlers only)** Signs the inbound request body and embeds the result as `counter_sign` inside the ACK `ack` object. Participates in both phases: request phase computes the signature; response phase injects it into the proxied ACK when the downstream app responds. No-op for `context.version != "2.0.0"`. Must be placed after all steps that can NACK (e.g. `validateSign`, `validateSchema`) so counter-signatures are only computed for requests that pass validation. Requires `signer` and `keyManager` plugins.
+- `validateCounterSign` — **(Beckn v2.0.0 LTS, Caller handlers only)** Validates the `counter_sign` field in the ACK response received from the receiver. Participates in the response phase only (the request phase is a no-op). Reads `message.ack.counter_sign` from the upstream ACK, looks up the receiver's public key via the key manager, and verifies the signature against the original outbound request body. Returns a sign-validation error if `counter_sign` is absent or the signature is invalid. No-op for `context.version != "2.0.0"`. Requires `signValidator` and `keyManager` plugins.
 
 **Example**:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The **Beckn Protocol** is an open protocol that enables location-aware, local co
 - `addRoute`: Determines routing based on configuration
 - `validateSchema`: Validates against JSON schemas
 - `sign`: Signs outgoing requests
+- `counterSign`: Generates a counter-signature and embeds it in the ACK response for Beckn v2.0.0 LTS; no-op for earlier versions
 - `cache`: Caches requests/responses
 - `publish`: Publishes messages to queue
 

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -102,7 +102,8 @@ modules:
         - checkPolicy
         - addRoute
         - validateSchema
-  
+        - counterSign
+
   - name: bapTxnCaller
     path: /bap/caller/
     handler:

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -169,4 +169,5 @@ modules:
         - addRoute
         - sign
         - validateSchema
+        - validateCounterSign
   

--- a/config/onix-bpp/adapter.yaml
+++ b/config/onix-bpp/adapter.yaml
@@ -120,3 +120,4 @@ modules:
         - validateSchema
         - addRoute
         - sign
+        - validateCounterSign

--- a/config/onix-bpp/adapter.yaml
+++ b/config/onix-bpp/adapter.yaml
@@ -69,6 +69,7 @@ modules:
         - validateSign
         - addRoute
         - validateSchema
+        - counterSign
   - name: bppTxnCaller
     path: /bpp/caller/
     handler:

--- a/config/onix/adapter.yaml
+++ b/config/onix/adapter.yaml
@@ -74,6 +74,7 @@ modules:
         - checkPolicy
         - addRoute
         - validateSchema
+        - counterSign
   - name: bapTxnCaller
     path: /bap/caller/
     handler:
@@ -187,6 +188,7 @@ modules:
         - checkPolicy
         - addRoute
         - validateSchema
+        - counterSign
   - name: bppTxnCaller
     path: /bpp/caller/
     handler:

--- a/config/onix/adapter.yaml
+++ b/config/onix/adapter.yaml
@@ -131,6 +131,7 @@ modules:
         - checkPolicy
         - addRoute
         - sign
+        - validateCounterSign
   - name: bppTxnReciever
     path: /bpp/reciever/
     handler:
@@ -245,3 +246,4 @@ modules:
         - checkPolicy
         - addRoute
         - sign
+        - validateCounterSign

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -185,6 +185,13 @@ func (h *stdHandler) stepCtx(r *http.Request, rh http.Header) (*model.StepContex
 	body := bodyBuffer.Bytes()
 	subID := h.subID(r.Context())
 	protocolVersion := extractProtocolVersion(body)
+	// Log the first 512 bytes of the body so protocol-version extraction failures
+	// can be diagnosed without enabling full request logging.
+	if len(body) > 512 {
+		log.Debugf(r.Context(), "stepCtx: extracted protocol version %q from body (truncated): %.512s", protocolVersion, body)
+	} else {
+		log.Debugf(r.Context(), "stepCtx: extracted protocol version %q from body: %s", protocolVersion, body)
+	}
 	// Store the protocol version in the Go context so downstream functions that
 	// only receive a context.Context (e.g. response.SendNack) can read it.
 	ctx := context.WithValue(r.Context(), model.ContextKeyProtocolVersion, protocolVersion)

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -182,14 +182,18 @@ func (h *stdHandler) stepCtx(r *http.Request, rh http.Header) (*model.StepContex
 	r.Body.Close()
 	body := bodyBuffer.Bytes()
 	subID := h.subID(r.Context())
+	protocolVersion := extractProtocolVersion(body)
+	// Store the protocol version in the Go context so downstream functions that
+	// only receive a context.Context (e.g. response.SendNack) can read it.
+	ctx := context.WithValue(r.Context(), model.ContextKeyProtocolVersion, protocolVersion)
 	return &model.StepContext{
-		Context:         r.Context(),
+		Context:         ctx,
 		Request:         r,
 		Body:            body,
 		Role:            h.role,
 		SubID:           subID,
 		RespHeader:      rh,
-		ProtocolVersion: extractProtocolVersion(body),
+		ProtocolVersion: protocolVersion,
 	}, nil
 }
 

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -165,7 +166,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Restore request body before forwarding or publishing.
 	r.Body = io.NopCloser(bytes.NewReader(stepCtx.Body))
 	if stepCtx.Route == nil {
-		response.SendAck(wrapped)
+		response.SendAck(wrapped, stepCtx.CounterSign)
 		return
 	}
 
@@ -236,7 +237,7 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 		response.SendNack(ctx, w, err)
 		return
 	}
-	response.SendAck(w)
+	response.SendAck(w, ctx.CounterSign)
 }
 func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client) {
 	target := ctx.Route.URL
@@ -252,9 +253,52 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 	proxy := &httputil.ReverseProxy{
 		Director:  director,
 		Transport: httpClient.Transport,
+		ModifyResponse: func(resp *http.Response) error {
+			return injectCounterSign(ctx, resp)
+		},
 	}
 
 	proxy.ServeHTTP(w, r)
+}
+
+// injectCounterSign reads the downstream app's ACK response body, injects the
+// counter_sign field when a counter-signature has been computed (v2.0.0 LTS),
+// and rewrites the response body. It is a no-op when CounterSign is empty.
+func injectCounterSign(ctx *model.StepContext, resp *http.Response) error {
+	if ctx.CounterSign == "" {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to read response body: %w", err)
+	}
+
+	// Parse the ACK envelope and inject counter_sign.
+	var envelope struct {
+		Message struct {
+			Ack model.Ack `json:"ack"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		// Not a JSON ACK body — restore original and skip injection.
+		log.Warnf(ctx, "counter-sign inject: response is not a JSON ACK, skipping: %v", err)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return nil
+	}
+
+	envelope.Message.Ack.CounterSign = ctx.CounterSign
+	modified, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to marshal modified ACK: %w", err)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(modified))
+	resp.ContentLength = int64(len(modified))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(modified)))
+	log.Debugf(ctx, "CounterSignature injected into proxied ACK response")
+	return nil
 }
 
 // loadPlugin is a generic function to load and validate plugins.
@@ -362,6 +406,8 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newAddRouteStep(h.router)
 		case "checkPolicy":
 			s, err = newCheckPolicyStep(h.policyChecker)
+		case "counterSign":
+			s, err = newCounterSignStep(h.signer, h.km)
 		default:
 			if customStep, exists := steps[step]; exists {
 				s = customStep

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -256,9 +255,6 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		Director:  director,
 		Transport: httpClient.Transport,
 		ModifyResponse: func(resp *http.Response) error {
-			if err := injectCounterSign(ctx, resp); err != nil {
-				return err
-			}
 			for _, rs := range responseSteps {
 				if err := rs.RunOnResponse(ctx, resp); err != nil {
 					return err
@@ -273,46 +269,6 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 	}
 
 	proxy.ServeHTTP(w, r)
-}
-
-// injectCounterSign reads the downstream app's ACK response body, injects the
-// counter_sign field when a counter-signature has been computed (v2.0.0 LTS),
-// and rewrites the response body. It is a no-op when CounterSign is empty.
-func injectCounterSign(ctx *model.StepContext, resp *http.Response) error {
-	if ctx.CounterSign == "" {
-		return nil
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return fmt.Errorf("counter-sign inject: failed to read response body: %w", err)
-	}
-
-	// Parse the ACK envelope and inject counter_sign.
-	var envelope struct {
-		Message struct {
-			Ack model.Ack `json:"ack"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		// Not a JSON ACK body — restore original and skip injection.
-		log.Warnf(ctx, "counter-sign inject: response is not a JSON ACK, skipping: %v", err)
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		return nil
-	}
-
-	envelope.Message.Ack.CounterSign = ctx.CounterSign
-	modified, err := json.Marshal(envelope)
-	if err != nil {
-		return fmt.Errorf("counter-sign inject: failed to marshal modified ACK: %w", err)
-	}
-
-	resp.Body = io.NopCloser(bytes.NewReader(modified))
-	resp.ContentLength = int64(len(modified))
-	resp.Header.Set("Content-Length", strconv.Itoa(len(modified)))
-	log.Debugf(ctx, "CounterSignature injected into proxied ACK response")
-	return nil
 }
 
 // loadPlugin is a generic function to load and validate plugins.

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -180,14 +180,16 @@ func (h *stdHandler) stepCtx(r *http.Request, rh http.Header) (*model.StepContex
 		return nil, model.NewBadReqErr(err)
 	}
 	r.Body.Close()
+	body := bodyBuffer.Bytes()
 	subID := h.subID(r.Context())
 	return &model.StepContext{
-		Context:    r.Context(),
-		Request:    r,
-		Body:       bodyBuffer.Bytes(),
-		Role:       h.role,
-		SubID:      subID,
-		RespHeader: rh,
+		Context:         r.Context(),
+		Request:         r,
+		Body:            body,
+		Role:            h.role,
+		SubID:           subID,
+		RespHeader:      rh,
+		ProtocolVersion: extractProtocolVersion(body),
 	}, nil
 }
 

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -31,6 +31,7 @@ import (
 type stdHandler struct {
 	signer           definition.Signer
 	steps            []definition.Step
+	responseSteps    []definition.ResponseStep
 	signValidator    definition.SignValidator
 	cache            definition.Cache
 	registry         definition.RegistryLookup
@@ -77,10 +78,11 @@ func newHTTPClient(cfg *HttpClientConfig, wrapper definition.TransportWrapper) *
 // NewStdHandler initializes a new processor with plugins and steps.
 func NewStdHandler(ctx context.Context, mgr PluginManager, cfg *Config, moduleName string) (http.Handler, error) {
 	h := &stdHandler{
-		steps:        []definition.Step{},
-		SubscriberID: cfg.SubscriberID,
-		role:         cfg.Role,
-		moduleName:   moduleName,
+		steps:         []definition.Step{},
+		responseSteps: []definition.ResponseStep{},
+		SubscriberID:  cfg.SubscriberID,
+		role:          cfg.Role,
+		moduleName:    moduleName,
 	}
 	// Initialize plugins.
 	if err := h.initPlugins(ctx, mgr, &cfg.Plugins); err != nil {
@@ -171,7 +173,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle routing based on the defined route type.
-	route(stepCtx, r, wrapped, h.publisher, h.httpClient)
+	route(stepCtx, r, wrapped, h.publisher, h.httpClient, h.responseSteps)
 }
 
 // stepCtx creates a new StepContext for processing an HTTP request.
@@ -210,12 +212,12 @@ func (h *stdHandler) subID(ctx context.Context) string {
 var proxyFunc = proxy
 
 // route handles request forwarding or message publishing based on the routing type.
-func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client) {
+func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client, responseSteps []definition.ResponseStep) {
 	log.Debugf(ctx, "Routing to ctx.Route to %#v", ctx.Route)
 	switch ctx.Route.TargetType {
 	case "url":
 		log.Infof(ctx.Context, "Forwarding request to URL: %s", ctx.Route.URL)
-		proxyFunc(ctx, r, w, httpClient)
+		proxyFunc(ctx, r, w, httpClient, responseSteps)
 		return
 	case "publisher":
 		if pb == nil {
@@ -239,7 +241,7 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 	}
 	response.SendAck(w, ctx.CounterSign)
 }
-func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client) {
+func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep) {
 	target := ctx.Route.URL
 	r.Header.Set("X-Forwarded-Host", r.Host)
 
@@ -254,7 +256,19 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		Director:  director,
 		Transport: httpClient.Transport,
 		ModifyResponse: func(resp *http.Response) error {
-			return injectCounterSign(ctx, resp)
+			if err := injectCounterSign(ctx, resp); err != nil {
+				return err
+			}
+			for _, rs := range responseSteps {
+				if err := rs.RunOnResponse(ctx, resp); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			log.Errorf(ctx, err, "proxy: upstream or response-step error: %v", err)
+			response.SendNack(ctx, rw, err)
 		},
 	}
 
@@ -408,6 +422,8 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newCheckPolicyStep(h.policyChecker)
 		case "counterSign":
 			s, err = newCounterSignStep(h.signer, h.km)
+		case "validateCounterSign":
+			s, err = newValidateCounterSignStep(h.signValidator, h.km)
 		default:
 			if customStep, exists := steps[step]; exists {
 				s = customStep
@@ -418,6 +434,12 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 
 		if err != nil {
 			return err
+		}
+		// Collect response-phase steps before instrumentation wrapping.
+		// The InstrumentedStep wrapper only covers Run(); RunOnResponse() is
+		// called directly on the original step.
+		if rs, ok := s.(definition.ResponseStep); ok {
+			h.responseSteps = append(h.responseSteps, rs)
 		}
 		instrumentedStep, wrapErr := NewInstrumentedStep(s, step, h.moduleName)
 		if wrapErr != nil {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -306,6 +307,60 @@ func TestStepCtx_ProtocolVersion(t *testing.T) {
 			}
 			if sctx.ProtocolVersion != tt.wantVer {
 				t.Errorf("ProtocolVersion = %q, want %q", sctx.ProtocolVersion, tt.wantVer)
+			}
+		})
+	}
+}
+
+func TestInjectCounterSign(t *testing.T) {
+	const testSign = `Signature keyId="bpp.example.com|key-1|ed25519",signature="abc123"`
+
+	tests := []struct {
+		name        string
+		counterSign string
+		respBody    string
+		wantBody    string
+		wantErr     bool
+	}{
+		{
+			name:        "injects counter_sign into valid ACK",
+			counterSign: testSign,
+			respBody:    `{"message":{"ack":{"status":"ACK"}}}`,
+			wantBody:    `{"message":{"ack":{"status":"ACK","counter_sign":"Signature keyId=\"bpp.example.com|key-1|ed25519\",signature=\"abc123\""}}}`,
+		},
+		{
+			name:        "no-op when CounterSign is empty",
+			counterSign: "",
+			respBody:    `{"message":{"ack":{"status":"ACK"}}}`,
+			wantBody:    `{"message":{"ack":{"status":"ACK"}}}`,
+		},
+		{
+			name:        "non-JSON body skipped gracefully",
+			counterSign: testSign,
+			respBody:    `not-json`,
+			wantBody:    `not-json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &model.StepContext{
+				Context:     context.Background(),
+				CounterSign: tt.counterSign,
+			}
+			resp := &http.Response{
+				Header: http.Header{},
+				Body:   io.NopCloser(bytes.NewBufferString(tt.respBody)),
+			}
+
+			err := injectCounterSign(ctx, resp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("injectCounterSign() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			got, _ := io.ReadAll(resp.Body)
+			if string(got) != tt.wantBody {
+				t.Errorf("body = %s, want %s", got, tt.wantBody)
 			}
 		})
 	}

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
@@ -250,4 +253,60 @@ type mockRoundTripper struct{}
 
 func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return nil, nil
+}
+
+func TestStepCtx_ProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantVer  string
+	}{
+		{
+			name:    "LTS version 2.0.0",
+			body:    `{"context":{"version":"2.0.0"}}`,
+			wantVer: "2.0.0",
+		},
+		{
+			name:    "RC escape hatch 2.0.0-rc",
+			body:    `{"context":{"version":"2.0.0-rc"}}`,
+			wantVer: "2.0.0-rc",
+		},
+		{
+			name:    "legacy version 1.1.0",
+			body:    `{"context":{"version":"1.1.0"}}`,
+			wantVer: "1.1.0",
+		},
+		{
+			name:    "version field missing",
+			body:    `{"context":{}}`,
+			wantVer: "",
+		},
+		{
+			name:    "context field missing",
+			body:    `{}`,
+			wantVer: "",
+		},
+		{
+			name:    "invalid JSON",
+			body:    `not-json`,
+			wantVer: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stdHandler{
+				role:         model.RoleBAP,
+				SubscriberID: "test-subscriber",
+			}
+			req := httptest.NewRequest(http.MethodPost, "/search", bytes.NewBufferString(tt.body))
+			sctx, err := h.stepCtx(req, http.Header{})
+			if err != nil {
+				t.Fatalf("stepCtx() returned unexpected error: %v", err)
+			}
+			if sctx.ProtocolVersion != tt.wantVer {
+				t.Errorf("ProtocolVersion = %q, want %q", sctx.ProtocolVersion, tt.wantVer)
+			}
+		})
+	}
 }

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +16,33 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
+
+// mockSignValidator is a configurable SignValidator for testing.
+type mockSignValidator struct {
+	err error
+}
+
+func (m *mockSignValidator) Validate(_ context.Context, _ []byte, _, _ string) error {
+	return m.err
+}
+
+// mockKeyManager is a configurable KeyManager for testing.
+type mockKeyManager struct {
+	signingPublicKey string
+	err              error
+}
+
+func (m *mockKeyManager) GenerateKeyset() (*model.Keyset, error)             { return nil, nil }
+func (m *mockKeyManager) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error {
+	return nil
+}
+func (m *mockKeyManager) Keyset(_ context.Context, _ string) (*model.Keyset, error) {
+	return nil, nil
+}
+func (m *mockKeyManager) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) {
+	return m.signingPublicKey, "", m.err
+}
+func (m *mockKeyManager) DeleteKeyset(_ context.Context, _ string) error { return nil }
 
 // noopPluginManager satisfies PluginManager with nil plugins (unused loaders are never invoked when config is omitted).
 type noopPluginManager struct{}
@@ -362,6 +391,117 @@ func TestCounterSignStepRunOnResponse(t *testing.T) {
 			got, _ := io.ReadAll(resp.Body)
 			if string(got) != tt.wantBody {
 				t.Errorf("body = %s, want %s", got, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestValidateCounterSignStepRunOnResponse(t *testing.T) {
+	const validSign = `Signature keyId="bpp.example.com|key-1|ed25519",algorithm="ed25519",created="1700000000",expires="1700000300",headers="(created) (expires) digest",signature="abc123"`
+
+	ltsCtx := func() *model.StepContext {
+		return &model.StepContext{
+			Context:         context.Background(),
+			ProtocolVersion: model.ProtocolVersionLTS,
+			Body:            []byte(`{"context":{"version":"2.0.0"}}`),
+		}
+	}
+
+	ackWith := func(counterSign string) string {
+		if counterSign == "" {
+			return `{"message":{"ack":{"status":"ACK"}}}`
+		}
+		// Use json.Marshal to correctly escape quotes inside the signature string.
+		escaped, _ := json.Marshal(counterSign)
+		return `{"message":{"ack":{"status":"ACK","counter_sign":` + string(escaped) + `}}}`
+	}
+
+	tests := []struct {
+		name        string
+		ctx         *model.StepContext
+		respBody    string
+		validator   *mockSignValidator
+		km          *mockKeyManager
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "no-op for non-LTS protocol version",
+			ctx:      &model.StepContext{Context: context.Background(), ProtocolVersion: "1.1.0"},
+			respBody: `{"message":{"ack":{"status":"ACK"}}}`,
+			// validator and km are nil — would panic if called, proving they are not reached
+		},
+		{
+			name:      "valid counter_sign passes validation",
+			ctx:       ltsCtx(),
+			respBody:  ackWith(validSign),
+			validator: &mockSignValidator{err: nil},
+			km:        &mockKeyManager{signingPublicKey: "some-public-key"},
+		},
+		{
+			name:        "missing counter_sign returns sign validation error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(""),
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "counter_sign missing",
+		},
+		{
+			name:        "malformed counter_sign header returns parse error",
+			ctx:         ltsCtx(),
+			respBody:    `{"message":{"ack":{"status":"ACK","counter_sign":"BadHeader"}}}`,
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "failed to parse counter_sign",
+		},
+		{
+			name:        "key lookup failure returns error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(validSign),
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{err: fmt.Errorf("registry unavailable")},
+			wantErr:     true,
+			errContains: "failed to look up public key",
+		},
+		{
+			name:        "signature validation failure returns sign validation error",
+			ctx:         ltsCtx(),
+			respBody:    ackWith(validSign),
+			validator:   &mockSignValidator{err: fmt.Errorf("signature mismatch")},
+			km:          &mockKeyManager{signingPublicKey: "some-public-key"},
+			wantErr:     true,
+			errContains: "counter-sign validation failed",
+		},
+		{
+			name:        "non-JSON response body returns error",
+			ctx:         ltsCtx(),
+			respBody:    `not-json`,
+			validator:   &mockSignValidator{},
+			km:          &mockKeyManager{},
+			wantErr:     true,
+			errContains: "not a valid ACK",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &validateCounterSignStep{
+				validator: tt.validator,
+				km:        tt.km,
+			}
+			resp := &http.Response{
+				Header: http.Header{},
+				Body:   io.NopCloser(bytes.NewBufferString(tt.respBody)),
+			}
+
+			err := step.RunOnResponse(tt.ctx, resp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("RunOnResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.errContains)
 			}
 		})
 	}

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -312,7 +312,7 @@ func TestStepCtx_ProtocolVersion(t *testing.T) {
 	}
 }
 
-func TestInjectCounterSign(t *testing.T) {
+func TestCounterSignStepRunOnResponse(t *testing.T) {
 	const testSign = `Signature keyId="bpp.example.com|key-1|ed25519",signature="abc123"`
 
 	tests := []struct {
@@ -353,9 +353,10 @@ func TestInjectCounterSign(t *testing.T) {
 				Body:   io.NopCloser(bytes.NewBufferString(tt.respBody)),
 			}
 
-			err := injectCounterSign(ctx, resp)
+			step := &counterSignStep{}
+			err := step.RunOnResponse(ctx, resp)
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("injectCounterSign() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("counterSignStep.RunOnResponse() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			got, _ := io.ReadAll(resp.Body)

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -314,6 +314,67 @@ func extractProtocolVersion(body []byte) string {
 	return ""
 }
 
+// counterSignStep generates a counter-signature for Beckn v2.0.0 LTS ACK responses.
+// It signs the inbound request body with the receiver's key and stores the result
+// in StepContext.CounterSign, which is later injected into the ACK response body.
+// For protocol versions other than "2.0.0" this step is a no-op.
+type counterSignStep struct {
+	signer definition.Signer
+	km     definition.KeyManager
+}
+
+// newCounterSignStep initialises and returns a new counter-sign step.
+func newCounterSignStep(signer definition.Signer, km definition.KeyManager) (definition.Step, error) {
+	if signer == nil {
+		return nil, fmt.Errorf("invalid config: Signer plugin not configured")
+	}
+	if km == nil {
+		return nil, fmt.Errorf("invalid config: KeyManager plugin not configured")
+	}
+	return &counterSignStep{signer: signer, km: km}, nil
+}
+
+// Run executes the counter-sign step.
+func (s *counterSignStep) Run(ctx *model.StepContext) error {
+	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		return nil // no-op for legacy protocol versions
+	}
+	if len(ctx.SubID) == 0 {
+		return model.NewBadReqErr(fmt.Errorf("subscriberID not set"))
+	}
+
+	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
+
+	var keySet *model.Keyset
+	{
+		keySetCtx, keySetSpan := tracer.Start(ctx.Context, "counter-sign-keyset")
+		ks, err := s.km.Keyset(keySetCtx, ctx.SubID)
+		keySetSpan.End()
+		if err != nil {
+			return fmt.Errorf("counter-sign: failed to get signing key: %w", err)
+		}
+		keySet = ks
+	}
+
+	{
+		signerCtx, signerSpan := tracer.Start(ctx.Context, "counter-sign")
+		createdAt := time.Now().Unix()
+		validTill := time.Now().Add(5 * time.Minute).Unix()
+		sign, err := s.signer.Sign(signerCtx, ctx.Body, keySet.SigningPrivate, createdAt, validTill)
+		signerSpan.End()
+		if err != nil {
+			return fmt.Errorf("counter-sign: failed to sign request body: %w", err)
+		}
+		ctx.CounterSign = fmt.Sprintf(
+			"Signature keyId=\"%s|%s|ed25519\",algorithm=\"ed25519\",created=\"%d\",expires=\"%d\",headers=\"(created) (expires) digest\",signature=\"%s\"",
+			ctx.SubID, keySet.UniqueKeyID, createdAt, validTill, sign,
+		)
+		log.Debugf(ctx, "CounterSignature generated for subscriber: %s", ctx.SubID)
+	}
+
+	return nil
+}
+
 // checkPolicyStep adapts PolicyChecker into the Step interface.
 type checkPolicyStep struct {
 	checker definition.PolicyChecker

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -255,7 +255,7 @@ func (s *validateSchemaStep) recordMetrics(ctx *model.StepContext, err error) {
 	if err != nil {
 		status = "failed"
 	}
-	version := extractSchemaVersion(ctx.Body)
+	version := extractProtocolVersion(ctx.Body)
 	s.metrics.SchemaValidationsTotal.Add(ctx.Context, 1,
 		metric.WithAttributes(
 			telemetry.AttrSchemaVersion.String(version),
@@ -301,7 +301,7 @@ func (s *addRouteStep) Run(ctx *model.StepContext) error {
 	return nil
 }
 
-func extractSchemaVersion(body []byte) string {
+func extractProtocolVersion(body []byte) string {
 	type contextEnvelope struct {
 		Context struct {
 			Version string `json:"version"`
@@ -309,11 +309,9 @@ func extractSchemaVersion(body []byte) string {
 	}
 	var payload contextEnvelope
 	if err := json.Unmarshal(body, &payload); err == nil {
-		if payload.Context.Version != "" {
-			return payload.Context.Version
-		}
+		return payload.Context.Version
 	}
-	return "unknown"
+	return ""
 }
 
 // checkPolicyStep adapts PolicyChecker into the Step interface.

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,7 +338,9 @@ func newCounterSignStep(signer definition.Signer, km definition.KeyManager) (def
 	return &counterSignStep{signer: signer, km: km}, nil
 }
 
-// Run executes the counter-sign step.
+// Run executes the counter-sign step. It signs the inbound request body and
+// stores the resulting auth-header string in ctx.CounterSign for injection
+// into the ACK response. For protocol versions other than "2.0.0" this is a no-op.
 func (s *counterSignStep) Run(ctx *model.StepContext) error {
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
 		return nil // no-op for legacy protocol versions
@@ -375,6 +378,45 @@ func (s *counterSignStep) Run(ctx *model.StepContext) error {
 		log.Debugf(ctx, "CounterSignature generated for subscriber: %s", ctx.SubID)
 	}
 
+	return nil
+}
+
+// RunOnResponse injects the counter_sign computed in Run into the upstream ACK
+// response body. It is a no-op when CounterSign is empty (i.e. non-LTS requests
+// or paths where the ACK was already sent directly without proxying).
+func (s *counterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	if ctx.CounterSign == "" {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to read response body: %w", err)
+	}
+
+	var envelope struct {
+		Message struct {
+			Ack model.Ack `json:"ack"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		// Not a JSON ACK body — restore original and skip injection.
+		log.Warnf(ctx, "counter-sign inject: response is not a JSON ACK, skipping: %v", err)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return nil
+	}
+
+	envelope.Message.Ack.CounterSign = ctx.CounterSign
+	modified, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("counter-sign inject: failed to marshal modified ACK: %w", err)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(modified))
+	resp.ContentLength = int64(len(modified))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(modified)))
+	log.Debugf(ctx, "CounterSignature injected into proxied ACK response")
 	return nil
 }
 

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -342,7 +342,9 @@ func newCounterSignStep(signer definition.Signer, km definition.KeyManager) (def
 // stores the resulting auth-header string in ctx.CounterSign for injection
 // into the ACK response. For protocol versions other than "2.0.0" this is a no-op.
 func (s *counterSignStep) Run(ctx *model.StepContext) error {
+	log.Debugf(ctx, "counterSign: Run called with protocol version %q", ctx.ProtocolVersion)
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		log.Debugf(ctx, "counterSign: skipping — not LTS protocol version")
 		return nil // no-op for legacy protocol versions
 	}
 	if len(ctx.SubID) == 0 {
@@ -385,6 +387,7 @@ func (s *counterSignStep) Run(ctx *model.StepContext) error {
 // response body. It is a no-op when CounterSign is empty (i.e. non-LTS requests
 // or paths where the ACK was already sent directly without proxying).
 func (s *counterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	log.Debugf(ctx, "counterSign: RunOnResponse called, CounterSign present=%v", ctx.CounterSign != "")
 	if ctx.CounterSign == "" {
 		return nil
 	}
@@ -465,7 +468,9 @@ func (s *validateCounterSignStep) Run(_ *model.StepContext) error {
 // RunOnResponse reads the upstream ACK, extracts counter_sign, and validates it.
 // ctx.Body is the original outbound request body that the receiver signed.
 func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	log.Debugf(ctx, "validateCounterSign: RunOnResponse called with protocol version %q", ctx.ProtocolVersion)
 	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		log.Debugf(ctx, "validateCounterSign: skipping — not LTS protocol version")
 		return nil
 	}
 
@@ -487,6 +492,7 @@ func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *ht
 	}
 
 	counterSign := envelope.Message.Ack.CounterSign
+	log.Debugf(ctx, "validateCounterSign: ACK parsed, counter_sign present=%v", counterSign != "")
 	if counterSign == "" {
 		return model.NewSignValidationErr(fmt.Errorf("counter_sign missing in ACK response"))
 	}

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -1,9 +1,12 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -389,4 +392,80 @@ func newCheckPolicyStep(policyChecker definition.PolicyChecker) (definition.Step
 
 func (s *checkPolicyStep) Run(ctx *model.StepContext) error {
 	return s.checker.CheckPolicy(ctx)
+}
+
+// validateCounterSignStep validates the counter_sign field in the upstream ACK
+// response on Caller-side handlers. It implements both Step (no-op Run, since
+// there is nothing to do on the inbound request) and ResponseStep (RunOnResponse,
+// which reads the ACK body and verifies the counter-signature).
+// For protocol versions other than "2.0.0" this step is a no-op.
+type validateCounterSignStep struct {
+	validator definition.SignValidator
+	km        definition.KeyManager
+}
+
+// newValidateCounterSignStep initialises and returns a new validateCounterSign step.
+func newValidateCounterSignStep(signValidator definition.SignValidator, km definition.KeyManager) (definition.Step, error) {
+	if signValidator == nil {
+		return nil, fmt.Errorf("invalid config: SignValidator plugin not configured")
+	}
+	if km == nil {
+		return nil, fmt.Errorf("invalid config: KeyManager plugin not configured")
+	}
+	return &validateCounterSignStep{validator: signValidator, km: km}, nil
+}
+
+// Run is a no-op — all work is deferred to RunOnResponse.
+func (s *validateCounterSignStep) Run(_ *model.StepContext) error {
+	return nil
+}
+
+// RunOnResponse reads the upstream ACK, extracts counter_sign, and validates it.
+// ctx.Body is the original outbound request body that the receiver signed.
+func (s *validateCounterSignStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+	if ctx.ProtocolVersion != model.ProtocolVersionLTS {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("counter-sign validate: failed to read response body: %w", err)
+	}
+	// Always restore the body so downstream handlers can read it.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	var envelope struct {
+		Message struct {
+			Ack model.Ack `json:"ack"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("counter-sign validate: response is not a valid ACK: %w", err)
+	}
+
+	counterSign := envelope.Message.Ack.CounterSign
+	if counterSign == "" {
+		return model.NewSignValidationErr(fmt.Errorf("counter_sign missing in ACK response"))
+	}
+
+	return s.validateCounterSign(ctx, counterSign)
+}
+
+// validateCounterSign parses the counter_sign header value, looks up the
+// receiver's public key, and verifies the signature against ctx.Body.
+func (s *validateCounterSignStep) validateCounterSign(ctx *model.StepContext, counterSign string) error {
+	headerVals, err := parseHeader(counterSign)
+	if err != nil {
+		return model.NewSignValidationErr(fmt.Errorf("counter-sign validate: failed to parse counter_sign: %w", err))
+	}
+	publicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
+	if err != nil {
+		return fmt.Errorf("counter-sign validate: failed to look up public key for %s: %w", headerVals.SubscriberID, err)
+	}
+	if err := s.validator.Validate(ctx, ctx.Body, counterSign, publicKey); err != nil {
+		return model.NewSignValidationErr(fmt.Errorf("counter-sign validation failed: %w", err))
+	}
+	log.Debugf(ctx, "CounterSignature validated for subscriber: %s", headerVals.SubscriberID)
+	return nil
 }

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -61,13 +61,15 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 
 	// run step with context that contains the step span
 	stepCtx := &model.StepContext{
-		Context:    spanCtx,
-		Request:    ctx.Request,
-		Body:       ctx.Body,
-		Role:       ctx.Role,
-		SubID:      ctx.SubID,
-		RespHeader: ctx.RespHeader,
-		Route:      ctx.Route,
+		Context:         spanCtx,
+		Request:         ctx.Request,
+		Body:            ctx.Body,
+		Role:            ctx.Role,
+		SubID:           ctx.SubID,
+		RespHeader:      ctx.RespHeader,
+		Route:           ctx.Route,
+		ProtocolVersion: ctx.ProtocolVersion,
+		CounterSign:     ctx.CounterSign,
 	}
 
 	start := time.Now()
@@ -100,6 +102,8 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 	if stepCtx.Route != nil {
 		ctx.Route = stepCtx.Route
 	}
+	// Propagate fields that steps may write during Run.
+	ctx.CounterSign = stepCtx.CounterSign
 	ctx.WithContext(stepCtx.Context)
 	return err
 }

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -59,21 +59,14 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 	spanCtx, span := tracer.Start(ctx.Context, stepName)
 	defer span.End()
 
-	// run step with context that contains the step span
-	stepCtx := &model.StepContext{
-		Context:         spanCtx,
-		Request:         ctx.Request,
-		Body:            ctx.Body,
-		Role:            ctx.Role,
-		SubID:           ctx.SubID,
-		RespHeader:      ctx.RespHeader,
-		Route:           ctx.Route,
-		ProtocolVersion: ctx.ProtocolVersion,
-		CounterSign:     ctx.CounterSign,
-	}
+	// Shallow-copy the entire StepContext so new fields are carried in
+	// automatically, then replace only the embedded context with the span context.
+	// This prevents silent breakage when new fields are added to StepContext.
+	stepCtx := *ctx
+	stepCtx.Context = spanCtx
 
 	start := time.Now()
-	err := is.step.Run(stepCtx)
+	err := is.step.Run(&stepCtx)
 	duration := time.Since(start).Seconds()
 
 	attrs := []attribute.KeyValue{
@@ -99,10 +92,11 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 		log.Errorf(stepCtx.Context, err, "Step %s failed", is.stepName)
 	}
 
+	// Write back fields that steps are permitted to mutate during Run.
+	// ProtocolVersion is read-only — steps must not change it.
 	if stepCtx.Route != nil {
 		ctx.Route = stepCtx.Route
 	}
-	// Propagate fields that steps may write during Run.
 	ctx.CounterSign = stepCtx.CounterSign
 	ctx.WithContext(stepCtx.Context)
 	return err

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -18,6 +18,16 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("Error: Code=%s, Path=%s, Message=%s", e.Code, e.Paths, e.Message)
 }
 
+// ToV2Error converts the legacy Error to its Beckn v2.0.0 LTS representation,
+// mapping code→errorCode, message→errorMessage, and paths→errorPaths.
+func (e *Error) ToV2Error() *V2Error {
+	return &V2Error{
+		ErrorCode:    e.Code,
+		ErrorPaths:   e.Paths,
+		ErrorMessage: e.Message,
+	}
+}
+
 // SchemaValidationErr occurs when schema validation errors are encountered.
 type SchemaValidationErr struct {
 	Errors []Error

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -25,6 +25,40 @@ func NewBadReqErrf(format string, a ...any) *BadReqErr {
 	return &BadReqErr{fmt.Errorf(format, a...)}
 }
 
+func TestError_ToV2Error(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *Error
+		want  *V2Error
+	}{
+		{
+			name:  "full error with paths",
+			input: &Error{Code: "Bad Request", Paths: "/a;/b", Message: "field required"},
+			want:  &V2Error{ErrorCode: "Bad Request", ErrorPaths: "/a;/b", ErrorMessage: "field required"},
+		},
+		{
+			name:  "error without paths",
+			input: &Error{Code: "Unauthorized", Message: "Signature Validation Error: invalid"},
+			want:  &V2Error{ErrorCode: "Unauthorized", ErrorMessage: "Signature Validation Error: invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.ToV2Error()
+			if got.ErrorCode != tt.want.ErrorCode {
+				t.Errorf("ErrorCode = %q, want %q", got.ErrorCode, tt.want.ErrorCode)
+			}
+			if got.ErrorPaths != tt.want.ErrorPaths {
+				t.Errorf("ErrorPaths = %q, want %q", got.ErrorPaths, tt.want.ErrorPaths)
+			}
+			if got.ErrorMessage != tt.want.ErrorMessage {
+				t.Errorf("ErrorMessage = %q, want %q", got.ErrorMessage, tt.want.ErrorMessage)
+			}
+		})
+	}
+}
+
 func TestError_Error(t *testing.T) {
 	err := &Error{
 		Code:    "404",

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -159,12 +159,13 @@ type Keyset struct {
 // StepContext holds context information for a request processing step.
 type StepContext struct {
 	context.Context
-	Request    *http.Request
-	Body       []byte
-	Route      *Route
-	SubID      string
-	Role       Role
-	RespHeader http.Header
+	Request         *http.Request
+	Body            []byte
+	Route           *Route
+	SubID           string
+	Role            Role
+	RespHeader      http.Header
+	ProtocolVersion string // Protocol version parsed from context.version (e.g. "2.0.0")
 }
 
 // WithContext updates the existing StepContext with a new context.

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -59,7 +59,15 @@ const (
 
 	// ContextKeyRemoteID is the context key for the caller who is calling the bap/bpp
 	ContextKeyRemoteID ContextKey = "remote_id"
+
+	// ContextKeyProtocolVersion is the context key for the Beckn protocol version
+	// parsed from context.version in the request body (e.g. "2.0.0").
+	ContextKeyProtocolVersion ContextKey = "protocol_version"
 )
+
+// ProtocolVersionLTS is the Beckn protocol version string for the v2.0.0 LTS release.
+// Requests carrying this version use the new error envelope and field names.
+const ProtocolVersionLTS = "2.0.0"
 
 var contextKeys = map[string]ContextKey{
 	// snake_case keys (legacy beckn spec)
@@ -194,10 +202,22 @@ type Message struct {
 	// Ack contains the acknowledgment status.
 	Ack Ack `json:"ack"`
 	// Error holds error details, if any, in the response.
+	// Nil for Beckn v2.0.0 LTS responses (error moves to the top-level Response).
 	Error *Error `json:"error,omitempty"`
 }
 
 // Response represents the main response structure.
+// For Beckn v2.0.0 LTS, Error is populated at the top level and Message.Error
+// is left nil. For legacy versions, Message.Error is populated and Error is nil.
 type Response struct {
-	Message Message `json:"message"`
+	Message Message  `json:"message"`
+	Error   *V2Error `json:"error,omitempty"` // v2.0.0 LTS: top-level error
+}
+
+// V2Error is the error payload for Beckn v2.0.0 LTS responses.
+// Field names changed from code/message to errorCode/errorMessage.
+type V2Error struct {
+	ErrorCode    string `json:"errorCode"`
+	ErrorPaths   string `json:"errorPaths,omitempty"`
+	ErrorMessage string `json:"errorMessage"`
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -174,6 +174,7 @@ type StepContext struct {
 	Role            Role
 	RespHeader      http.Header
 	ProtocolVersion string // Protocol version parsed from context.version (e.g. "2.0.0")
+	CounterSign     string // Populated by counterSignStep for v2.0.0 LTS; injected into ACK response
 }
 
 // WithContext updates the existing StepContext with a new context.
@@ -195,6 +196,9 @@ const (
 type Ack struct {
 	// Status holds the acknowledgment status (ACK/NACK).
 	Status Status `json:"status"`
+	// CounterSign is the receiver's signature over the inbound request body,
+	// included only for Beckn v2.0.0 LTS responses as a signed receipt.
+	CounterSign string `json:"counter_sign,omitempty"`
 }
 
 // Message represents the structure of a response message.

--- a/pkg/plugin/definition/step.go
+++ b/pkg/plugin/definition/step.go
@@ -2,12 +2,22 @@ package definition
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
+// Step processes the inbound request before routing.
 type Step interface {
 	Run(ctx *model.StepContext) error
+}
+
+// ResponseStep processes the upstream response before it is forwarded to the caller.
+// A step may implement Step, ResponseStep, or both depending on which phase it needs.
+// Steps implementing ResponseStep are automatically registered for response-phase
+// invocation by the handler — no separate configuration is required.
+type ResponseStep interface {
+	RunOnResponse(ctx *model.StepContext, resp *http.Response) error
 }
 
 type StepProvider interface {

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -12,11 +12,14 @@ import (
 )
 
 // SendAck sends an acknowledgment response (ACK) to the client.
-func SendAck(w http.ResponseWriter) {
+// counterSign is the v2.0.0 LTS counter-signature string; pass an empty string
+// for legacy protocol versions and the field will be omitted from the response.
+func SendAck(w http.ResponseWriter, counterSign string) {
 	resp := &model.Response{
 		Message: model.Message{
 			Ack: model.Ack{
-				Status: model.StatusACK,
+				Status:      model.StatusACK,
+				CounterSign: counterSign,
 			},
 		},
 	}

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -33,16 +33,18 @@ func SendAck(w http.ResponseWriter) {
 }
 
 // nack sends a negative acknowledgment (NACK) response with an error message.
+// When the request carries Beckn protocol version "2.0.0" (LTS), the error moves
+// to the top-level response field and field names change to errorCode/errorMessage.
 func nack(ctx context.Context, w http.ResponseWriter, err *model.Error, status int) {
 	resp := &model.Response{
-		Message: model.Message{
-			Ack: model.Ack{
-				Status: model.StatusNACK,
-			},
-			Error: err,
-		},
+		Message: model.Message{Ack: model.Ack{Status: model.StatusNACK}},
 	}
-	data, _ := json.Marshal(resp) //should not fail here
+	if version, _ := ctx.Value(model.ContextKeyProtocolVersion).(string); version == model.ProtocolVersionLTS {
+		resp.Error = err.ToV2Error() // v2: top-level error, renamed fields
+	} else {
+		resp.Message.Error = err // legacy: error nested inside message
+	}
+	data, _ := json.Marshal(resp) // should not fail here
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -53,6 +53,7 @@ func TestSendNack(t *testing.T) {
 		err      error
 		expected string
 		status   int
+		ctx      context.Context // if nil, uses the default ctx above
 	}{
 		{
 			name: "SchemaValidationErr",
@@ -89,6 +90,52 @@ func TestSendNack(t *testing.T) {
 			status:   http.StatusInternalServerError,
 			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Internal Server Error","message":"Internal server error, MessageID: 123456"}}}`,
 		},
+		// ── Beckn v2.0.0 LTS cases ──────────────────────────────────────────────
+		{
+			name: "v2 SchemaValidationErr - top-level error, renamed fields",
+			ctx: context.WithValue(
+				context.WithValue(context.Background(), model.ContextKeyMsgID, "123456"),
+				model.ContextKeyProtocolVersion, model.ProtocolVersionLTS,
+			),
+			err: &model.SchemaValidationErr{
+				Errors: []model.Error{
+					{Paths: "/path1", Message: "Error 1"},
+					{Paths: "/path2", Message: "Error 2"},
+				},
+			},
+			status:   http.StatusBadRequest,
+			expected: `{"message":{"ack":{"status":"NACK"}},"error":{"errorCode":"Bad Request","errorPaths":"/path1;/path2","errorMessage":"Error 1; Error 2"}}`,
+		},
+		{
+			name: "v2 SignValidationErr - top-level error, renamed fields",
+			ctx: context.WithValue(
+				context.WithValue(context.Background(), model.ContextKeyMsgID, "123456"),
+				model.ContextKeyProtocolVersion, model.ProtocolVersionLTS,
+			),
+			err:      model.NewSignValidationErr(errors.New("signature invalid")),
+			status:   http.StatusUnauthorized,
+			expected: `{"message":{"ack":{"status":"NACK"}},"error":{"errorCode":"Unauthorized","errorMessage":"Signature Validation Error: signature invalid"}}`,
+		},
+		{
+			name: "v2 BadReqErr - top-level error, renamed fields",
+			ctx: context.WithValue(
+				context.WithValue(context.Background(), model.ContextKeyMsgID, "123456"),
+				model.ContextKeyProtocolVersion, model.ProtocolVersionLTS,
+			),
+			err:      model.NewBadReqErr(errors.New("bad request error")),
+			status:   http.StatusBadRequest,
+			expected: `{"message":{"ack":{"status":"NACK"}},"error":{"errorCode":"Bad Request","errorMessage":"BAD Request: bad request error"}}`,
+		},
+		{
+			name: "v2 InternalServerError - top-level error, renamed fields",
+			ctx: context.WithValue(
+				context.WithValue(context.Background(), model.ContextKeyMsgID, "123456"),
+				model.ContextKeyProtocolVersion, model.ProtocolVersionLTS,
+			),
+			err:      errors.New("unexpected error"),
+			status:   http.StatusInternalServerError,
+			expected: `{"message":{"ack":{"status":"NACK"}},"error":{"errorCode":"Internal Server Error","errorMessage":"Internal server error, MessageID: 123456"}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -99,7 +146,11 @@ func TestSendNack(t *testing.T) {
 			}
 			rr := httptest.NewRecorder()
 
-			SendNack(ctx, rr, tt.err)
+			testCtx := ctx
+			if tt.ctx != nil {
+				testCtx = tt.ctx
+			}
+			SendNack(testCtx, rr, tt.err)
 
 			if rr.Code != tt.status {
 				t.Errorf("wanted status code %d, got %d", tt.status, rr.Code)

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -25,23 +25,35 @@ func (e *errorResponseWriter) Header() http.Header {
 }
 
 func TestSendAck(t *testing.T) {
-	_, err := http.NewRequest("GET", "/", nil)
-	if err != nil {
-		t.Fatal(err) // For tests
+	tests := []struct {
+		name        string
+		counterSign string
+		expected    string
+	}{
+		{
+			name:        "legacy — no counter_sign",
+			counterSign: "",
+			expected:    `{"message":{"ack":{"status":"ACK"}}}`,
+		},
+		{
+			name:        "v2.0.0 LTS — counter_sign present",
+			counterSign: `Signature keyId="bpp.example.com|key-1|ed25519",signature="abc123"`,
+			expected:    `{"message":{"ack":{"status":"ACK","counter_sign":"Signature keyId=\"bpp.example.com|key-1|ed25519\",signature=\"abc123\""}}}`,
+		},
 	}
-	rr := httptest.NewRecorder()
 
-	SendAck(rr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			SendAck(rr, tt.counterSign)
 
-	if rr.Code != http.StatusOK {
-		t.Errorf("wanted status code %d, got %d", http.StatusOK, rr.Code)
-	}
-
-	expected := `{"message":{"ack":{"status":"ACK"}}}`
-	if rr.Body.String() != expected {
-		t.Errorf("err.Error() = %s, want %s",
-			rr.Body.String(), expected)
-
+			if rr.Code != http.StatusOK {
+				t.Errorf("wanted status code %d, got %d", http.StatusOK, rr.Code)
+			}
+			if rr.Body.String() != tt.expected {
+				t.Errorf("body = %s, want %s", rr.Body.String(), tt.expected)
+			}
+		})
 	}
 }
 
@@ -185,7 +197,7 @@ func compareJSON(expected, actual map[string]interface{}) bool {
 
 func TestSendAck_WriteError(t *testing.T) {
 	w := &errorResponseWriter{}
-	SendAck(w)
+	SendAck(w, "")
 }
 
 // Mock struct to force JSON marshalling error


### PR DESCRIPTION
## Summary

This PR consolidates all transport-layer changes for Beckn Protocol v2.0.0 LTS into a single reviewable unit. It covers two milestones tracked in separate issues:

- **#651** — Counter-signature support on the Receiver side (BAP + BPP)
- **#682** — \`validateCounterSign\` step on the Caller side (BAP + BPP), dual-phase step design, and related bug fixes

It supersedes PR #683 (now closed), which was a stacked PR targeting an intermediate branch.

---

## Dependency chain

| Commit | Ticket | Description |
|--------|--------|-------------|
| \`70b793e\` | #651 | Add \`ProtocolVersion\` to \`StepContext\` for v2.0.0 LTS gating |
| \`7130106\` | #651 | Emit v2.0.0 LTS error shape in NACK responses |
| \`4472f59\` | #651 | Add \`counterSign\` step — Receiver-side ACK counter-signature |
| \`fa00eab\` | #682 | Add \`ResponseStep\` interface and \`validateCounterSign\` step |
| \`d3084d4\` | #682 | Refactor: move counter-sign injection into \`counterSignStep.RunOnResponse\` |
| \`19fb798\` | #682 | Docs: document dual-phase steps and \`validateCounterSign\` in CONFIG.md |
| \`22b47eb\` | #682 | Tests: \`validateCounterSignStep.RunOnResponse\` unit tests (7 cases) |
| \`ddc8c0a\` | #682 | Debug: entry-point logs in \`counterSign\` and \`validateCounterSign\` |
| \`3957023\` | #682 | Debug: log request body and extracted protocol version in \`stepCtx\` |
| \`c3ae1dc\` | #682 | Fix: propagate \`ProtocolVersion\` and \`CounterSign\` through \`InstrumentedStep\` |
| \`5800149\` | #682 | Refactor: use struct copy in \`InstrumentedStep\` to avoid future field omissions |

---

## What changed

### 1. \`ProtocolVersion\` in \`StepContext\` (\`pkg/model/step_context.go\`)
All steps now receive \`ctx.ProtocolVersion\` (extracted from \`context.version\` in the request body). Steps gate v2.0.0 LTS behaviour with:
```go
if ctx.ProtocolVersion != model.ProtocolVersionLTS { return nil }
```
The protocol version is also stored in the Go \`context.Context\` (via \`model.ContextKeyProtocolVersion\`) so that functions receiving only a \`context.Context\` (e.g. \`response.SendNack\`) can read it without needing access to \`StepContext\`.

### 2. v2.0.0 LTS error envelope (\`pkg/model/model.go\`, \`pkg/model/error.go\`, \`pkg/response/response.go\`)

In Beckn v2.0.0 LTS the error response wire format changed in two ways:
- **Location**: the error object moves from \`message.error\` to the **top level** of the response.
- **Field names**: \`code\` → \`errorCode\`, \`message\` → \`errorMessage\`, \`paths\` → \`errorPaths\`.

**Legacy (v1) NACK:**
```json
{
  "message": {
    "ack": { "status": "NACK" },
    "error": { "code": "Unauthorized", "message": "Signature Validation Error: ..." }
  }
}
```

**v2.0.0 LTS NACK:**
```json
{
  "message": { "ack": { "status": "NACK" } },
  "error": { "errorCode": "Unauthorized", "errorMessage": "Signature Validation Error: ..." }
}
```

Implementation:
- Added \`V2Error\` struct to \`pkg/model/model.go\` with \`errorCode / errorMessage / errorPaths\` JSON tags.
- Extended \`Response\` with a top-level \`Error *V2Error\` field (\`omitempty\`); for legacy versions \`Message.Error\` is populated instead — a single struct handles both shapes.
- Added \`Error.ToV2Error()\` conversion method to \`pkg/model/error.go\`.
- \`nack()\` in \`pkg/response/response.go\` reads \`ContextKeyProtocolVersion\` and branches:
```go
if version, _ := ctx.Value(model.ContextKeyProtocolVersion).(string); version == model.ProtocolVersionLTS {
    resp.Error = err.ToV2Error() // v2: top-level, renamed fields
} else {
    resp.Message.Error = err     // legacy: nested inside message
}
```
Legacy behaviour is fully preserved for any version other than \`"2.0.0"\`.

Tests added in \`pkg/model/error_test.go\` and \`pkg/response/response_test.go\` covering all four error types (SchemaValidation, SignValidation, BadRequest, InternalServer) in both legacy and v2 shapes.

### 3. \`counterSign\` step — Receiver side (\`core/module/handler/step.go\`)
- **\`Run\`**: Signs the inbound request body; stores the \`Authorization\` header value in \`ctx.CounterSign\`.
- **\`RunOnResponse\`**: Injects \`counter_sign\` into the proxied ACK before it is returned to the upstream caller.
- Only active when \`ctx.ProtocolVersion == "2.0.0"\`.

### 4. \`ResponseStep\` interface (\`pkg/plugin/definition/step.go\`)
```go
// ResponseStep processes the upstream response before it is forwarded to the caller.
type ResponseStep interface {
    RunOnResponse(ctx *model.StepContext, resp *http.Response) error
}
```
Steps that implement \`ResponseStep\` are auto-registered via type assertion in \`initSteps\` — no separate \`responseSteps:\` config key is needed. A single entry in \`steps:\` can participate in both request and response phases.

### 5. \`validateCounterSign\` step — Caller side (\`core/module/handler/step.go\`)
- **\`Run\`**: No-op (counter-sign validation only makes sense on the response).
- **\`RunOnResponse\`**: Parses the \`counter_sign\` field from the ACK body, resolves the signer's public key via \`KeyManager.LookupNPKeys\`, and validates the signature against the original request body via \`SignValidator.Validate\`.
- Returns \`NewSignValidationErr\` if \`counter_sign\` is absent or the signature is invalid.
- Only active when \`ctx.ProtocolVersion == "2.0.0"\`.

### 6. \`InstrumentedStep\` bug fix (\`core/module/handler/step_instrumentor.go\`)
**Critical bug**: The telemetry wrapper was constructing a fresh \`StepContext\` struct literal, silently dropping \`ProtocolVersion\` (so LTS gating never triggered) and failing to write back \`CounterSign\` (so injected signatures were lost).

Fixed by replacing the struct literal with a shallow copy + targeted write-back:
```go
stepCtx := *ctx           // all fields copied automatically
stepCtx.Context = spanCtx // replace only the span context

err := is.step.Run(&stepCtx)

if stepCtx.Route != nil { ctx.Route = stepCtx.Route }
ctx.CounterSign = stepCtx.CounterSign
ctx.WithContext(stepCtx.Context)
// ProtocolVersion is read-only — not written back
```
This also future-proofs the wrapper: new fields added to \`StepContext\` are automatically included.

### 7. \`ErrorHandler\` on reverse proxy (\`core/module/handler/stdHandler.go\`)
If a \`ResponseStep\` returns an error, \`ModifyResponse\` returns that error and the \`ErrorHandler\` sends a proper NACK:
```go
ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
    log.Errorf(ctx, err, "proxy: upstream or response-step error: %v", err)
    response.SendNack(ctx, rw, err)
},
```

### 8. Config and docs
- \`CONFIG.md\`: Rewrote \`steps:\` section to explain dual-phase execution; added \`validateCounterSign\` entry.
- \`config/local-beckn-one-bap.yaml\`: Added \`- validateCounterSign\` to \`bapTxnCaller\` steps.
- \`config/onix/adapter.yaml\` and \`config/onix-bpp/adapter.yaml\`: Added \`- validateCounterSign\` to Caller handler steps.

---

## Handler ↔ step assignment

| Side | Handler | Steps |
|------|---------|-------|
| BAP Receiver | \`bapTxnReceiver\` | \`validateSign\`, \`checkPolicy\`, \`addRoute\`, \`validateSchema\`, **\`counterSign\`** |
| BAP Caller | \`bapTxnCaller\` | \`checkPolicy\`, \`addRoute\`, \`sign\`, \`validateSchema\`, **\`validateCounterSign\`** |
| BPP Receiver | \`bppTxnReceiver\` | \`validateSign\`, \`addRoute\`, \`validateSchema\`, **\`counterSign\`** |
| BPP Caller | \`bppTxnCaller\` | \`validateSchema\`, \`addRoute\`, \`sign\`, **\`validateCounterSign\`** |

> \`counterSign\` is a Receiver step; \`validateCounterSign\` is a Caller step. Both are v2.0.0 LTS-gated (no-op for older protocol versions).

---

## Unit tests

**\`pkg/model/error_test.go\`** — \`TestError_ToV2Error\` (2 cases): full error with paths, error without paths.

**\`pkg/response/response_test.go\`** — 4 new v2 cases added to \`TestSendNack\`: SchemaValidation, SignValidation, BadRequest, InternalServer — each asserting top-level \`error\` field and renamed keys.

**\`core/module/handler/stdHandler_test.go\`**:

\`TestValidateCounterSignStepRunOnResponse\` (7 cases):
1. Non-LTS protocol version → no-op (nil validator/km prove they are not called)
2. Valid \`counter_sign\` → success
3. Missing \`counter_sign\` field in ACK → \`SignValidationErr\`
4. Malformed Authorization header → parse error
5. Key-lookup failure → error propagated
6. Signature mismatch → \`SignValidationErr\`
7. Non-JSON response body → unmarshal error

\`TestCounterSignStepRunOnResponse\` (renamed from \`TestInjectCounterSign\`): updated to call \`step.RunOnResponse\` directly.

---

## How to test end-to-end

Prerequisites: Beckn v2.0.0 request body (\`"context": { "version": "2.0.0", ... }\`), BAP and BPP both running with the config above, OTel collector optional.

1. Send a \`select\` from BAP → BPP.
2. **BPP Receiver** log: \`counterSign: Run called with protocol version "2.0.0"\` — signs request, stores counter-sign in context.
3. **BPP Receiver** log: \`counterSign: RunOnResponse called, CounterSign present=true\` — injects \`counter_sign\` into the \`on_select\` ACK.
4. **BAP Caller** log: \`validateCounterSign: RunOnResponse called with protocol version "2.0.0"\` — validates counter-sign from ACK.
5. On success, \`on_select\` is forwarded to BAP application layer with \`counter_sign\` intact.
6. On failure (bad or missing counter-sign), BAP Caller returns a v2.0.0 LTS NACK (top-level \`error\` with \`errorCode\`/\`errorMessage\`) to BPP.

For v1 requests (no \`context.version\` or \`!= "2.0.0"\`): all counter-sign steps are no-ops and the legacy NACK shape is preserved.

---

## Checklist

- [x] Unit tests pass (\`go test ./core/module/handler/...\`, \`go test ./pkg/model/...\`, \`go test ./pkg/response/...\`)
- [x] Pre-existing router test failure (\`TestValidateRulesFailure\`) confirmed present on \`main\` — not introduced by this PR
- [x] E2E tested: \`select\` → \`on_select\` flow with v2.0.0 payload (counter-sign injected and validated successfully)
- [x] Backward compatible: v1 protocol requests are unaffected (legacy error shape preserved)
- [x] \`InstrumentedStep\` fix is backward compatible (struct copy preserves all existing fields)

Closes #682
Related: #651