### PR TITLE
fix(observability): downgrade disabled-audit log from WARN to DEBUG

### DIFF
--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -19,11 +19,11 @@ func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
 	// global.GetLoggerProvider() always returns a no-op provider (never nil),
 	// so a nil-check on the provider is ineffective. Instead we rely on the
 	// logEnabled atomic flag, which otelsetup sets to true after calling
-	// global.SetLoggerProvider with a real SDK provider. If logging was not
-	// configured, we warn and return early rather than silently dropping records
-	// into the no-op provider.
+	// global.SetLoggerProvider with a real SDK provider. Observability is
+	// optional, so a disabled logs path is expected in production — emit a
+	// debug breadcrumb rather than a warning to avoid per-request WARN noise.
 	if !LogsEnabled() {
-		logger.Warnf(ctx, "failed to emit audit logs, logs disabled")
+		logger.Debugf(ctx, "audit logs disabled, skipping emit")
 		return
 	}
 

--- a/pkg/telemetry/audit_test.go
+++ b/pkg/telemetry/audit_test.go
@@ -1,7 +1,10 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
 	"testing"
 
 	"go.opentelemetry.io/otel/log"
@@ -34,10 +37,23 @@ func TestEmitAuditLogs_Disabled(t *testing.T) {
 
 	SetLogsEnabled(false)
 
-	// Should return early without panicking.
+	// Capture stdout to assert the disabled path emits no WARN.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
 	require.NotPanics(t, func() {
 		EmitAuditLogs(context.Background(), []byte(`{"message":"test"}`))
 	}, "EmitAuditLogs should not panic when logs are disabled")
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = oldStdout
+
+	assert.NotContains(t, buf.String(), `"level":"warn"`,
+		"disabled path must not emit a WARN log on every request")
 }
 
 func TestEmitAuditLogs_Enabled(t *testing.T) {


### PR DESCRIPTION
## What changed
- `EmitAuditLogs` now calls `logger.Debugf` instead of `logger.Warnf` when `LogsEnabled()` is false.
- Updated the code comment to explain that observability is optional and the disabled path is an expected production state.
- `TestEmitAuditLogs_Disabled` now captures stdout and asserts no `"level":"warn"` entry is emitted, providing real regression protection.

## Why
`EmitAuditLogs` is called unconditionally on every request. When observability is not configured, the previous `Warnf` fired once per request — producing thousands of WARN entries per minute that tell operators nothing useful (telemetry being disabled is intentional, not an error).

A `Debugf` breadcrumb preserves diagnosability (enable debug logging to see why audit records aren't flowing) without generating WARN noise proportional to traffic.

## Validation
```
go test ./pkg/telemetry/... -count=1
```

## Notes
This supersedes #671 (same fix, correct direction) which has been inactive. The original contribution and review discussion are in that PR and issue #666.

Closes #666