### PR TITLE
fix(simplekeymanager): rename networkParticipant config key to subscriberId

### DIFF
--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -51,7 +51,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -60,12 +60,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bap.example.com
-            keyId: 76EU7LZ7gfqj13dWDKR1Uitnim11mCoxWBPdzLxUpAMBPVdANKgyFM
-            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
-            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
-            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
-            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            subscriberId: ev-charging.sandbox1.com
+            keyId: 76EU7PktCXdPoNEZBjmg4Eb25A2egsd5MYJ67Qxza7bJQFvBHCYxgk
+            signingPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
+            signingPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
+            encrPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
+            encrPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
         cache:
           id: cache
           config:
@@ -117,7 +117,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -126,12 +126,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bap.example.com
-            keyId: 76EU7LZ7gfqj13dWDKR1Uitnim11mCoxWBPdzLxUpAMBPVdANKgyFM
-            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
-            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
-            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
-            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            subscriberId: ev-charging.sandbox1.com
+            keyId: 76EU7PktCXdPoNEZBjmg4Eb25A2egsd5MYJ67Qxza7bJQFvBHCYxgk
+            signingPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
+            signingPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
+            encrPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
+            encrPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
         cache:
           id: cache
           config:

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -51,7 +51,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
+            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -60,12 +60,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            subscriberId: ev-charging.sandbox1.com
-            keyId: 76EU7PktCXdPoNEZBjmg4Eb25A2egsd5MYJ67Qxza7bJQFvBHCYxgk
-            signingPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
-            signingPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
-            encrPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
-            encrPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
+            subscriberId: bap.example.com
+            keyId: 76EU7LZ7gfqj13dWDKR1Uitnim11mCoxWBPdzLxUpAMBPVdANKgyFM
+            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
         cache:
           id: cache
           config:
@@ -117,7 +117,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
+            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -126,12 +126,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            subscriberId: ev-charging.sandbox1.com
-            keyId: 76EU7PktCXdPoNEZBjmg4Eb25A2egsd5MYJ67Qxza7bJQFvBHCYxgk
-            signingPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
-            signingPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
-            encrPrivateKey: 9NBh67Pk/6v3irrkYZHlQ5E1qw+GivHdDFtKeCylzIM=
-            encrPublicKey: Z3Hnc8FZDo/7dwWApeRVs6OV560gr7uxPsFUDGUMsBg=
+            subscriberId: bap.example.com
+            keyId: 76EU7LZ7gfqj13dWDKR1Uitnim11mCoxWBPdzLxUpAMBPVdANKgyFM
+            signingPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            signingPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
+            encrPrivateKey: TTQMAEy0xJcoRXRNofZAwZq1c3VH6j98UUaHP7budQQ=
+            encrPublicKey: g/3swjI93IhZ0SScrVZapeLjU+W0AeiSid3LViYZJFo=
         cache:
           id: cache
           config:

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -49,7 +49,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -58,12 +58,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bpp.example.com
-            keyId: 76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy
-            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
-            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            subscriberId: ev-charging.sandbox2.com
+            keyId: 76EU7ncBX74BMNTQJMcMYoTMSzU7k71owUF53fN4jdxmosxZrdjdDk
+            signingPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
+            signingPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
+            encrPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
+            encrPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
         cache:
           id: cache
           config:
@@ -110,7 +110,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
+            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -119,12 +119,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bpp.example.com
-            keyId: 76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy
-            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
-            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
-            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            subscriberId: ev-charging.sandbox2.com
+            keyId: 76EU7ncBX74BMNTQJMcMYoTMSzU7k71owUF53fN4jdxmosxZrdjdDk
+            signingPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
+            signingPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
+            encrPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
+            encrPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
         cache:
           id: cache
           config:

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -49,7 +49,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
+            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -58,12 +58,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            subscriberId: ev-charging.sandbox2.com
-            keyId: 76EU7ncBX74BMNTQJMcMYoTMSzU7k71owUF53fN4jdxmosxZrdjdDk
-            signingPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
-            signingPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
-            encrPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
-            encrPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
+            subscriberId: bpp.example.com
+            keyId: 76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy
+            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
         cache:
           id: cache
           config:
@@ -110,7 +110,7 @@ modules:
         registry:
           id: dediregistry
           config:
-            url: https://api.dev.beckn.io/registry/dedi # This is the testnet URL. The production URL is https://api.beckn.io/registry/dedi
+            url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
             registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
@@ -119,12 +119,12 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            subscriberId: ev-charging.sandbox2.com
-            keyId: 76EU7ncBX74BMNTQJMcMYoTMSzU7k71owUF53fN4jdxmosxZrdjdDk
-            signingPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
-            signingPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
-            encrPrivateKey: hnMdzvcZBnLJ6W1f4Y2ZCLlJo4phKMvs48ZbXjbS7/k=
-            encrPublicKey: H1xM/ejGIJpH+DmAF1A9KjBBLJ74pZ8B0gnZ4z4DIkU=
+            subscriberId: bpp.example.com
+            keyId: 76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy
+            signingPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+            signingPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
+            encrPrivateKey: 393fVJJsfqssJCRAjedKR2cKAjSLrjU3t+bICQ5KzYM=
+            encrPublicKey: CqVy97DW45bcZPPrWIYGe2ldl9C93NFeVciiAEYsvR0=
         cache:
           id: cache
           config:

--- a/config/local-simple.yaml
+++ b/config/local-simple.yaml
@@ -46,7 +46,7 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bap-network
+            subscriberId: bap-network
             keyId: bap-network-key
             signingPrivateKey: uc5WYG/eke0PVGyQ9JNVLpwQL0K9JIZfHfqUHdLBTaY=
             signingPublicKey: UX1EDpL4YHOnfkuhrtS+Bz18qwidrX+oJxButD8xaCE=
@@ -102,7 +102,7 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bap-network
+            subscriberId: bap-network
             keyId: bap-network-key
             signingPrivateKey: uc5WYG/eke0PVGyQ9JNVLpwQL0K9JIZfHfqUHdLBTaY=
             signingPublicKey: UX1EDpL4YHOnfkuhrtS+Bz18qwidrX+oJxButD8xaCE=
@@ -148,7 +148,7 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bpp-network
+            subscriberId: bpp-network
             keyId: bpp-network-key
             signingPrivateKey: uc5WYG/eke0PVGyQ9JNVLpwQL0K9JIZfHfqUHdLBTaY=
             signingPublicKey: 8CANv4rto7u6RZEB9b6z6mXIIfBLlExIRLBLd5YYl/Y=
@@ -199,7 +199,7 @@ modules:
         keyManager:
           id: simplekeymanager
           config:
-            networkParticipant: bpp-network
+            subscriberId: bpp-network
             keyId: bpp-network-key
             signingPrivateKey: uc5WYG/eke0PVGyQ9JNVLpwQL0K9JIZfHfqUHdLBTaY=
             signingPublicKey: 8CANv4rto7u6RZEB9b6z6mXIIfBLlExIRLBLd5YYl/Y=

--- a/pkg/plugin/implementation/simplekeymanager/README.md
+++ b/pkg/plugin/implementation/simplekeymanager/README.md
@@ -26,7 +26,7 @@ plugins:
   keymanager:
     id: simplekeymanager
     config:
-      networkParticipant: bap-network
+      subscriberId: bap-network
       keyId: bap-network-key
       signingPrivateKey: uc5WYG/eke0PVGyQ9JNVLpwQL0K9JIZfHfqUHdLBTaY=
       signingPublicKey: kUSiFNAD3+6oE7KffKucxZ74e6g4i9VM6ypImg4rVCM=
@@ -38,7 +38,7 @@ plugins:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `networkParticipant` | string | Yes | Identifier for the keyset, represents subscriberId or networkParticipant name |
+| `subscriberId` | string | Yes | Beckn subscriber identity for this node (e.g. `bpp.example.com`). Matches `handler.subscriberId`. Deprecated alias: `networkParticipant` (still accepted with a warning). |
 | `keyId` | string | Yes | Unique Key id for the keyset |
 | `signingPrivateKey` | string | Yes* | Ed25519 private key for signing (Base64 or PEM) |
 | `signingPublicKey` | string | Yes* | Ed25519 public key for signing (Base64 or PEM) |

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
@@ -16,16 +16,24 @@ var newSimpleKeyManagerFunc = simplekeymanager.New
 
 // New creates and initializes a new SimpleKeyManager instance using the provided cache, registry lookup, and configuration.
 func (k *simpleKeyManagerProvider) New(ctx context.Context, cache definition.Cache, registry definition.RegistryLookup, cfg map[string]string) (definition.KeyManager, func() error, error) {
-	config := &simplekeymanager.Config{
-		NetworkParticipant: cfg["networkParticipant"],
-		KeyID:              cfg["keyId"],
-		SigningPrivateKey:  cfg["signingPrivateKey"],
-		SigningPublicKey:   cfg["signingPublicKey"],
-		EncrPrivateKey:     cfg["encrPrivateKey"],
-		EncrPublicKey:      cfg["encrPublicKey"],
+	subscriberID := cfg["subscriberId"]
+	if subscriberID == "" {
+		if np := cfg["networkParticipant"]; np != "" {
+			log.Warnf(ctx, "config key 'networkParticipant' is deprecated, use 'subscriberId' instead")
+			subscriberID = np
+		}
 	}
-	log.Debugf(ctx, "SimpleKeyManager config mapped: np=%s, keyId=%s, has_signing_private=%v, has_signing_public=%v, has_encr_private=%v, has_encr_public=%v",
-		config.NetworkParticipant,
+
+	config := &simplekeymanager.Config{
+		SubscriberID:     subscriberID,
+		KeyID:            cfg["keyId"],
+		SigningPrivateKey: cfg["signingPrivateKey"],
+		SigningPublicKey:  cfg["signingPublicKey"],
+		EncrPrivateKey:   cfg["encrPrivateKey"],
+		EncrPublicKey:    cfg["encrPublicKey"],
+	}
+	log.Debugf(ctx, "SimpleKeyManager config mapped: subscriberId=%s, keyId=%s, has_signing_private=%v, has_signing_public=%v, has_encr_private=%v, has_encr_public=%v",
+		config.SubscriberID,
 		config.KeyID,
 		config.SigningPrivateKey != "",
 		config.SigningPublicKey != "",

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
@@ -53,8 +53,8 @@ func TestSimpleKeyManagerProvider_New(t *testing.T) {
 		{
 			name: "valid config with keys",
 			config: map[string]string{
-				"networkParticipant": "bap-one",
-				"keyId":              "test-key",
+				"subscriberId": "bap-one",
+				"keyId":        "test-key",
 				"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
 				"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
@@ -146,8 +146,8 @@ func TestConfigMapping(t *testing.T) {
 	registry := &mockRegistry{}
 
 	configMap := map[string]string{
-		"networkParticipant": "mapped-np",
-		"keyId":              "mapped-key-id",
+		"subscriberId": "mapped-np",
+		"keyId":        "mapped-key-id",
 		"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 		"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
 		"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
@@ -162,6 +162,46 @@ func TestConfigMapping(t *testing.T) {
 		return
 	}
 
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+func TestDeprecatedNetworkParticipantKey(t *testing.T) {
+	provider := &simpleKeyManagerProvider{}
+	ctx := context.Background()
+	cache := &mockCache{}
+	registry := &mockRegistry{}
+
+	// Config using the deprecated networkParticipant key should still work.
+	_, cleanup, err := provider.New(ctx, cache, registry, map[string]string{
+		"networkParticipant": "bap-one",
+		"keyId":              "test-key",
+		"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+		"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+		"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
+		"encrPublicKey":      "dGVzdC1lbmNyLXB1YmxpYw==",
+	})
+	if err != nil {
+		t.Errorf("deprecated networkParticipant key should still work: %v", err)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+
+	// subscriberId takes precedence over deprecated networkParticipant when both are present.
+	_, cleanup, err = provider.New(ctx, cache, registry, map[string]string{
+		"subscriberId":       "bap-primary",
+		"networkParticipant": "bap-ignored",
+		"keyId":              "test-key",
+		"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+		"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+		"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
+		"encrPublicKey":      "dGVzdC1lbmNyLXB1YmxpYw==",
+	})
+	if err != nil {
+		t.Errorf("subscriberId should take precedence over networkParticipant: %v", err)
+	}
 	if cleanup != nil {
 		cleanup()
 	}

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -23,8 +23,8 @@ import (
 
 // Config holds configuration parameters for SimpleKeyManager.
 type Config struct {
-	NetworkParticipant string `yaml:"networkParticipant" json:"networkParticipant"`
-	KeyID              string `yaml:"keyId" json:"keyId"`
+	SubscriberID      string `yaml:"subscriberId" json:"subscriberId"`
+	KeyID             string `yaml:"keyId" json:"keyId"`
 	SigningPrivateKey  string `yaml:"signingPrivateKey" json:"signingPrivateKey"`
 	SigningPublicKey   string `yaml:"signingPublicKey" json:"signingPublicKey"`
 	EncrPrivateKey     string `yaml:"encrPrivateKey" json:"encrPrivateKey"`
@@ -75,7 +75,7 @@ func ValidateCfg(cfg *Config) error {
 
 	// But if keys are provided, all must be provided
 	hasKeys := cfg.SigningPrivateKey != "" || cfg.SigningPublicKey != "" ||
-		cfg.EncrPrivateKey != "" || cfg.EncrPublicKey != "" || cfg.NetworkParticipant != "" ||
+		cfg.EncrPrivateKey != "" || cfg.EncrPublicKey != "" || cfg.SubscriberID != "" ||
 		cfg.KeyID != ""
 
 	if hasKeys {
@@ -91,8 +91,8 @@ func ValidateCfg(cfg *Config) error {
 		if cfg.EncrPublicKey == "" {
 			return fmt.Errorf("%w: encrPublicKey is required when keys are configured", ErrInvalidConfig)
 		}
-		if cfg.NetworkParticipant == "" {
-			return fmt.Errorf("%w: networkParticipant is required when keys are configured", ErrInvalidConfig)
+		if cfg.SubscriberID == "" {
+			return fmt.Errorf("%w: subscriberId is required when keys are configured", ErrInvalidConfig)
 		}
 		if cfg.KeyID == "" {
 			return fmt.Errorf("%w: keyId is required when keys are configured", ErrInvalidConfig)
@@ -319,13 +319,12 @@ func (skm *SimpleKeyMgr) loadKeysFromConfig(ctx context.Context, cfg *Config) er
 			return fmt.Errorf("failed to parse encrPublicKey: %w", err)
 		}
 
-		// Determine keyID - use configured keyId or default to "default"
-		networkParticipant := cfg.NetworkParticipant
+		subscriberID := cfg.SubscriberID
 		keyId := cfg.KeyID
 
 		// Create keyset from configuration
 		keyset := &model.Keyset{
-			SubscriberID:   networkParticipant,
+			SubscriberID:   subscriberID,
 			UniqueKeyID:    keyId,
 			SigningPrivate: encodeBase64(signingPrivate),
 			SigningPublic:  encodeBase64(signingPublic),
@@ -333,9 +332,8 @@ func (skm *SimpleKeyMgr) loadKeysFromConfig(ctx context.Context, cfg *Config) er
 			EncrPublic:     encodeBase64(encrPublic),
 		}
 
-		// Store the keyset using the keyID
-		skm.keysets[networkParticipant] = keyset
-		log.Infof(ctx, "Successfully loaded keyset from configuration with keyID: %s", keyId)
+		skm.keysets[subscriberID] = keyset
+		log.Infof(ctx, "Successfully loaded keyset from configuration for subscriberID: %s, keyId: %s", subscriberID, keyId)
 	} else {
 		log.Debug(ctx, "No keys found in configuration, keyset storage will be empty initially")
 	}

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -62,8 +62,8 @@ func TestValidateCfg(t *testing.T) {
 		{
 			name: "valid config with all keys",
 			cfg: &Config{
-				NetworkParticipant: "test-np",
-				KeyID:              "test-key",
+				SubscriberID: "test-np",
+				KeyID:        "test-key",
 				SigningPrivateKey:  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				SigningPublicKey:   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
 				EncrPrivateKey:     "dGVzdC1lbmNyLXByaXZhdGU=",
@@ -115,8 +115,8 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config with keys",
 			cfg: &Config{
-				NetworkParticipant: "test-np",
-				KeyID:              "test-key",
+				SubscriberID: "test-np",
+				KeyID:        "test-key",
 				SigningPrivateKey:  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				SigningPublicKey:   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
 				EncrPrivateKey:     "dGVzdC1lbmNyLXByaXZhdGU=",
@@ -397,8 +397,8 @@ func TestLoadKeysFromConfig(t *testing.T) {
 
 	// Test with valid config
 	cfg := &Config{
-		NetworkParticipant: "test-np",
-		KeyID:              "test-key",
+		SubscriberID: "test-np",
+		KeyID:        "test-key",
 		SigningPrivateKey:  base64.StdEncoding.EncodeToString([]byte("signing-private")),
 		SigningPublicKey:   base64.StdEncoding.EncodeToString([]byte("signing-public")),
 		EncrPrivateKey:     base64.StdEncoding.EncodeToString([]byte("encr-private")),
@@ -411,10 +411,13 @@ func TestLoadKeysFromConfig(t *testing.T) {
 		return
 	}
 
-	// Verify keyset was loaded
+	// Verify keyset is stored under subscriberID and retrievable via Keyset()
 	_, exists := skm.keysets["test-np"]
 	if !exists {
-		t.Error("loadKeysFromConfig() did not load keyset")
+		t.Error("loadKeysFromConfig() did not store keyset under subscriberID")
+	}
+	if _, err := skm.Keyset(ctx, "test-np"); err != nil {
+		t.Errorf("Keyset() could not retrieve config-loaded keyset by subscriberID: %v", err)
 	}
 
 	// Test with empty config (should not error)


### PR DESCRIPTION
## Summary

- Renames the `networkParticipant` config key in `simplekeymanager` to `subscriberId`, aligning it with `handler.subscriberId` and Beckn protocol terminology
- Adds a backward-compatible fallback: the deprecated `networkParticipant` key is still accepted but logs a warning at startup; `subscriberId` takes precedence when both are present
- Updates all sample configs, README, and tests

## Why

The same beckn subscriber identity (e.g. `bpp.example.com`) had to be set in two places under two different key names — `handler.subscriberId` and `plugins.keyManager.config.networkParticipant`. This was a holdover from the gen-1 registry era where the term "network participant" was used. The rest of the codebase, the Beckn protocol wire format, and Grafana dashboards all use `subscriber_id` / `subscriberId`.

Fixes #663. Duplicate issue #672 was closed in favour of this fix.

## Changes

| File | Change |
|---|---|
| `simplekeymanager.go` | `Config.NetworkParticipant` → `Config.SubscriberID`, YAML tag `subscriberId`, updated `ValidateCfg` and `loadKeysFromConfig` |
| `cmd/plugin.go` | Reads `subscriberId` first, falls back to `networkParticipant` with deprecation warning |
| `simplekeymanager_test.go` | Field renames + regression test that `Keyset(subscriberID)` works for config-loaded keys |
| `cmd/plugin_test.go` | Key renames + `TestDeprecatedNetworkParticipantKey` covering backward-compat and precedence |
| `config/local-beckn-one-bap.yaml`, `local-beckn-one-bpp.yaml`, `local-simple.yaml` | `networkParticipant:` → `subscriberId:` |
| `simplekeymanager/README.md` | Config example and table updated, deprecation alias noted |

## Backward compatibility

| Scenario | Behaviour |
|---|---|
| Config uses `subscriberId` | Works, no warning |
| Config uses `networkParticipant` | Works, logs deprecation warning |
| Config uses neither (no keys configured) | Unchanged — no error |
| Config uses both | `subscriberId` wins |

## Test plan

- [x] `go test ./pkg/plugin/implementation/simplekeymanager/...` passes
- [x] Existing deployments using `networkParticipant` continue to work (covered by `TestDeprecatedNetworkParticipantKey`)
- [x] New deployments using `subscriberId` work correctly