### PR TITLE
Parse DeDi registry retry config

### DIFF
--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
@@ -15,19 +16,16 @@ import (
 // dediRegistryProvider implements the RegistryLookupProvider interface for the DeDi registry plugin.
 type dediRegistryProvider struct{}
 
-// New creates a new DeDi registry plugin instance.
-func (d dediRegistryProvider) New(ctx context.Context, config map[string]string) (definition.RegistryLookup, func() error, error) {
-	if ctx == nil {
-		return nil, nil, errors.New("context cannot be nil")
-	}
+// newDediRegistryFunc creates a new DeDi registry instance.
+var newDediRegistryFunc = dediregistry.New
 
-	// Create dediregistry.Config directly from map - validation is handled by dediregistry.New
+func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string]string) *dediregistry.Config {
 	dediConfig := &dediregistry.Config{
 		URL:          config["url"],
 		RegistryName: config["registryName"],
 	}
 
-	// Parse timeout if provided
+	// Parse timeout if provided.
 	if timeoutStr, exists := config["timeout"]; exists && timeoutStr != "" {
 		if timeout, err := strconv.Atoi(timeoutStr); err == nil {
 			dediConfig.Timeout = timeout
@@ -36,6 +34,43 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 		}
 	}
 
+	// Parse retry_max if provided.
+	if retryMaxStr, exists := config["retry_max"]; exists && retryMaxStr != "" {
+		if retryMax, err := strconv.Atoi(retryMaxStr); err == nil {
+			dediConfig.RetryMax = retryMax
+		} else {
+			log.Warnf(ctx, "Invalid retry_max value '%s', using default", retryMaxStr)
+		}
+	}
+
+	// Parse retry_wait_min if provided.
+	if retryWaitMinStr, exists := config["retry_wait_min"]; exists && retryWaitMinStr != "" {
+		if retryWaitMin, err := time.ParseDuration(retryWaitMinStr); err == nil {
+			dediConfig.RetryWaitMin = retryWaitMin
+		} else {
+			log.Warnf(ctx, "Invalid retry_wait_min value '%s', using default", retryWaitMinStr)
+		}
+	}
+
+	// Parse retry_wait_max if provided.
+	if retryWaitMaxStr, exists := config["retry_wait_max"]; exists && retryWaitMaxStr != "" {
+		if retryWaitMax, err := time.ParseDuration(retryWaitMaxStr); err == nil {
+			dediConfig.RetryWaitMax = retryWaitMax
+		} else {
+			log.Warnf(ctx, "Invalid retry_wait_max value '%s', using default", retryWaitMaxStr)
+		}
+	}
+
+	return dediConfig
+}
+
+// New creates a new DeDi registry plugin instance.
+func (d dediRegistryProvider) New(ctx context.Context, config map[string]string) (definition.RegistryLookup, func() error, error) {
+	if ctx == nil {
+		return nil, nil, errors.New("context cannot be nil")
+	}
+
+	dediConfig := d.parseConfig(ctx, config)
 	allowedNetworkIDs, err := resolveAllowedNetworkIDs(config)
 	if err != nil {
 		return nil, nil, err
@@ -44,7 +79,7 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 
 	log.Debugf(ctx, "DeDi Registry config mapped: %+v", dediConfig)
 
-	dediClient, closer, err := dediregistry.New(ctx, dediConfig)
+	dediClient, closer, err := newDediRegistryFunc(ctx, dediConfig)
 	if err != nil {
 		log.Errorf(ctx, err, "Failed to create DeDi registry instance")
 		return nil, nil, err

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -14,12 +14,11 @@ import (
 )
 
 // dediRegistryProvider implements the RegistryLookupProvider interface for the DeDi registry plugin.
-type dediRegistryProvider struct{}
+type dediRegistryProvider struct {
+	newFunc func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error)
+}
 
-// newDediRegistryFunc creates a new DeDi registry instance.
-var newDediRegistryFunc = dediregistry.New
-
-func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string]string) (*dediregistry.Config, error) {
+func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregistry.Config, error) {
 	dediConfig := &dediregistry.Config{
 		URL:          config["url"],
 		RegistryName: config["registryName"],
@@ -27,11 +26,11 @@ func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string
 
 	// Parse timeout if provided.
 	if timeoutStr, exists := config["timeout"]; exists && timeoutStr != "" {
-		if timeout, err := strconv.Atoi(timeoutStr); err == nil {
-			dediConfig.Timeout = timeout
-		} else {
-			log.Warnf(ctx, "Invalid timeout value '%s', using default", timeoutStr)
+		timeout, err := strconv.Atoi(timeoutStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timeout value '%s': %w", timeoutStr, err)
 		}
+		dediConfig.Timeout = timeout
 	}
 
 	// Parse retry_max if provided.
@@ -39,6 +38,9 @@ func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string
 		retryMax, err := strconv.Atoi(retryMaxStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid retry_max value '%s': %w", retryMaxStr, err)
+		}
+		if retryMax < 0 {
+			return nil, fmt.Errorf("retry_max must be non-negative, got %d", retryMax)
 		}
 		dediConfig.RetryMax = retryMax
 	}
@@ -49,6 +51,9 @@ func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string
 		if err != nil {
 			return nil, fmt.Errorf("invalid retry_wait_min value '%s': %w", retryWaitMinStr, err)
 		}
+		if retryWaitMin < 0 {
+			return nil, fmt.Errorf("retry_wait_min must be non-negative, got %v", retryWaitMin)
+		}
 		dediConfig.RetryWaitMin = retryWaitMin
 	}
 
@@ -57,6 +62,9 @@ func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string
 		retryWaitMax, err := time.ParseDuration(retryWaitMaxStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid retry_wait_max value '%s': %w", retryWaitMaxStr, err)
+		}
+		if retryWaitMax < 0 {
+			return nil, fmt.Errorf("retry_wait_max must be non-negative, got %v", retryWaitMax)
 		}
 		dediConfig.RetryWaitMax = retryWaitMax
 	}
@@ -70,7 +78,7 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 		return nil, nil, errors.New("context cannot be nil")
 	}
 
-	dediConfig, err := d.parseConfig(ctx, config)
+	dediConfig, err := d.parseConfig(config)
 	if err != nil {
 		log.Errorf(ctx, err, "Failed to parse DeDi registry configuration")
 		return nil, nil, fmt.Errorf("failed to parse DeDi registry configuration: %w", err)
@@ -84,7 +92,7 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 
 	log.Debugf(ctx, "DeDi Registry config mapped: %+v", dediConfig)
 
-	dediClient, closer, err := newDediRegistryFunc(ctx, dediConfig)
+	dediClient, closer, err := d.newFunc(ctx, dediConfig)
 	if err != nil {
 		log.Errorf(ctx, err, "Failed to create DeDi registry instance")
 		return nil, nil, err
@@ -122,4 +130,4 @@ func resolveAllowedNetworkIDs(config map[string]string) ([]string, error) {
 }
 
 // Provider is the exported plugin instance
-var Provider = dediRegistryProvider{}
+var Provider = dediRegistryProvider{newFunc: dediregistry.New}

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -30,6 +30,9 @@ func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregist
 		if err != nil {
 			return nil, fmt.Errorf("invalid timeout value '%s': %w", timeoutStr, err)
 		}
+		if timeout <= 0 {
+			return nil, fmt.Errorf("timeout must be positive, got %d", timeout)
+		}
 		dediConfig.Timeout = timeout
 	}
 
@@ -67,6 +70,11 @@ func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregist
 			return nil, fmt.Errorf("retry_wait_max must be non-negative, got %v", retryWaitMax)
 		}
 		dediConfig.RetryWaitMax = retryWaitMax
+	}
+
+	// Validate retry wait bounds relationship.
+	if dediConfig.RetryWaitMin > 0 && dediConfig.RetryWaitMax > 0 && dediConfig.RetryWaitMin > dediConfig.RetryWaitMax {
+		return nil, fmt.Errorf("retry_wait_min (%v) must not exceed retry_wait_max (%v)", dediConfig.RetryWaitMin, dediConfig.RetryWaitMax)
 	}
 
 	return dediConfig, nil

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -19,7 +19,7 @@ type dediRegistryProvider struct{}
 // newDediRegistryFunc creates a new DeDi registry instance.
 var newDediRegistryFunc = dediregistry.New
 
-func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string]string) *dediregistry.Config {
+func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string]string) (*dediregistry.Config, error) {
 	dediConfig := &dediregistry.Config{
 		URL:          config["url"],
 		RegistryName: config["registryName"],
@@ -36,32 +36,32 @@ func (d dediRegistryProvider) parseConfig(ctx context.Context, config map[string
 
 	// Parse retry_max if provided.
 	if retryMaxStr, exists := config["retry_max"]; exists && retryMaxStr != "" {
-		if retryMax, err := strconv.Atoi(retryMaxStr); err == nil {
-			dediConfig.RetryMax = retryMax
-		} else {
-			log.Warnf(ctx, "Invalid retry_max value '%s', using default", retryMaxStr)
+		retryMax, err := strconv.Atoi(retryMaxStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid retry_max value '%s': %w", retryMaxStr, err)
 		}
+		dediConfig.RetryMax = retryMax
 	}
 
 	// Parse retry_wait_min if provided.
 	if retryWaitMinStr, exists := config["retry_wait_min"]; exists && retryWaitMinStr != "" {
-		if retryWaitMin, err := time.ParseDuration(retryWaitMinStr); err == nil {
-			dediConfig.RetryWaitMin = retryWaitMin
-		} else {
-			log.Warnf(ctx, "Invalid retry_wait_min value '%s', using default", retryWaitMinStr)
+		retryWaitMin, err := time.ParseDuration(retryWaitMinStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid retry_wait_min value '%s': %w", retryWaitMinStr, err)
 		}
+		dediConfig.RetryWaitMin = retryWaitMin
 	}
 
 	// Parse retry_wait_max if provided.
 	if retryWaitMaxStr, exists := config["retry_wait_max"]; exists && retryWaitMaxStr != "" {
-		if retryWaitMax, err := time.ParseDuration(retryWaitMaxStr); err == nil {
-			dediConfig.RetryWaitMax = retryWaitMax
-		} else {
-			log.Warnf(ctx, "Invalid retry_wait_max value '%s', using default", retryWaitMaxStr)
+		retryWaitMax, err := time.ParseDuration(retryWaitMaxStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid retry_wait_max value '%s': %w", retryWaitMaxStr, err)
 		}
+		dediConfig.RetryWaitMax = retryWaitMax
 	}
 
-	return dediConfig
+	return dediConfig, nil
 }
 
 // New creates a new DeDi registry plugin instance.
@@ -70,7 +70,12 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 		return nil, nil, errors.New("context cannot be nil")
 	}
 
-	dediConfig := d.parseConfig(ctx, config)
+	dediConfig, err := d.parseConfig(ctx, config)
+	if err != nil {
+		log.Errorf(ctx, err, "Failed to parse DeDi registry configuration")
+		return nil, nil, fmt.Errorf("failed to parse DeDi registry configuration: %w", err)
+	}
+
 	allowedNetworkIDs, err := resolveAllowedNetworkIDs(config)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -3,7 +3,89 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/dediregistry"
 )
+
+func TestDediRegistryProvider_ParseConfig(t *testing.T) {
+	provider := dediRegistryProvider{}
+	ctx := context.Background()
+
+	cfg := provider.parseConfig(ctx, map[string]string{
+		"url":            "https://test.com/dedi",
+		"registryName":   "subscribers.beckn.one",
+		"timeout":        "30",
+		"retry_max":      "5",
+		"retry_wait_min": "100ms",
+		"retry_wait_max": "2s",
+	})
+
+	if cfg.URL != "https://test.com/dedi" {
+		t.Fatalf("expected URL to be parsed, got %q", cfg.URL)
+	}
+	if cfg.RegistryName != "subscribers.beckn.one" {
+		t.Fatalf("expected RegistryName to be parsed, got %q", cfg.RegistryName)
+	}
+	if cfg.Timeout != 30 {
+		t.Fatalf("expected Timeout 30, got %d", cfg.Timeout)
+	}
+	if cfg.RetryMax != 5 {
+		t.Fatalf("expected RetryMax 5, got %d", cfg.RetryMax)
+	}
+	if cfg.RetryWaitMin != 100*time.Millisecond {
+		t.Fatalf("expected RetryWaitMin 100ms, got %v", cfg.RetryWaitMin)
+	}
+	if cfg.RetryWaitMax != 2*time.Second {
+		t.Fatalf("expected RetryWaitMax 2s, got %v", cfg.RetryWaitMax)
+	}
+}
+
+func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
+	provider := dediRegistryProvider{}
+	originalNewDediRegistryFunc := newDediRegistryFunc
+	t.Cleanup(func() {
+		newDediRegistryFunc = originalNewDediRegistryFunc
+	})
+
+	var captured *dediregistry.Config
+	newDediRegistryFunc = func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error) {
+		captured = cfg
+		return new(dediregistry.DeDiRegistryClient), func() error { return nil }, nil
+	}
+
+	config := map[string]string{
+		"url":            "https://test.com/dedi",
+		"registryName":   "subscribers.beckn.one",
+		"timeout":        "30",
+		"retry_max":      "5",
+		"retry_wait_min": "100ms",
+		"retry_wait_max": "2s",
+	}
+
+	_, closer, err := provider.New(context.Background(), config)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if closer == nil {
+		t.Fatal("expected closer to be non-nil")
+	}
+	if err := closer(); err != nil {
+		t.Fatalf("closer() error = %v", err)
+	}
+	if captured == nil {
+		t.Fatal("expected config to be forwarded to client constructor")
+	}
+	if captured.RetryMax != 5 {
+		t.Fatalf("expected RetryMax 5, got %d", captured.RetryMax)
+	}
+	if captured.RetryWaitMin != 100*time.Millisecond {
+		t.Fatalf("expected RetryWaitMin 100ms, got %v", captured.RetryWaitMin)
+	}
+	if captured.RetryWaitMax != 2*time.Second {
+		t.Fatalf("expected RetryWaitMax 2s, got %v", captured.RetryWaitMax)
+	}
+}
 
 func TestDediRegistryProvider_New(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -11,9 +11,8 @@ import (
 
 func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
-	ctx := context.Background()
 
-	cfg, err := provider.parseConfig(ctx, map[string]string{
+	cfg, err := provider.parseConfig(map[string]string{
 		"url":            "https://test.com/dedi",
 		"registryName":   "subscribers.beckn.one",
 		"timeout":        "30",
@@ -45,15 +44,23 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 	}
 }
 
-func TestDediRegistryProvider_ParseConfig_InvalidRetryConfig(t *testing.T) {
+func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
-	ctx := context.Background()
 
 	tests := []struct {
 		name        string
 		config      map[string]string
 		expectedErr string
 	}{
+		{
+			name: "invalid timeout",
+			config: map[string]string{
+				"url":          "https://test.com/dedi",
+				"registryName": "subscribers.beckn.one",
+				"timeout":      "abc",
+			},
+			expectedErr: "invalid timeout value 'abc'",
+		},
 		{
 			name: "invalid retry_max",
 			config: map[string]string{
@@ -62,6 +69,15 @@ func TestDediRegistryProvider_ParseConfig_InvalidRetryConfig(t *testing.T) {
 				"retry_max":    "abc",
 			},
 			expectedErr: "invalid retry_max value 'abc'",
+		},
+		{
+			name: "negative retry_max",
+			config: map[string]string{
+				"url":          "https://test.com/dedi",
+				"registryName": "subscribers.beckn.one",
+				"retry_max":    "-1",
+			},
+			expectedErr: "retry_max must be non-negative",
 		},
 		{
 			name: "invalid retry_wait_min",
@@ -73,6 +89,15 @@ func TestDediRegistryProvider_ParseConfig_InvalidRetryConfig(t *testing.T) {
 			expectedErr: "invalid retry_wait_min value 'notaduration'",
 		},
 		{
+			name: "negative retry_wait_min",
+			config: map[string]string{
+				"url":            "https://test.com/dedi",
+				"registryName":   "subscribers.beckn.one",
+				"retry_wait_min": "-100ms",
+			},
+			expectedErr: "retry_wait_min must be non-negative",
+		},
+		{
 			name: "invalid retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
@@ -81,11 +106,20 @@ func TestDediRegistryProvider_ParseConfig_InvalidRetryConfig(t *testing.T) {
 			},
 			expectedErr: "invalid retry_wait_max value 'notaduration'",
 		},
+		{
+			name: "negative retry_wait_max",
+			config: map[string]string{
+				"url":            "https://test.com/dedi",
+				"registryName":   "subscribers.beckn.one",
+				"retry_wait_max": "-2s",
+			},
+			expectedErr: "retry_wait_max must be non-negative",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := provider.parseConfig(ctx, tt.config)
+			cfg, err := provider.parseConfig(tt.config)
 			if err == nil {
 				t.Fatal("expected parseConfig() to return an error")
 			}
@@ -116,16 +150,12 @@ func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
 }
 
 func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
-	provider := dediRegistryProvider{}
-	originalNewDediRegistryFunc := newDediRegistryFunc
-	t.Cleanup(func() {
-		newDediRegistryFunc = originalNewDediRegistryFunc
-	})
-
 	var captured *dediregistry.Config
-	newDediRegistryFunc = func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error) {
-		captured = cfg
-		return new(dediregistry.DeDiRegistryClient), func() error { return nil }, nil
+	provider := dediRegistryProvider{
+		newFunc: func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error) {
+			captured = cfg
+			return new(dediregistry.DeDiRegistryClient), func() error { return nil }, nil
+		},
 	}
 
 	config := map[string]string{
@@ -163,7 +193,7 @@ func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
 
 func TestDediRegistryProvider_New(t *testing.T) {
 	ctx := context.Background()
-	provider := dediRegistryProvider{}
+	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
 	config := map[string]string{
 		"url":          "https://test.com/dedi",
@@ -193,7 +223,7 @@ func TestDediRegistryProvider_New(t *testing.T) {
 
 func TestDediRegistryProvider_New_InvalidConfig(t *testing.T) {
 	ctx := context.Background()
-	provider := dediRegistryProvider{}
+	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
 	tests := []struct {
 		name   string
@@ -224,25 +254,18 @@ func TestDediRegistryProvider_New_InvalidConfig(t *testing.T) {
 }
 
 func TestDediRegistryProvider_New_InvalidTimeout(t *testing.T) {
-	ctx := context.Background()
-	provider := dediRegistryProvider{}
+	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
-	config := map[string]string{
+	_, _, err := provider.New(context.Background(), map[string]string{
 		"url":          "https://test.com/dedi",
 		"registryName": "subscribers.beckn.one",
 		"timeout":      "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected New() to return an error for invalid timeout")
 	}
-
-	// Invalid timeout should be ignored, not cause error
-	dediRegistry, closer, err := provider.New(ctx, config)
-	if err != nil {
-		t.Errorf("New() with invalid timeout should not return error, got: %v", err)
-	}
-	if dediRegistry == nil {
-		t.Error("New() should return valid registry even with invalid timeout")
-	}
-	if closer != nil {
-		closer()
+	if !strings.Contains(err.Error(), "invalid timeout value 'invalid'") {
+		t.Fatalf("expected timeout parse error, got %q", err.Error())
 	}
 }
 

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
 	ctx := context.Background()
 
-	cfg := provider.parseConfig(ctx, map[string]string{
+	cfg, err := provider.parseConfig(ctx, map[string]string{
 		"url":            "https://test.com/dedi",
 		"registryName":   "subscribers.beckn.one",
 		"timeout":        "30",
@@ -20,6 +21,9 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 		"retry_wait_min": "100ms",
 		"retry_wait_max": "2s",
 	})
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
 
 	if cfg.URL != "https://test.com/dedi" {
 		t.Fatalf("expected URL to be parsed, got %q", cfg.URL)
@@ -38,6 +42,76 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 	}
 	if cfg.RetryWaitMax != 2*time.Second {
 		t.Fatalf("expected RetryWaitMax 2s, got %v", cfg.RetryWaitMax)
+	}
+}
+
+func TestDediRegistryProvider_ParseConfig_InvalidRetryConfig(t *testing.T) {
+	provider := dediRegistryProvider{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		config      map[string]string
+		expectedErr string
+	}{
+		{
+			name: "invalid retry_max",
+			config: map[string]string{
+				"url":          "https://test.com/dedi",
+				"registryName": "subscribers.beckn.one",
+				"retry_max":    "abc",
+			},
+			expectedErr: "invalid retry_max value 'abc'",
+		},
+		{
+			name: "invalid retry_wait_min",
+			config: map[string]string{
+				"url":            "https://test.com/dedi",
+				"registryName":   "subscribers.beckn.one",
+				"retry_wait_min": "notaduration",
+			},
+			expectedErr: "invalid retry_wait_min value 'notaduration'",
+		},
+		{
+			name: "invalid retry_wait_max",
+			config: map[string]string{
+				"url":            "https://test.com/dedi",
+				"registryName":   "subscribers.beckn.one",
+				"retry_wait_max": "notaduration",
+			},
+			expectedErr: "invalid retry_wait_max value 'notaduration'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := provider.parseConfig(ctx, tt.config)
+			if err == nil {
+				t.Fatal("expected parseConfig() to return an error")
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config on error, got %#v", cfg)
+			}
+			if !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Fatalf("expected error to contain %q, got %q", tt.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
+	provider := dediRegistryProvider{}
+
+	_, _, err := provider.New(context.Background(), map[string]string{
+		"url":          "https://test.com/dedi",
+		"registryName": "subscribers.beckn.one",
+		"retry_max":    "abc",
+	})
+	if err == nil {
+		t.Fatal("expected New() to return an error for invalid retry config")
+	}
+	if !strings.Contains(err.Error(), "failed to parse DeDi registry configuration") {
+		t.Fatalf("expected wrapped parse error, got %q", err.Error())
 	}
 }
 

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -115,6 +115,34 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			},
 			expectedErr: "retry_wait_max must be non-negative",
 		},
+		{
+			name: "zero timeout",
+			config: map[string]string{
+				"url":          "https://test.com/dedi",
+				"registryName": "subscribers.beckn.one",
+				"timeout":      "0",
+			},
+			expectedErr: "timeout must be positive",
+		},
+		{
+			name: "negative timeout",
+			config: map[string]string{
+				"url":          "https://test.com/dedi",
+				"registryName": "subscribers.beckn.one",
+				"timeout":      "-5",
+			},
+			expectedErr: "timeout must be positive",
+		},
+		{
+			name: "retry_wait_min exceeds retry_wait_max",
+			config: map[string]string{
+				"url":            "https://test.com/dedi",
+				"registryName":   "subscribers.beckn.one",
+				"retry_wait_min": "5s",
+				"retry_wait_max": "1s",
+			},
+			expectedErr: "retry_wait_min (5s) must not exceed retry_wait_max (1s)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -254,6 +282,7 @@ func TestDediRegistryProvider_New_InvalidConfig(t *testing.T) {
 }
 
 func TestDediRegistryProvider_New_InvalidTimeout(t *testing.T) {
+	// Invalid timeout is now a hard error, not a warn-and-continue fallback.
 	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
 	_, _, err := provider.New(context.Background(), map[string]string{


### PR DESCRIPTION
## Summary

This PR adds parsing for the DeDi registry plugin retry settings so operator config values are forwarded instead of being silently ignored.

## What changed

- Parse `retry_max`, `retry_wait_min`, and `retry_wait_max` in `pkg/plugin/implementation/dediregistry/cmd/plugin.go`
- Keep the existing timeout and allowed network ID handling intact
- Add tests covering config parsing and forwarding into the DeDi client constructor

## Why

The DeDi plugin already supports retry configuration in `dediregistry.Config`, but the command layer never populated those fields from the config map. That meant the HTTP client always fell back to library defaults.

## Validation

- `go test ./pkg/plugin/implementation/dediregistry/cmd -count=1`
