### PR TITLE
fix(cache): cache.Get returns ("", nil) on miss instead of leaking redis.Nil

### DIFF
--- a/pkg/plugin/implementation/cache/cache.go
+++ b/pkg/plugin/implementation/cache/cache.go
@@ -123,7 +123,7 @@ func (c *Cache) Get(ctx context.Context, key string) (string, error) {
 			telemetry.AttrOperation.String("get"),
 		}
 		switch {
-		case err == redis.Nil:
+		case errors.Is(err, redis.Nil):
 			c.metrics.CacheMissesTotal.Add(spanCtx, 1, metric.WithAttributes(attrs...))
 			c.metrics.CacheOperationsTotal.Add(spanCtx, 1,
 				metric.WithAttributes(append(attrs, telemetry.AttrStatus.String("miss"))...))
@@ -135,6 +135,9 @@ func (c *Cache) Get(ctx context.Context, key string) (string, error) {
 			c.metrics.CacheOperationsTotal.Add(spanCtx, 1,
 				metric.WithAttributes(append(attrs, telemetry.AttrStatus.String("hit"))...))
 		}
+	}
+	if errors.Is(err, redis.Nil) {
+		return "", nil
 	}
 	return result, err
 }

--- a/pkg/plugin/implementation/cache/cache_test.go
+++ b/pkg/plugin/implementation/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -48,16 +49,33 @@ func (m *MockRedisClient) Close() error {
 
 // TestCache_Get tests the Get method of the Cache type
 func TestCache_Get(t *testing.T) {
-	mockClient := new(MockRedisClient)
-	ctx := context.Background()
-	cache := &Cache{Client: mockClient}
-
-	mockClient.On("Get", ctx, "my-key").Return("my-value", nil)
-
-	value, err := cache.Get(ctx, "my-key")
-	assert.NoError(t, err)
-	assert.Equal(t, "my-value", value)
-	mockClient.AssertExpectations(t)
+	tests := []struct {
+		name    string
+		mockVal string
+		mockErr error
+		wantVal string
+		wantErr bool
+	}{
+		{name: "hit", mockVal: "my-value", mockErr: nil, wantVal: "my-value", wantErr: false},
+		{name: "miss", mockVal: "", mockErr: redis.Nil, wantVal: "", wantErr: false},
+		{name: "error", mockVal: "", mockErr: errors.New("connection refused"), wantVal: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := new(MockRedisClient)
+			ctx := context.Background()
+			cache := &Cache{Client: mockClient}
+			mockClient.On("Get", mock.Anything, "my-key").Return(tt.mockVal, tt.mockErr)
+			value, err := cache.Get(ctx, "my-key")
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantVal, value)
+			mockClient.AssertExpectations(t)
+		})
+	}
 }
 
 // TestCache_Set tests the Set method of the Cache type
@@ -66,7 +84,7 @@ func TestCache_Set(t *testing.T) {
 	ctx := context.Background()
 	cache := &Cache{Client: mockClient}
 
-	mockClient.On("Set", ctx, "my-key", "my-value", time.Minute).Return("OK", nil)
+	mockClient.On("Set", mock.Anything, "my-key", "my-value", time.Minute).Return("OK", nil)
 
 	err := cache.Set(ctx, "my-key", "my-value", time.Minute)
 	assert.NoError(t, err)
@@ -79,7 +97,7 @@ func TestCache_Delete(t *testing.T) {
 	ctx := context.Background()
 	cache := &Cache{Client: mockClient}
 
-	mockClient.On("Del", ctx, []string{"my-key"}).Return(1, nil)
+	mockClient.On("Del", mock.Anything, []string{"my-key"}).Return(1, nil)
 
 	err := cache.Delete(ctx, "my-key")
 	assert.NoError(t, err)
@@ -92,7 +110,7 @@ func TestCache_Clear(t *testing.T) {
 	ctx := context.Background()
 	cache := &Cache{Client: mockClient}
 
-	mockClient.On("FlushDB", ctx).Return("OK", nil)
+	mockClient.On("FlushDB", mock.Anything).Return("OK", nil)
 
 	err := cache.Clear(ctx)
 	assert.NoError(t, err)

--- a/pkg/plugin/implementation/payloadstore/payloadstore.go
+++ b/pkg/plugin/implementation/payloadstore/payloadstore.go
@@ -376,13 +376,10 @@ func (s *store) GetByMessageID(ctx context.Context, messageID, action string) (*
 }
 
 // Exists returns true if a payload with the given message ID is present in the store.
-// Cache errors are treated as a miss (fail-open) because the cache plugin currently
-// leaks redis.Nil (key not found) as an error rather than returning ("", nil).
-// Once the cache plugin is fixed, this should propagate real errors. See: #717.
 func (s *store) Exists(ctx context.Context, messageID string) (bool, error) {
 	raw, err := s.cache.Get(ctx, msgKey(s.namespace, messageID))
-	if err != nil || raw == "" {
-		return false, nil
+	if err != nil {
+		return false, err
 	}
-	return true, nil
+	return raw != "", nil
 }


### PR DESCRIPTION
## Summary

Closes #717

- `cache.Get` now absorbs `redis.Nil` (go-redis key-not-found sentinel) and returns `("", nil)`, honouring the implicit contract of `definition.Cache.Get`
- `payloadstore.Exists` drops the fail-open workaround and propagates real cache errors now that misses are clean
- `TestCache_Get` expanded to a table-driven test covering hit, miss, and genuine error cases
- Fixed pre-existing broken mock expectations in `TestCache_Set`, `TestCache_Delete`, `TestCache_Clear` (bare `ctx` used instead of `mock.Anything` for the OTel span-wrapped context)

## Impact on other call sites

All other `cache.Get` callers use `if err != nil || raw == ""` — the `raw == ""` branch still catches misses after this change, so no further edits were needed.

## Test plan

- [x] `go test ./pkg/plugin/implementation/cache/...` — all three subtests (hit / miss / error) pass
- [x] `go test ./pkg/plugin/implementation/payloadstore/...` — `TestExists_*` pass without modification