### PR TITLE
Feat/local schema support

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -40,8 +40,22 @@ schemaValidator:
 | `extendedSchema_maxCacheSize` | string | No | "100" | Maximum number of cached domain schemas |
 | `extendedSchema_downloadTimeout` | string | No | "30" | Timeout for downloading domain schemas |
 | `extendedSchema_allowedDomains` | string | No | "" | Comma-separated domain whitelist (empty = all allowed) |
+| `extendedSchema_localSchemaPath` | string | No | "" | Path to local schema directory; schemas preloaded at startup, network used as fallback |
 
+### Local Schema Directory Layout
 
+When `extendedSchema_localSchemaPath` is set, schemas are preloaded from that directory at startup. Each schema must follow this structure:
+
+```
+config/
+ schema/
+  <TypeName>/
+    attributes.yaml
+  <AnotherType>/
+    attributes.yaml
+```
+
+A startup warning is logged if no schemas are found, which usually means the directory path is wrong or the layout doesn't match the expected structure.
 
 ## How It Works
 

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
@@ -66,6 +66,9 @@ func (vp schemav2ValidatorProvider) New(ctx context.Context, config map[string]s
 		if v, ok := config["extendedSchema_allowedDomains"]; ok && v != "" {
 			cfg.ExtendedSchemaConfig.AllowedDomains = strings.Split(v, ",")
 		}
+		if v, ok := config["extendedSchema_devTest"]; ok {
+			cfg.ExtendedSchemaConfig.DevTest = v == "true"
+		}
 
 	}
 

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
@@ -66,8 +66,8 @@ func (vp schemav2ValidatorProvider) New(ctx context.Context, config map[string]s
 		if v, ok := config["extendedSchema_allowedDomains"]; ok && v != "" {
 			cfg.ExtendedSchemaConfig.AllowedDomains = strings.Split(v, ",")
 		}
-		if v, ok := config["extendedSchema_devTest"]; ok {
-			cfg.ExtendedSchemaConfig.DevTest = v == "true"
+		if v, ok := config["extendedSchema_localSchemaPath"]; ok && v != "" {
+			cfg.ExtendedSchemaConfig.LocalSchemaPath = v
 		}
 
 	}

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -18,9 +18,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// localSchemaBasePath is the base directory for local schema files in dev/test mode.
-const localSchemaBasePath = "config/schema"
-
 func extractRelativeSchemaPath(u *url.URL) string {
 	const marker = "/schema/"
 	var pathPart string
@@ -36,7 +33,7 @@ func extractRelativeSchemaPath(u *url.URL) string {
 			continue
 		}
 		ext := filepath.Ext(seg)
-		if ext == ".yaml" || ext == ".yml" || ext == ".json" {
+		if ext == ".yaml" || ext == ".yml" || ext == ".json" || ext == ".jsonld" {
 			continue
 		}
 		if isSchemaVersionSegment(seg) {
@@ -73,7 +70,7 @@ type ExtendedSchemaConfig struct {
 	MaxCacheSize    int      // default 100
 	DownloadTimeout int      // seconds, default 30
 	AllowedDomains  []string // whitelist (empty = all allowed)
-	DevTest         bool     // when true, preload schemas from disk into memory at startup and serve from memory
+	LocalSchemaPath string   // when non-empty, preload schemas from this directory; network is fallback
 }
 
 // referencedObject represents a domain-specific object with @context.
@@ -114,7 +111,7 @@ func rawSchemaKey(rel string) string {
 	return filepath.ToSlash(rel)
 }
 
-func PreloadSchemasToCache(ctx context.Context, c *schemaCache, baseDir string) error {
+func preloadSchemasToCache(ctx context.Context, c *schemaCache, baseDir string) error {
 	count := 0
 	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -132,7 +129,9 @@ func PreloadSchemasToCache(ctx context.Context, c *schemaCache, baseDir string) 
 			return fmt.Errorf("failed to compute relative path for %s: %w", path, relErr)
 		}
 		key := rawSchemaKey(rel)
+		c.mu.Lock()
 		c.rawSchemas[key] = data
+		c.mu.Unlock()
 		count++
 		log.Debugf(ctx, "Preloaded schema to memory: %s", key)
 		return nil
@@ -181,15 +180,17 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 	}
 	allowedDomains = refConfig.AllowedDomains
 
-	log.Debugf(ctx, "Extended Schema config: ttl=%v, timeout=%v, allowedDomains=%v, devTest=%v",
-		ttl, timeout, allowedDomains, refConfig.DevTest)
+	log.Debugf(ctx, "Extended Schema config: ttl=%v, timeout=%v, allowedDomains=%v, localSchemaPath=%v",
+		ttl, timeout, allowedDomains, refConfig.LocalSchemaPath)
+
+	localSchema := refConfig.LocalSchemaPath != ""
 
 	// Validate each object
 	for _, obj := range objects {
 		log.Debugf(ctx, "Validating object at path: %s, @context: %s, @type: %s",
 			obj.Path, obj.Context, obj.Type)
 
-		if err := v.schemaCache.validateReferencedObject(ctx, obj, ttl, timeout, allowedDomains, refConfig.DevTest); err != nil {
+		if err := v.schemaCache.validateReferencedObject(ctx, obj, ttl, timeout, allowedDomains, localSchema); err != nil {
 			var schemaErrors []model.Error
 			v.extractSchemaErrors(err, &schemaErrors)
 
@@ -302,7 +303,7 @@ func (c *schemaCache) cleanupExpired() int {
 	return len(expired)
 }
 
-func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string, ttl, timeout time.Duration, devTest bool) (*openapi3.T, error) {
+func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string, ttl, timeout time.Duration, localSchema bool) (*openapi3.T, error) {
 	urlHash := hashURL(schemaPath)
 
 	u, parseErr := url.Parse(schemaPath)
@@ -316,8 +317,13 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 	var doc *openapi3.T
 	var err error
 
-	// Step 1: rawSchemas — preloaded local schemas, only consulted when devTest is enabled.
-	if devTest {
+	// Schema lookup chain:
+	//   1. rawSchemas — in-memory preloaded schemas, keyed by TypeName/attributes.yaml (localSchema mode only)
+	//   2. LRU schemaCache — previously parsed docs, keyed by URL hash
+	//   3. Network — fetched from the @context URL (http/https) or local filesystem
+
+	// Step 1: rawSchemas — preloaded local schemas, only consulted when localSchema is enabled.
+	if localSchema {
 		relPath := extractRelativeSchemaPath(u)
 		if schemaBytes, ok := c.rawSchemas[relPath]; ok {
 			log.Debugf(ctx, "Loading from memory: %s -> %s", schemaPath, relPath)
@@ -482,23 +488,31 @@ func (c *schemaCache) validateReferencedObject(
 	obj referencedObject,
 	ttl, timeout time.Duration,
 	allowedDomains []string,
-	devTest bool,
+	localSchema bool,
 ) error {
-	if !devTest && !isAllowedDomain(obj.Context, allowedDomains) {
-		log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
-		return fmt.Errorf("domain not allowed: %s", obj.Context)
-	}
-
 	var doc *openapi3.T
 
-	// DevTest: try @type-based rawSchemas lookup first.
-	if devTest {
-		doc, _ = c.loadSchemaFromPath(ctx, obj.Type+"/attributes.yaml", ttl, timeout, devTest)
+	if localSchema {
+		typeName := obj.Type
+		if idx := strings.LastIndex(typeName, ":"); idx >= 0 {
+			typeName = typeName[idx+1:]
+		}
+		if typeName != "" && !strings.ContainsAny(typeName, "/\\") {
+			if localDoc, localErr := c.loadSchemaFromPath(ctx, typeName+"/attributes.yaml", ttl, timeout, localSchema); localErr != nil {
+				log.Debugf(ctx, "local @type lookup failed for %s: %v", obj.Type, localErr)
+			} else {
+				doc = localDoc
+			}
+		}
 	}
 
 	if doc == nil {
+		if !isAllowedDomain(obj.Context, allowedDomains) {
+			log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
+			return fmt.Errorf("domain not allowed: %s", obj.Context)
+		}
 		schemaPath := transformContextToSchemaURL(obj.Context)
-		log.Debugf(ctx, "Transformed %s -> %s (devTest=%v)", obj.Context, schemaPath, devTest)
+		log.Debugf(ctx, "Transformed %s -> %s (localSchema=%v)", obj.Context, schemaPath, localSchema)
 		var err error
 		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
 		if err != nil {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -5,7 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -15,12 +18,62 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// localSchemaBasePath is the base directory for local schema files in dev/test mode.
+const localSchemaBasePath = "config/schema"
+
+func extractRelativeSchemaPath(u *url.URL) string {
+	const marker = "/schema/"
+	var pathPart string
+	if idx := strings.LastIndex(u.Path, marker); idx != -1 {
+		pathPart = u.Path[idx+len(marker):]
+	} else {
+		pathPart = strings.TrimPrefix(u.Path, "/")
+	}
+
+	var typeName string
+	for _, seg := range strings.Split(pathPart, "/") {
+		if seg == "" {
+			continue
+		}
+		ext := filepath.Ext(seg)
+		if ext == ".yaml" || ext == ".yml" || ext == ".json" {
+			continue
+		}
+		if isSchemaVersionSegment(seg) {
+			continue
+		}
+		typeName = seg
+	}
+	return typeName + "/attributes.yaml"
+}
+
+// isSchemaVersionSegment returns true for path segments that are version identifiers
+func isSchemaVersionSegment(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	check := s
+	if check[0] == 'v' || check[0] == 'V' {
+		check = check[1:]
+	}
+	if len(check) == 0 {
+		return false
+	}
+	for _, c := range check {
+		if c != '.' && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
 // ExtendedSchemaConfig holds configuration for referenced schema validation.
 type ExtendedSchemaConfig struct {
 	CacheTTL        int      // seconds, default 86400 (24h)
 	MaxCacheSize    int      // default 100
 	DownloadTimeout int      // seconds, default 30
 	AllowedDomains  []string // whitelist (empty = all allowed)
+	DevTest         bool     // when true, preload schemas from disk into memory at startup and serve from memory
 }
 
 // referencedObject represents a domain-specific object with @context.
@@ -33,9 +86,10 @@ type referencedObject struct {
 
 // schemaCache caches loaded domain schemas with LRU eviction.
 type schemaCache struct {
-	mu      sync.RWMutex
-	schemas map[string]*cachedDomainSchema
-	maxSize int
+	mu         sync.RWMutex
+	schemas    map[string]*cachedDomainSchema
+	rawSchemas map[string][]byte // preloaded raw YAML bytes keyed by "TypeName/attributes.yaml"
+	maxSize    int
 }
 
 // cachedDomainSchema holds a cached domain schema with metadata.
@@ -50,6 +104,44 @@ type cachedDomainSchema struct {
 // isCoreSchema checks if @context URL is a core Beckn schema.
 func isCoreSchema(contextURL string) bool {
 	return strings.Contains(contextURL, "/schema/core/")
+}
+
+func rawSchemaKey(rel string) string {
+	parts := strings.SplitN(filepath.ToSlash(rel), "/", 3)
+	if len(parts) == 3 {
+		return parts[0] + "/" + parts[2]
+	}
+	return filepath.ToSlash(rel)
+}
+
+func PreloadSchemasToCache(ctx context.Context, c *schemaCache, baseDir string) error {
+	count := 0
+	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return fmt.Errorf("failed to read %s: %w", path, readErr)
+		}
+		rel, relErr := filepath.Rel(baseDir, path)
+		if relErr != nil {
+			return fmt.Errorf("failed to compute relative path for %s: %w", path, relErr)
+		}
+		key := rawSchemaKey(rel)
+		c.rawSchemas[key] = data
+		count++
+		log.Debugf(ctx, "Preloaded schema to memory: %s", key)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("schema preload failed: %w", err)
+	}
+	log.Infof(ctx, "Preloaded %d schemas to memory from %s", count, baseDir)
+	return nil
 }
 
 // validateExtendedSchemas validates all objects with @context against their schemas.
@@ -89,16 +181,15 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 	}
 	allowedDomains = refConfig.AllowedDomains
 
-	log.Debugf(ctx, "Extended Schema config: ttl=%v, timeout=%v, allowedDomains=%v",
-		ttl, timeout, allowedDomains)
+	log.Debugf(ctx, "Extended Schema config: ttl=%v, timeout=%v, allowedDomains=%v, devTest=%v",
+		ttl, timeout, allowedDomains, refConfig.DevTest)
 
 	// Validate each object
 	for _, obj := range objects {
 		log.Debugf(ctx, "Validating object at path: %s, @context: %s, @type: %s",
 			obj.Path, obj.Context, obj.Type)
 
-		if err := v.schemaCache.validateReferencedObject(ctx, obj, ttl, timeout, allowedDomains); err != nil {
-			// Extract and prefix error paths
+		if err := v.schemaCache.validateReferencedObject(ctx, obj, ttl, timeout, allowedDomains, refConfig.DevTest); err != nil {
 			var schemaErrors []model.Error
 			v.extractSchemaErrors(err, &schemaErrors)
 
@@ -121,8 +212,9 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 // newSchemaCache creates a new schema cache.
 func newSchemaCache(maxSize int) *schemaCache {
 	return &schemaCache{
-		schemas: make(map[string]*cachedDomainSchema),
-		maxSize: maxSize,
+		schemas:    make(map[string]*cachedDomainSchema),
+		rawSchemas: make(map[string][]byte),
+		maxSize:    maxSize,
 	}
 }
 
@@ -210,8 +302,7 @@ func (c *schemaCache) cleanupExpired() int {
 	return len(expired)
 }
 
-// loadSchemaFromPath loads a schema from URL or local file with timeout and caching.
-func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string, ttl, timeout time.Duration) (*openapi3.T, error) {
+func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string, ttl, timeout time.Duration, devTest bool) (*openapi3.T, error) {
 	urlHash := hashURL(schemaPath)
 
 	// Check cache first
@@ -222,31 +313,64 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 
 	log.Debugf(ctx, "Schema cache miss, loading from: %s", schemaPath)
 
-	// Validate path format
-	if !isValidSchemaPath(schemaPath) {
-		return nil, fmt.Errorf("invalid schema path: %s", schemaPath)
-	}
-
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 
 	var doc *openapi3.T
 	var err error
 
-	u, parseErr := url.Parse(schemaPath)
-	if parseErr == nil && (u.Scheme == "http" || u.Scheme == "https") {
-		// Load from URL with timeout
-		loadCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-		loader.Context = loadCtx
-		doc, err = loader.LoadFromURI(u)
-	} else {
-		// Load from local file (file:// or path)
-		filePath := schemaPath
-		if u != nil && u.Scheme == "file" {
-			filePath = u.Path
+	if devTest {
+		u, parseErr := url.Parse(schemaPath)
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse schema URL %s: %w", schemaPath, parseErr)
 		}
-		doc, err = loader.LoadFromFile(filePath)
+		relPath := extractRelativeSchemaPath(u)
+		log.Debugf(ctx, "DevTest: loading from memory: %s -> %s", schemaPath, relPath)
+
+		schemaBytes, ok := c.rawSchemas[relPath]
+		if !ok {
+			return nil, fmt.Errorf("failed to load schema from %s: schema not found in memory (key %s)", schemaPath, relPath)
+		}
+
+		loader.ReadFromURIFunc = func(l *openapi3.Loader, refURL *url.URL) ([]byte, error) {
+			var refRelPath string
+			switch refURL.Scheme {
+			case "http", "https", "file":
+				refRelPath = extractRelativeSchemaPath(refURL)
+			default:
+				refRelPath = strings.TrimPrefix(refURL.Path, localSchemaBasePath+"/")
+			}
+			log.Debugf(ctx, "DevTest: resolving $ref %s -> %s", refURL.String(), refRelPath)
+			data, ok := c.rawSchemas[refRelPath]
+			if !ok {
+				return nil, fmt.Errorf("$ref schema not found in memory (key %s)", refRelPath)
+			}
+			return data, nil
+		}
+
+		baseURL := &url.URL{Scheme: "https", Host: "schema.beckn.io", Path: "/" + relPath}
+		doc, err = loader.LoadFromDataWithPath(schemaBytes, baseURL)
+
+	} else {
+		if !isValidSchemaPath(schemaPath) {
+			return nil, fmt.Errorf("invalid schema path: %s", schemaPath)
+		}
+
+		u, parseErr := url.Parse(schemaPath)
+		if parseErr == nil && (u.Scheme == "http" || u.Scheme == "https") {
+			// Load from URL with timeout
+			loadCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			loader.Context = loadCtx
+			doc, err = loader.LoadFromURI(u)
+		} else {
+			// Load from local file (file:// or path)
+			filePath := schemaPath
+			if u != nil && u.Scheme == "file" {
+				filePath = u.Path
+			}
+			doc, err = loader.LoadFromFile(filePath)
+		}
 	}
 
 	if err != nil {
@@ -265,7 +389,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 	return doc, nil
 }
 
-// findReferencedObjects recursively finds domain-specific objects with @context .
+// findReferencedObjects recursively finds domain-specific objects with @context.
 func findReferencedObjects(data interface{}, path string) []referencedObject {
 	var results []referencedObject
 
@@ -353,25 +477,38 @@ func isAllowedDomain(schemaURL string, allowedDomains []string) bool {
 	return false
 }
 
+// typeNameFromAtType strips any namespace prefix from an @type value.
+func typeNameFromAtType(atType string) string {
+	if idx := strings.LastIndex(atType, ":"); idx != -1 {
+		return atType[idx+1:]
+	}
+	return atType
+}
+
 // validateReferencedObject validates a single object with @context.
 func (c *schemaCache) validateReferencedObject(
 	ctx context.Context,
 	obj referencedObject,
 	ttl, timeout time.Duration,
 	allowedDomains []string,
+	devTest bool,
 ) error {
-	// Domain whitelist check
-	if !isAllowedDomain(obj.Context, allowedDomains) {
+	if !devTest && !isAllowedDomain(obj.Context, allowedDomains) {
 		log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
 		return fmt.Errorf("domain not allowed: %s", obj.Context)
 	}
 
-	// Transform @context to schema path (URL or file)
-	schemaPath := transformContextToSchemaURL(obj.Context)
-	log.Debugf(ctx, "Transformed %s -> %s", obj.Context, schemaPath)
+	var schemaPath string
+	if devTest {
+		// Use @type directly as the schema name — no URL parsing needed.
+		schemaPath = typeNameFromAtType(obj.Type) + "/attributes.yaml"
+		log.Debugf(ctx, "DevTest: using @type %q -> schema path %s", obj.Type, schemaPath)
+	} else {
+		schemaPath = transformContextToSchemaURL(obj.Context)
+		log.Debugf(ctx, "Transformed %s -> %s", obj.Context, schemaPath)
+	}
 
-	// Load schema with timeout (supports URL or local file)
-	doc, err := c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout)
+	doc, err := c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, devTest)
 	if err != nil {
 		return fmt.Errorf("at %s: %w", obj.Path, err)
 	}

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -88,7 +88,7 @@ type referencedObject struct {
 type schemaCache struct {
 	mu         sync.RWMutex
 	schemas    map[string]*cachedDomainSchema
-	rawSchemas map[string][]byte // preloaded raw YAML bytes keyed by "TypeName/attributes.yaml"
+	rawSchemas map[string][]byte // preloaded raw YAML bytes
 	maxSize    int
 }
 
@@ -305,13 +305,10 @@ func (c *schemaCache) cleanupExpired() int {
 func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string, ttl, timeout time.Duration, devTest bool) (*openapi3.T, error) {
 	urlHash := hashURL(schemaPath)
 
-	// Check cache first
-	if doc, found := c.get(urlHash); found {
-		log.Debugf(ctx, "Schema cache hit for: %s", schemaPath)
-		return doc, nil
+	u, parseErr := url.Parse(schemaPath)
+	if parseErr != nil {
+		return nil, fmt.Errorf("failed to parse schema URL %s: %w", schemaPath, parseErr)
 	}
-
-	log.Debugf(ctx, "Schema cache miss, loading from: %s", schemaPath)
 
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
@@ -319,58 +316,60 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 	var doc *openapi3.T
 	var err error
 
+	// Step 1: rawSchemas — preloaded local schemas, only consulted when devTest is enabled.
 	if devTest {
-		u, parseErr := url.Parse(schemaPath)
-		if parseErr != nil {
-			return nil, fmt.Errorf("failed to parse schema URL %s: %w", schemaPath, parseErr)
-		}
 		relPath := extractRelativeSchemaPath(u)
-		log.Debugf(ctx, "DevTest: loading from memory: %s -> %s", schemaPath, relPath)
+		if schemaBytes, ok := c.rawSchemas[relPath]; ok {
+			log.Debugf(ctx, "Loading from memory: %s -> %s", schemaPath, relPath)
 
-		schemaBytes, ok := c.rawSchemas[relPath]
-		if !ok {
-			return nil, fmt.Errorf("failed to load schema from %s: schema not found in memory (key %s)", schemaPath, relPath)
-		}
-
-		loader.ReadFromURIFunc = func(l *openapi3.Loader, refURL *url.URL) ([]byte, error) {
-			var refRelPath string
-			switch refURL.Scheme {
-			case "http", "https", "file":
-				refRelPath = extractRelativeSchemaPath(refURL)
-			default:
-				refRelPath = strings.TrimPrefix(refURL.Path, localSchemaBasePath+"/")
+			// $ref lookups: memory first, network fallback.
+			loader.ReadFromURIFunc = func(l *openapi3.Loader, refURL *url.URL) ([]byte, error) {
+				refRelPath := extractRelativeSchemaPath(refURL)
+				if data, ok := c.rawSchemas[refRelPath]; ok {
+					log.Debugf(ctx, "$ref from memory: %s -> %s", refURL.String(), refRelPath)
+					return data, nil
+				}
+				log.Debugf(ctx, "$ref not in memory, fetching from network: %s", refURL.String())
+				return openapi3.DefaultReadFromURI(l, refURL)
 			}
-			log.Debugf(ctx, "DevTest: resolving $ref %s -> %s", refURL.String(), refRelPath)
-			data, ok := c.rawSchemas[refRelPath]
-			if !ok {
-				return nil, fmt.Errorf("$ref schema not found in memory (key %s)", refRelPath)
+
+			baseURL := &url.URL{Scheme: "https", Host: "schema.beckn.io", Path: "/" + relPath}
+			doc, err = loader.LoadFromDataWithPath(schemaBytes, baseURL)
+			if err != nil {
+				log.Errorf(ctx, err, "Failed to load schema from memory: %s", schemaPath)
+				return nil, fmt.Errorf("failed to load schema from %s: %w", schemaPath, err)
 			}
-			return data, nil
+			if err := doc.Validate(ctx); err != nil {
+				log.Debugf(ctx, "Schema validation warnings for %s: %v", schemaPath, err)
+			}
+			c.set(urlHash, doc, ttl)
+			log.Debugf(ctx, "Loaded and cached schema from memory: %s", schemaPath)
+			return doc, nil
 		}
+	}
 
-		baseURL := &url.URL{Scheme: "https", Host: "schema.beckn.io", Path: "/" + relPath}
-		doc, err = loader.LoadFromDataWithPath(schemaBytes, baseURL)
+	// Step 2: LRU schemaCache — previously parsed docs.
+	if doc, found := c.get(urlHash); found {
+		log.Debugf(ctx, "Schema LRU cache hit for: %s", schemaPath)
+		return doc, nil
+	}
 
+	// Step 3: Network — fetch from @context URL.
+	log.Debugf(ctx, "Schema not in memory or cache, fetching from network: %s", schemaPath)
+	if !isValidSchemaPath(schemaPath) {
+		return nil, fmt.Errorf("invalid schema path: %s", schemaPath)
+	}
+	if u.Scheme == "http" || u.Scheme == "https" {
+		loadCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		loader.Context = loadCtx
+		doc, err = loader.LoadFromURI(u)
 	} else {
-		if !isValidSchemaPath(schemaPath) {
-			return nil, fmt.Errorf("invalid schema path: %s", schemaPath)
+		filePath := schemaPath
+		if u.Scheme == "file" {
+			filePath = u.Path
 		}
-
-		u, parseErr := url.Parse(schemaPath)
-		if parseErr == nil && (u.Scheme == "http" || u.Scheme == "https") {
-			// Load from URL with timeout
-			loadCtx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
-			loader.Context = loadCtx
-			doc, err = loader.LoadFromURI(u)
-		} else {
-			// Load from local file (file:// or path)
-			filePath := schemaPath
-			if u != nil && u.Scheme == "file" {
-				filePath = u.Path
-			}
-			doc, err = loader.LoadFromFile(filePath)
-		}
+		doc, err = loader.LoadFromFile(filePath)
 	}
 
 	if err != nil {
@@ -477,14 +476,6 @@ func isAllowedDomain(schemaURL string, allowedDomains []string) bool {
 	return false
 }
 
-// typeNameFromAtType strips any namespace prefix from an @type value.
-func typeNameFromAtType(atType string) string {
-	if idx := strings.LastIndex(atType, ":"); idx != -1 {
-		return atType[idx+1:]
-	}
-	return atType
-}
-
 // validateReferencedObject validates a single object with @context.
 func (c *schemaCache) validateReferencedObject(
 	ctx context.Context,
@@ -498,19 +489,21 @@ func (c *schemaCache) validateReferencedObject(
 		return fmt.Errorf("domain not allowed: %s", obj.Context)
 	}
 
-	var schemaPath string
+	var doc *openapi3.T
+
+	// DevTest: try @type-based rawSchemas lookup first.
 	if devTest {
-		// Use @type directly as the schema name — no URL parsing needed.
-		schemaPath = typeNameFromAtType(obj.Type) + "/attributes.yaml"
-		log.Debugf(ctx, "DevTest: using @type %q -> schema path %s", obj.Type, schemaPath)
-	} else {
-		schemaPath = transformContextToSchemaURL(obj.Context)
-		log.Debugf(ctx, "Transformed %s -> %s", obj.Context, schemaPath)
+		doc, _ = c.loadSchemaFromPath(ctx, obj.Type+"/attributes.yaml", ttl, timeout, devTest)
 	}
 
-	doc, err := c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, devTest)
-	if err != nil {
-		return fmt.Errorf("at %s: %w", obj.Path, err)
+	if doc == nil {
+		schemaPath := transformContextToSchemaURL(obj.Context)
+		log.Debugf(ctx, "Transformed %s -> %s (devTest=%v)", obj.Context, schemaPath, devTest)
+		var err error
+		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
+		if err != nil {
+			return fmt.Errorf("at %s: %w", obj.Path, err)
+		}
 	}
 
 	// Find schema by @type

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -139,7 +139,11 @@ func preloadSchemasToCache(ctx context.Context, c *schemaCache, baseDir string) 
 	if err != nil {
 		return fmt.Errorf("schema preload failed: %w", err)
 	}
-	log.Infof(ctx, "Preloaded %d schemas to memory from %s", count, baseDir)
+	if count == 0 {
+		log.Warnf(ctx, "No schemas loaded from %s — expected layout: TypeName/attributes.yaml", baseDir)
+	} else {
+		log.Infof(ctx, "Preloaded %d schemas to memory from %s", count, baseDir)
+	}
 	return nil
 }
 
@@ -325,13 +329,19 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 	// Step 1: rawSchemas — preloaded local schemas, only consulted when localSchema is enabled.
 	if localSchema {
 		relPath := extractRelativeSchemaPath(u)
-		if schemaBytes, ok := c.rawSchemas[relPath]; ok {
+		c.mu.RLock()
+		schemaBytes, ok := c.rawSchemas[relPath]
+		c.mu.RUnlock()
+		if ok {
 			log.Debugf(ctx, "Loading from memory: %s -> %s", schemaPath, relPath)
 
 			// $ref lookups: memory first, network fallback.
 			loader.ReadFromURIFunc = func(l *openapi3.Loader, refURL *url.URL) ([]byte, error) {
 				refRelPath := extractRelativeSchemaPath(refURL)
-				if data, ok := c.rawSchemas[refRelPath]; ok {
+				c.mu.RLock()
+				data, ok := c.rawSchemas[refRelPath]
+				c.mu.RUnlock()
+				if ok {
 					log.Debugf(ctx, "$ref from memory: %s -> %s", refURL.String(), refRelPath)
 					return data, nil
 				}
@@ -339,8 +349,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 				return openapi3.DefaultReadFromURI(l, refURL)
 			}
 
-			baseURL := &url.URL{Scheme: "https", Host: "schema.beckn.io", Path: "/" + relPath}
-			doc, err = loader.LoadFromDataWithPath(schemaBytes, baseURL)
+			doc, err = loader.LoadFromData(schemaBytes)
 			if err != nil {
 				log.Errorf(ctx, err, "Failed to load schema from memory: %s", schemaPath)
 				return nil, fmt.Errorf("failed to load schema from %s: %w", schemaPath, err)

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -261,11 +261,13 @@ func TestNewSchemaCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cache := newSchemaCache(tt.maxSize)
-			
+
 			assert.NotNil(t, cache)
 			assert.Equal(t, tt.maxSize, cache.maxSize)
 			assert.NotNil(t, cache.schemas)
 			assert.Equal(t, 0, len(cache.schemas))
+			assert.NotNil(t, cache.rawSchemas)
+			assert.Equal(t, 0, len(cache.rawSchemas))
 		})
 	}
 }
@@ -467,7 +469,7 @@ components:
 	assert.NoError(t, err)
 	tmpFile.Close()
 	
-	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second)
+	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, doc)
 	assert.Equal(t, "3.1.0", doc.OpenAPI)
@@ -489,10 +491,10 @@ info:
 	tmpFile.Write([]byte(schemaContent))
 	tmpFile.Close()
 	
-	doc1, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second)
+	doc1, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, false)
 	assert.NoError(t, err)
-	
-	doc2, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second)
+
+	doc2, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, false)
 	assert.NoError(t, err)
 	
 	assert.Equal(t, doc1, doc2)
@@ -502,7 +504,7 @@ func TestLoadSchemaFromPath_InvalidPath(t *testing.T) {
 	cache := newSchemaCache(10)
 	ctx := context.Background()
 	
-	_, err := cache.loadSchemaFromPath(ctx, "/nonexistent/schema.yaml", 1*time.Hour, 30*time.Second)
+	_, err := cache.loadSchemaFromPath(ctx, "/nonexistent/schema.yaml", 1*time.Hour, 30*time.Second, false)
 	assert.Error(t, err)
 }
 
@@ -529,9 +531,9 @@ components:
 	tmpFile.Write([]byte(schemaContent))
 	tmpFile.Close()
 	
-	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second)
+	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, false)
 	assert.NoError(t, err)
-	
+
 	schema, err := findSchemaByType(ctx, doc, "TestType")
 	assert.NoError(t, err)
 	assert.NotNil(t, schema)
@@ -557,9 +559,9 @@ components:
 	tmpFile.Write([]byte(schemaContent))
 	tmpFile.Close()
 	
-	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second)
+	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, false)
 	assert.NoError(t, err)
-	
+
 	_, err = findSchemaByType(ctx, doc, "NonExistentType")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no schema found")
@@ -605,7 +607,7 @@ components:
 		},
 	}
 	
-	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil)
+	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
 	assert.NoError(t, err)
 }
 
@@ -648,7 +650,7 @@ components:
 		},
 	}
 	
-	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil)
+	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
 	assert.Error(t, err)
 }
 
@@ -665,7 +667,7 @@ func TestValidateReferencedObject_DomainNotAllowed(t *testing.T) {
 	
 	allowedDomains := []string{"trusted.com"}
 	
-	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains)
+	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "domain not allowed")
 }

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -2,7 +2,9 @@ package schemav2validator
 
 import (
 	"context"
+	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -708,4 +710,278 @@ func TestValidateExtendedSchemas_MissingMessage(t *testing.T) {
 	err := v.validateExtendedSchemas(ctx, body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'message' field")
+}
+
+func TestIsSchemaVersionSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		seg  string
+		want bool
+	}{
+		{name: "v1", seg: "v1", want: true},
+		{name: "v2.1", seg: "v2.1", want: true},
+		{name: "v1.2.3", seg: "v1.2.3", want: true},
+		{name: "V2 uppercase", seg: "V2", want: true},
+		{name: "1.0 no prefix", seg: "1.0", want: true},
+		{name: "bare v", seg: "v", want: false},
+		{name: "type name", seg: "JobType", want: false},
+		{name: "empty", seg: "", want: false},
+		{name: "v1beta", seg: "v1beta", want: false},
+		{name: "plain word", seg: "main", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSchemaVersionSegment(tt.seg))
+		})
+	}
+}
+
+func TestExtractRelativeSchemaPath(t *testing.T) {
+	tests := []struct {
+		name string
+		rawURL string
+		want string
+	}{
+		{
+			name:   "URL with /schema/ marker and version",
+			rawURL: "https://example.com/schema/JobType/v2.1/attributes.yaml",
+			want:   "JobType/attributes.yaml",
+		},
+		{
+			name:   "namespaced URL extracts last non-version segment",
+			rawURL: "https://example.com/schema/common/CodedValue/v2.1/attributes.yaml",
+			want:   "CodedValue/attributes.yaml",
+		},
+		{
+			name:   "GitHub raw URL without /schema/ marker",
+			rawURL: "https://raw.githubusercontent.com/org/repo/main/hiring-jobs/HiringJobResource/v2.1/attributes.yaml",
+			want:   "HiringJobResource/attributes.yaml",
+		},
+		{
+			name:   "context.jsonld URL",
+			rawURL: "https://example.com/schema/ChargingSession/v1/context.jsonld",
+			want:   "ChargingSession/attributes.yaml",
+		},
+		{
+			name:   "no version segment",
+			rawURL: "https://example.com/schema/JobType/attributes.yaml",
+			want:   "JobType/attributes.yaml",
+		},
+		{
+			name:   "bare key no scheme",
+			rawURL: "JobType/attributes.yaml",
+			want:   "JobType/attributes.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, extractRelativeSchemaPath(u))
+		})
+	}
+}
+
+func TestRawSchemaKey(t *testing.T) {
+	tests := []struct {
+		name string
+		rel  string
+		want string
+	}{
+		{
+			name: "2-part path unchanged",
+			rel:  "JobType/attributes.yaml",
+			want: "JobType/attributes.yaml",
+		},
+		{
+			name: "3-part path strips version segment",
+			rel:  "JobType/v2.1/attributes.yaml",
+			want: "JobType/attributes.yaml",
+		},
+		{
+			name: "3-part path with v1.0",
+			rel:  "AnotherType/v1.0/attributes.yaml",
+			want: "AnotherType/attributes.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rawSchemaKey(tt.rel))
+		})
+	}
+}
+
+func TestRawSchemaKey_ConsistentWithExtractRelativeSchemaPath(t *testing.T) {
+	cases := []struct {
+		fileRel   string
+		schemaURL string
+	}{
+		{
+			fileRel:   "JobType/v2.1/attributes.yaml",
+			schemaURL: "https://example.com/schema/JobType/v2.1/attributes.yaml",
+		},
+		{
+			fileRel:   "HiringJobResource/v2.1/attributes.yaml",
+			schemaURL: "https://raw.githubusercontent.com/org/repo/main/hiring-jobs/HiringJobResource/v2.1/attributes.yaml",
+		},
+	}
+	for _, c := range cases {
+		fileKey := rawSchemaKey(c.fileRel)
+		u, _ := url.Parse(c.schemaURL)
+		urlKey := extractRelativeSchemaPath(u)
+		assert.Equal(t, fileKey, urlKey, "key mismatch for %s", c.fileRel)
+	}
+}
+
+func TestPreloadSchemasToCache(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "schema-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	schemaContent := []byte(`openapi: 3.1.0
+info:
+  title: Test
+  version: 1.0.0`)
+
+	os.MkdirAll(filepath.Join(tmpDir, "TypeA", "v2.1"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "TypeA", "v2.1", "attributes.yaml"), schemaContent, 0644)
+
+	os.MkdirAll(filepath.Join(tmpDir, "TypeB", "v1.0"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "TypeB", "v1.0", "attributes.yaml"), schemaContent, 0644)
+
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	err = preloadSchemasToCache(ctx, cache, tmpDir)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(cache.rawSchemas))
+	assert.Contains(t, cache.rawSchemas, "TypeA/attributes.yaml")
+	assert.Contains(t, cache.rawSchemas, "TypeB/attributes.yaml")
+}
+
+func TestPreloadSchemasToCache_InvalidDir(t *testing.T) {
+	cache := newSchemaCache(10)
+	err := preloadSchemasToCache(context.Background(), cache, "/nonexistent/dir")
+	assert.Error(t, err)
+}
+
+func TestLoadSchemaFromPath_RawSchemasHit(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	schemaContent := `openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object`
+
+	cache.rawSchemas["TestType/attributes.yaml"] = []byte(schemaContent)
+
+	doc, err := cache.loadSchemaFromPath(ctx, "TestType/attributes.yaml", 1*time.Hour, 30*time.Second, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+	assert.Equal(t, "3.1.0", doc.OpenAPI)
+}
+
+func TestLoadSchemaFromPath_LRUHit(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	expected := &openapi3.T{OpenAPI: "3.1.0"}
+	cache.set(hashURL("TestType/attributes.yaml"), expected, 1*time.Hour)
+
+	// localSchema=false skips rawSchemas step, goes straight to LRU
+	doc, err := cache.loadSchemaFromPath(ctx, "TestType/attributes.yaml", 1*time.Hour, 30*time.Second, false)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, doc)
+}
+
+func TestLoadSchemaFromPath_LocalMissFallsBackToFile(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-schema-*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Write([]byte(`openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0`))
+	tmpFile.Close()
+
+	// rawSchemas empty, localSchema=true — local miss, falls through to file load
+	doc, err := cache.loadSchemaFromPath(ctx, tmpFile.Name(), 1*time.Hour, 30*time.Second, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+}
+
+func TestValidateReferencedObject_LocalSchemaHit(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	cache.rawSchemas["TestType/attributes.yaml"] = []byte(`openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object
+      properties:
+        field1:
+          type: string`)
+
+	obj := referencedObject{
+		Path: "message.test",
+		Type: "TestType",
+		Data: map[string]interface{}{
+			"@type":  "TestType",
+			"field1": "value1",
+		},
+	}
+
+	// localSchema=true, no @context — relies entirely on rawSchemas lookup by @type
+	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, true)
+	assert.NoError(t, err)
+}
+
+func TestValidateReferencedObject_LocalMissFallsBackToContext(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-schema-*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	tmpFile.Write([]byte(`openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object
+      properties:
+        field1:
+          type: string`))
+	tmpFile.Close()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: tmpFile.Name(),
+		Type:    "TestType",
+		Data: map[string]interface{}{
+			"@context": tmpFile.Name(),
+			"@type":    "TestType",
+			"field1":   "value1",
+		},
+	}
+
+	// rawSchemas empty, localSchema=true — local miss, falls back to @context file path
+	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, true)
+	assert.NoError(t, err)
 }

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -772,6 +772,11 @@ func TestExtractRelativeSchemaPath(t *testing.T) {
 			rawURL: "JobType/attributes.yaml",
 			want:   "JobType/attributes.yaml",
 		},
+		{
+			name:   "relative path with ../ segments",
+			rawURL: "../../../../common/VerificationSummary/v2.1/attributes.yaml",
+			want:   "VerificationSummary/attributes.yaml",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -843,11 +848,11 @@ info:
   title: Test
   version: 1.0.0`)
 
-	os.MkdirAll(filepath.Join(tmpDir, "TypeA", "v2.1"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "TypeA", "v2.1", "attributes.yaml"), schemaContent, 0644)
+	os.MkdirAll(filepath.Join(tmpDir, "TypeA"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "TypeA", "attributes.yaml"), schemaContent, 0644)
 
-	os.MkdirAll(filepath.Join(tmpDir, "TypeB", "v1.0"), 0755)
-	os.WriteFile(filepath.Join(tmpDir, "TypeB", "v1.0", "attributes.yaml"), schemaContent, 0644)
+	os.MkdirAll(filepath.Join(tmpDir, "TypeB"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "TypeB", "attributes.yaml"), schemaContent, 0644)
 
 	cache := newSchemaCache(10)
 	ctx := context.Background()

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -77,7 +77,16 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 		if config.ExtendedSchemaConfig.MaxCacheSize > 0 {
 			maxSize = config.ExtendedSchemaConfig.MaxCacheSize
 		}
+
 		v.schemaCache = newSchemaCache(maxSize)
+
+		if config.ExtendedSchemaConfig.DevTest {
+			log.Infof(ctx, "DevTest mode: preloading schemas from %s to memory", localSchemaBasePath)
+			if err := PreloadSchemasToCache(ctx, v.schemaCache, localSchemaBasePath); err != nil {
+				return nil, nil, fmt.Errorf("failed to preload schemas: %w", err)
+			}
+		}
+
 		log.Infof(ctx, "Initialized extended schema cache with max size: %d", maxSize)
 	}
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -80,9 +80,9 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 
 		v.schemaCache = newSchemaCache(maxSize)
 
-		if config.ExtendedSchemaConfig.DevTest {
-			log.Infof(ctx, "DevTest mode: preloading schemas from %s to memory", localSchemaBasePath)
-			if err := PreloadSchemasToCache(ctx, v.schemaCache, localSchemaBasePath); err != nil {
+		if p := config.ExtendedSchemaConfig.LocalSchemaPath; p != "" {
+			log.Warnf(ctx, "Local schema mode: preloading schemas from %s", p)
+			if err := preloadSchemasToCache(ctx, v.schemaCache, p); err != nil {
 				return nil, nil, fmt.Errorf("failed to preload schemas: %w", err)
 			}
 		}


### PR DESCRIPTION
Local Schema Support for Extended Schema Validation Summary

- Added PreloadSchemasToCache — when devTest: true, schemas are walked from config/schema/ at startup and stored in rawSchemas as TypeName/attributes.yaml keys.
- @type-first local lookup — in devTest mode, schema resolution tries TypeName/attributes.yaml directly against rawSchemas before touching the network. @context URL is used only as fallback for LRU cache and network fetch.
- Fixed namespaced $ref path resolution — rewrote extractRelativeSchemaPath to scan all path segments and take the last non-version, non-file segment as the type name. This fixes schemas with paths like common/CodedValue/v2.1/attributes.yaml that previously extracted common instead of CodedValue.
- $ref resolution in memory — when loading a schema from rawSchemas, the loader's ReadFromURIFunc is overridden to resolve $ref references from rawSchemas first, falling back to network only if not found locally.

**Lookup chain (devTest=true)**
@type → rawSchemas["TypeName/attributes.yaml"]
      → LRU cache (via @context URL)
      → Network fetch (via @context URL)
**Lookup chain (devTest=false)**
@context URL → LRU cache → Network fetch