### PR TITLE
fix(schemav2validator): read native Const field for OpenAPI 3.1 action extraction

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -384,7 +384,11 @@ func (v *schemav2Validator) extractActionFromSchema(schema *openapi3.Schema) str
 // getActionValue extracts action value from context schema.
 func (v *schemav2Validator) getActionValue(contextSchema *openapi3.Schema) string {
 	if actionProp := contextSchema.Properties["action"]; actionProp != nil && actionProp.Value != nil {
-		// Check const field
+		// Native OpenAPI 3.1 const (kin-openapi >= v0.137 parses this into the typed field).
+		if action, ok := actionProp.Value.Const.(string); ok && action != "" {
+			return action
+		}
+		// Fallback: older kin-openapi versions surfaced const via Extensions.
 		if constVal, ok := actionProp.Value.Extensions["const"]; ok {
 			if action, ok := constVal.(string); ok {
 				return action


### PR DESCRIPTION
Closes #701 

## Summary
- After #696 bumped kin-openapi v0.133 → v0.137, OpenAPI 3.1 `const` is now parsed into the typed `Schema.Const` field instead of landing in `Extensions`. The action extractor in `schemav2validator` only read `Extensions["const"]`, so every action declared with `const:` (select, init, confirm, status, on_status, …) silently failed to index. Live BAP/BPP traffic NACKed with `BAD Request: unsupported action: <action>`. Only `enum:`-declared actions still worked.
- Read `Schema.Const` first; keep `Extensions["const"]` as a fallback so older kin-openapi versions still work.

## Repro
The existing `TestValidate_ActionExtraction/valid_search_action` test (which uses `const: search` against an `openapi: 3.1.0` doc) reproduces the regression on `main`:

```
$ go test ./pkg/plugin/implementation/schemav2validator/ -run TestValidate_ActionExtraction/valid_search_action -v
--- FAIL: TestValidate_ActionExtraction/valid_search_action
    schemav2validator_test.go:144: Validate() error = unsupported action: search, wantErr false
```

With this change the test passes.

End-to-end verified by rebuilding the DEG demand-flex devkit's onix-adapter image against this branch and running its Arazzo workflows — `select` / `init` / `confirm` / `update` / `status` / `on_status` all index and ACK; container logs show `25 actions indexed` (was `3`).

## Test plan
- [x] `go test ./pkg/plugin/implementation/schemav2validator/...` passes
- [x] Confirmed the existing test reproduces the regression on `main` and is green on this branch
- [x] DEG demand-flex Arazzo flows return ACK end-to-end against an image built from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)