### PR TITLE
[Proto-v2.0] Parse and propagate context.version in StepContext

### DIFF
--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -182,13 +182,21 @@ func (h *stdHandler) stepCtx(r *http.Request, rh http.Header) (*model.StepContex
 	r.Body.Close()
 	subID := h.subID(r.Context())
 	return &model.StepContext{
-		Context:    r.Context(),
-		Request:    r,
-		Body:       bodyBuffer.Bytes(),
-		Role:       h.role,
-		SubID:      subID,
-		RespHeader: rh,
+		Context:      r.Context(),
+		Request:      r,
+		Body:         bodyBuffer.Bytes(),
+		Role:         h.role,
+		SubID:        subID,
+		BecknVersion: becknVersionFromContext(r.Context()),
+		RespHeader:   rh,
 	}, nil
+}
+
+func becknVersionFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(model.ContextKeyBecknVersion).(string); ok {
+		return v
+	}
+	return ""
 }
 
 // subID retrieves the subscriber ID from the request context.

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
@@ -23,16 +24,24 @@ func (noopPluginManager) SignValidator(context.Context, *plugin.Config) (definit
 func (noopPluginManager) Validator(context.Context, *plugin.Config) (definition.SchemaValidator, error) {
 	return nil, nil
 }
-func (noopPluginManager) Router(context.Context, *plugin.Config) (definition.Router, error) { return nil, nil }
+func (noopPluginManager) Router(context.Context, *plugin.Config) (definition.Router, error) {
+	return nil, nil
+}
 func (noopPluginManager) Publisher(context.Context, *plugin.Config) (definition.Publisher, error) {
 	return nil, nil
 }
-func (noopPluginManager) Signer(context.Context, *plugin.Config) (definition.Signer, error) { return nil, nil }
-func (noopPluginManager) Step(context.Context, *plugin.Config) (definition.Step, error) { return nil, nil }
+func (noopPluginManager) Signer(context.Context, *plugin.Config) (definition.Signer, error) {
+	return nil, nil
+}
+func (noopPluginManager) Step(context.Context, *plugin.Config) (definition.Step, error) {
+	return nil, nil
+}
 func (noopPluginManager) PolicyChecker(context.Context, *plugin.Config) (definition.PolicyChecker, error) {
 	return nil, nil
 }
-func (noopPluginManager) Cache(context.Context, *plugin.Config) (definition.Cache, error) { return nil, nil }
+func (noopPluginManager) Cache(context.Context, *plugin.Config) (definition.Cache, error) {
+	return nil, nil
+}
 func (noopPluginManager) Registry(context.Context, *plugin.Config) (definition.RegistryLookup, error) {
 	return nil, nil
 }
@@ -61,6 +70,48 @@ func TestNewStdHandler_CheckPolicyStepWithoutPluginFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "PolicyChecker plugin not configured") {
 		t.Fatalf("expected explicit PolicyChecker config error, got: %v", err)
+	}
+}
+
+func TestStepCtxPropagatesBecknVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestCtx  context.Context
+		wantVersion string
+	}{
+		{
+			name:        "version absent",
+			requestCtx:  context.Background(),
+			wantVersion: "",
+		},
+		{
+			name: "version present",
+			requestCtx: context.WithValue(
+				context.Background(),
+				model.ContextKeyBecknVersion,
+				"2.0.0",
+			),
+			wantVersion: "2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stdHandler{role: model.RoleBAP, SubscriberID: "fallback-subscriber"}
+			req, err := http.NewRequestWithContext(tt.requestCtx, http.MethodPost, "/", strings.NewReader(`{"context":{}}`))
+			if err != nil {
+				t.Fatalf("NewRequestWithContext() error = %v", err)
+			}
+
+			stepCtx, err := h.stepCtx(req, http.Header{})
+			if err != nil {
+				t.Fatalf("stepCtx() error = %v", err)
+			}
+
+			if stepCtx.BecknVersion != tt.wantVersion {
+				t.Fatalf("BecknVersion = %q, want %q", stepCtx.BecknVersion, tt.wantVersion)
+			}
+		})
 	}
 }
 

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -113,13 +113,14 @@ func (s *validateSignStep) Run(ctx *model.StepContext) error {
 	spanCtx, span := tracer.Start(ctx.Context, "validate-sign")
 	defer span.End()
 	stepCtx := &model.StepContext{
-		Context:    spanCtx,
-		Request:    ctx.Request,
-		Body:       ctx.Body,
-		Role:       ctx.Role,
-		SubID:      ctx.SubID,
-		RespHeader: ctx.RespHeader,
-		Route:      ctx.Route,
+		Context:      spanCtx,
+		Request:      ctx.Request,
+		Body:         ctx.Body,
+		Role:         ctx.Role,
+		BecknVersion: ctx.BecknVersion,
+		SubID:        ctx.SubID,
+		RespHeader:   ctx.RespHeader,
+		Route:        ctx.Route,
 	}
 	err := s.validateHeaders(stepCtx)
 	s.recordMetrics(stepCtx, err)

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -61,13 +61,14 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 
 	// run step with context that contains the step span
 	stepCtx := &model.StepContext{
-		Context:    spanCtx,
-		Request:    ctx.Request,
-		Body:       ctx.Body,
-		Role:       ctx.Role,
-		SubID:      ctx.SubID,
-		RespHeader: ctx.RespHeader,
-		Route:      ctx.Route,
+		Context:      spanCtx,
+		Request:      ctx.Request,
+		Body:         ctx.Body,
+		Role:         ctx.Role,
+		BecknVersion: ctx.BecknVersion,
+		SubID:        ctx.SubID,
+		RespHeader:   ctx.RespHeader,
+		Route:        ctx.Route,
 	}
 
 	start := time.Now()

--- a/core/module/handler/step_instrumentor_test.go
+++ b/core/module/handler/step_instrumentor_test.go
@@ -11,10 +11,12 @@ import (
 )
 
 type stubStep struct {
-	err error
+	err        error
+	gotVersion string
 }
 
-func (s stubStep) Run(ctx *model.StepContext) error {
+func (s *stubStep) Run(ctx *model.StepContext) error {
+	s.gotVersion = ctx.BecknVersion
 	return s.err
 }
 
@@ -24,14 +26,17 @@ func TestInstrumentedStepSuccess(t *testing.T) {
 	require.NoError(t, err)
 	defer provider.Shutdown(context.Background())
 
-	step, err := NewInstrumentedStep(stubStep{}, "test-step", "test-module")
+	stub := &stubStep{}
+	step, err := NewInstrumentedStep(stub, "test-step", "test-module")
 	require.NoError(t, err)
 
 	stepCtx := &model.StepContext{
-		Context: context.Background(),
-		Role:    model.RoleBAP,
+		Context:      context.Background(),
+		Role:         model.RoleBAP,
+		BecknVersion: "2.0.0",
 	}
 	require.NoError(t, step.Run(stepCtx))
+	require.Equal(t, "2.0.0", stub.gotVersion)
 }
 
 func TestInstrumentedStepError(t *testing.T) {
@@ -40,13 +45,15 @@ func TestInstrumentedStepError(t *testing.T) {
 	require.NoError(t, err)
 	defer provider.Shutdown(context.Background())
 
-	step, err := NewInstrumentedStep(stubStep{err: errors.New("boom")}, "test-step", "test-module")
+	stub := &stubStep{err: errors.New("boom")}
+	step, err := NewInstrumentedStep(stub, "test-step", "test-module")
 	require.NoError(t, err)
 
 	stepCtx := &model.StepContext{
-		Context: context.Background(),
-		Role:    model.RoleBAP,
+		Context:      context.Background(),
+		Role:         model.RoleBAP,
+		BecknVersion: "2.0.0-rc",
 	}
 	require.Error(t, step.Run(stepCtx))
+	require.Equal(t, "2.0.0-rc", stub.gotVersion)
 }
-

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -59,6 +59,9 @@ const (
 
 	// ContextKeyRemoteID is the context key for the caller who is calling the bap/bpp
 	ContextKeyRemoteID ContextKey = "remote_id"
+
+	// ContextKeyBecknVersion stores the Beckn protocol version for the request.
+	ContextKeyBecknVersion ContextKey = "beckn_version"
 )
 
 var contextKeys = map[string]ContextKey{
@@ -159,12 +162,13 @@ type Keyset struct {
 // StepContext holds context information for a request processing step.
 type StepContext struct {
 	context.Context
-	Request    *http.Request
-	Body       []byte
-	Route      *Route
-	SubID      string
-	Role       Role
-	RespHeader http.Header
+	Request      *http.Request
+	Body         []byte
+	Route        *Route
+	SubID        string
+	Role         Role
+	BecknVersion string
+	RespHeader   http.Header
 }
 
 // WithContext updates the existing StepContext with a new context.

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -78,6 +78,10 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				return
 			}
 
+			if becknVersion, ok := reqContext["version"].(string); ok && becknVersion != "" {
+				ctx = context.WithValue(ctx, model.ContextKeyBecknVersion, becknVersion)
+			}
+
 			// Resolve subscriber ID — checks snake_case key first, falls back to camelCase.
 			var subID any
 			switch cfg.Role {

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -122,6 +122,76 @@ func TestNewPreProcessorSuccessCases(t *testing.T) {
 	}
 }
 
+func TestNewPreProcessorBecknVersionPropagation(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestBody  map[string]any
+		wantBecknVer any
+	}{
+		{
+			name: "version absent",
+			requestBody: map[string]any{
+				"context": map[string]any{
+					"bap_id": "bap-123",
+				},
+			},
+			wantBecknVer: nil,
+		},
+		{
+			name: "version 2.0.0",
+			requestBody: map[string]any{
+				"context": map[string]any{
+					"bap_id":  "bap-123",
+					"version": "2.0.0",
+				},
+			},
+			wantBecknVer: "2.0.0",
+		},
+		{
+			name: "version 2.0.0-rc",
+			requestBody: map[string]any{
+				"context": map[string]any{
+					"bap_id":  "bap-123",
+					"version": "2.0.0-rc",
+				},
+			},
+			wantBecknVer: "2.0.0-rc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			middleware, err := NewPreProcessor(&Config{Role: "bap"})
+			if err != nil {
+				t.Fatalf("NewPreProcessor() error = %v", err)
+			}
+
+			bodyBytes, err := json.Marshal(tt.requestBody)
+			if err != nil {
+				t.Fatalf("Failed to marshal request body: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(bodyBytes))
+
+			rec := httptest.NewRecorder()
+			var gotBecknVersion any
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBecknVersion = r.Context().Value(model.ContextKeyBecknVersion)
+				w.WriteHeader(http.StatusOK)
+			})
+
+			middleware(handler).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", rec.Code)
+			}
+			if gotBecknVersion != tt.wantBecknVer {
+				t.Fatalf("beckn version: got %v, want %v", gotBecknVersion, tt.wantBecknVer)
+			}
+		})
+	}
+}
+
 func TestNewPreProcessorErrorCases(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

This PR parses `context.version` once in the request preprocessor and carries it through `StepContext` so downstream plugins can make transport decisions without re-parsing the request body.

## What changed

- Added `BecknVersion` to `pkg/model/StepContext`
- Parsed `context.version` in `pkg/plugin/implementation/reqpreprocessor`
- Copied the value through the handler and instrumentation StepContext clones
- Added tests for:
  - version present
  - version absent
  - `2.0.0`
  - `2.0.0-rc`

## Why

Beckn v2.0 LTS work needs a reliable way to distinguish LTS requests from pre-LTS traffic at runtime. The version has to be parsed once early in the pipeline and then made available everywhere else through `StepContext`.

## Validation

- `go test ./pkg/plugin/implementation/reqpreprocessor ./core/module/handler -count=1`
