### PR TITLE
refactor(dediregistry): remove `registryName` config and hardcode wildcard constant

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -586,7 +586,6 @@ registry:
   id: dediregistry
   config:
     url: "https://fabric.nfh.global/registry/dedi"
-    registryName: "subscribers.beckn.one"
     allowedNetworkIDs: "commerce-network.org/prod,local-commerce.org/production"
     timeout: 30
     retry_max: 3
@@ -596,7 +595,6 @@ registry:
 
 **Parameters**:
 - `url`: Beckn registry base URL including the `/dedi` path (Required)
-- `registryName`: Registry name used in the lookup path. Keep this value as `subscribers.beckn.one` so lookups include all cached registries. Use `allowedNetworkIDs` if you want lookup to be restricted within one or more networks. (Required)
 - `allowedNetworkIDs`: Comma-separated list of allowed network IDs used to restrict lookup results to specific networks. See [Beckn network setup documentation](https://docs.beckn.io/creating-an-open-network/setting-up-the-network-environment#registering-the-network-on-beckn-fabric) for more on network IDs. (Optional)
 - `timeout`: Request timeout in seconds (Optional, default: client default)
 - `retry_max`: Maximum number of retry attempts (Optional, default: 4)

--- a/config/local-beckn-one-bap.yaml
+++ b/config/local-beckn-one-bap.yaml
@@ -52,7 +52,6 @@ modules:
           id: dediregistry
           config:
             url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
-            registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
             retry_wait_min: 100ms
@@ -128,7 +127,6 @@ modules:
           id: dediregistry
           config:
             url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
-            registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
             retry_wait_min: 100ms

--- a/config/local-beckn-one-bpp.yaml
+++ b/config/local-beckn-one-bpp.yaml
@@ -50,7 +50,6 @@ modules:
           id: dediregistry
           config:
             url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
-            registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
             retry_wait_min: 100ms
@@ -126,7 +125,6 @@ modules:
           id: dediregistry
           config:
             url: https://fabric.nfh.global/registry/dedi # This is the registry URL.
-            registryName: subscribers.beckn.one # This is the wildcard string used to lookup across registries in Beckn One. Do not change this.
             timeout: 10
             retry_max: 3
             retry_wait_min: 100ms

--- a/pkg/plugin/implementation/dediregistry/README.md
+++ b/pkg/plugin/implementation/dediregistry/README.md
@@ -17,7 +17,6 @@ registry:
   id: dediregistry
   config:
     url: "https://fabric.nfh.global/registry/dedi"
-    registryName: "subscribers.beckn.one"
     allowedNetworkIDs: "commerce-network.org/prod,local-commerce.org/production"
     timeout: 30
     retry_max: 3
@@ -30,7 +29,6 @@ registry:
 | Parameter | Required | Description | Default |
 |-----------|----------|-------------|---------|
 | `url` | Yes | DeDi wrapper API base URL (include /dedi path) | - |
-| `registryName` | Yes | Registry name for lookup path | - |
 | `allowedNetworkIDs` | No | Allowlist of network membership IDs from `data.network_memberships` for signature validation | - |
 | `timeout` | No | Request timeout in seconds | Client default |
 | `retry_max` | No | Maximum number of retry attempts | 4 (library default) |
@@ -41,7 +39,7 @@ registry:
 
 ### Beckn Registry API Format
 ```
-GET {url}/lookup/{subscriber_id}/{registryName}/{key_id}
+GET {url}/lookup/{subscriber_id}/subscribers.beckn.one/{key_id}
 ```
 
 **Example**: `https://fabric.nfh.global/registry/dedi/lookup/bpp.example.com/subscribers.beckn.one/76EU7ofwRCF1aobQkShARrf1PAUsNpHqWUJoynPu9w45YFKmzqaPmy`
@@ -79,7 +77,7 @@ GET {url}/lookup/{subscriber_id}/{registryName}/{key_id}
 2. ONIX Receiver → parseHeader() extracts subscriberID/keyID  
 3. validateSign step → KeyManager.LookupNPKeys()
 4. KeyManager → DeDiRegistry.Lookup() with extracted values
-5. DeDi Registry → GET {url}/lookup/{subscriberID}/{registryName}/{keyID}
+5. DeDi Registry → GET {url}/lookup/{subscriberID}/subscribers.beckn.one/{keyID}
 6. DeDi Wrapper → Returns participant public keys
 7. SignValidator → Validates signature using retrieved public key
 ```
@@ -95,7 +93,6 @@ modules:
           id: dediregistry
           config:
             url: "https://fabric.nfh.global/registry/dedi"
-            registryName: "subscribers.beckn.one"
             allowedNetworkIDs: "commerce-network.org/prod,local-commerce.org/production"
             timeout: 30
             retry_max: 3
@@ -146,7 +143,6 @@ The tests cover:
 This plugin replaces direct DeDi API integration with the new DeDi Wrapper API format:
 
 - **Removed**: API key authentication, namespaceID parameters
-- **Added**: Configurable registryName parameter
 - **Changed**: POST requests → GET requests
 - **Updated**: Response structure parsing (`data.details` object)
 - **Updated**: Optional allowlist validation now checks `data.network_memberships`
@@ -160,7 +156,7 @@ This plugin replaces direct DeDi API integration with the new DeDi Wrapper API f
 
 ## Error Handling
 
-- **Configuration Errors**: Missing url or registryName
+- **Configuration Errors**: Missing url
 - **Network Errors**: Connection failures, timeouts
 - **HTTP Errors**: Non-200 status codes from DeDi wrapper
 - **Data Errors**: Missing required fields in response

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -20,8 +20,7 @@ type dediRegistryProvider struct {
 
 func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregistry.Config, error) {
 	dediConfig := &dediregistry.Config{
-		URL:          config["url"],
-		RegistryName: config["registryName"],
+		URL: config["url"],
 	}
 
 	// Parse timeout if provided.

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -14,7 +14,6 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 
 	cfg, err := provider.parseConfig(map[string]string{
 		"url":            "https://test.com/dedi",
-		"registryName":   "subscribers.beckn.one",
 		"timeout":        "30",
 		"retry_max":      "5",
 		"retry_wait_min": "100ms",
@@ -26,9 +25,6 @@ func TestDediRegistryProvider_ParseConfig(t *testing.T) {
 
 	if cfg.URL != "https://test.com/dedi" {
 		t.Fatalf("expected URL to be parsed, got %q", cfg.URL)
-	}
-	if cfg.RegistryName != "subscribers.beckn.one" {
-		t.Fatalf("expected RegistryName to be parsed, got %q", cfg.RegistryName)
 	}
 	if cfg.Timeout != 30 {
 		t.Fatalf("expected Timeout 30, got %d", cfg.Timeout)
@@ -56,8 +52,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid timeout",
 			config: map[string]string{
 				"url":          "https://test.com/dedi",
-				"registryName": "subscribers.beckn.one",
-				"timeout":      "abc",
+		"timeout":      "abc",
 			},
 			expectedErr: "invalid timeout value 'abc'",
 		},
@@ -65,8 +60,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid retry_max",
 			config: map[string]string{
 				"url":          "https://test.com/dedi",
-				"registryName": "subscribers.beckn.one",
-				"retry_max":    "abc",
+		"retry_max":    "abc",
 			},
 			expectedErr: "invalid retry_max value 'abc'",
 		},
@@ -74,8 +68,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative retry_max",
 			config: map[string]string{
 				"url":          "https://test.com/dedi",
-				"registryName": "subscribers.beckn.one",
-				"retry_max":    "-1",
+		"retry_max":    "-1",
 			},
 			expectedErr: "retry_max must be non-negative",
 		},
@@ -83,8 +76,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid retry_wait_min",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-				"registryName":   "subscribers.beckn.one",
-				"retry_wait_min": "notaduration",
+		"retry_wait_min": "notaduration",
 			},
 			expectedErr: "invalid retry_wait_min value 'notaduration'",
 		},
@@ -92,8 +84,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative retry_wait_min",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-				"registryName":   "subscribers.beckn.one",
-				"retry_wait_min": "-100ms",
+		"retry_wait_min": "-100ms",
 			},
 			expectedErr: "retry_wait_min must be non-negative",
 		},
@@ -101,8 +92,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-				"registryName":   "subscribers.beckn.one",
-				"retry_wait_max": "notaduration",
+		"retry_wait_max": "notaduration",
 			},
 			expectedErr: "invalid retry_wait_max value 'notaduration'",
 		},
@@ -110,8 +100,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-				"registryName":   "subscribers.beckn.one",
-				"retry_wait_max": "-2s",
+		"retry_wait_max": "-2s",
 			},
 			expectedErr: "retry_wait_max must be non-negative",
 		},
@@ -119,8 +108,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "zero timeout",
 			config: map[string]string{
 				"url":          "https://test.com/dedi",
-				"registryName": "subscribers.beckn.one",
-				"timeout":      "0",
+		"timeout":      "0",
 			},
 			expectedErr: "timeout must be positive",
 		},
@@ -128,8 +116,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative timeout",
 			config: map[string]string{
 				"url":          "https://test.com/dedi",
-				"registryName": "subscribers.beckn.one",
-				"timeout":      "-5",
+		"timeout":      "-5",
 			},
 			expectedErr: "timeout must be positive",
 		},
@@ -137,8 +124,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "retry_wait_min exceeds retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-				"registryName":   "subscribers.beckn.one",
-				"retry_wait_min": "5s",
+		"retry_wait_min": "5s",
 				"retry_wait_max": "1s",
 			},
 			expectedErr: "retry_wait_min (5s) must not exceed retry_wait_max (1s)",
@@ -165,9 +151,8 @@ func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
 
 	_, _, err := provider.New(context.Background(), map[string]string{
-		"url":          "https://test.com/dedi",
-		"registryName": "subscribers.beckn.one",
-		"retry_max":    "abc",
+		"url":       "https://test.com/dedi",
+		"retry_max": "abc",
 	})
 	if err == nil {
 		t.Fatal("expected New() to return an error for invalid retry config")
@@ -188,7 +173,6 @@ func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
 
 	config := map[string]string{
 		"url":            "https://test.com/dedi",
-		"registryName":   "subscribers.beckn.one",
 		"timeout":        "30",
 		"retry_max":      "5",
 		"retry_wait_min": "100ms",
@@ -224,9 +208,8 @@ func TestDediRegistryProvider_New(t *testing.T) {
 	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
 	config := map[string]string{
-		"url":          "https://test.com/dedi",
-		"registryName": "subscribers.beckn.one",
-		"timeout":      "30",
+		"url":     "https://test.com/dedi",
+		"timeout": "30",
 	}
 
 	dediRegistry, closer, err := provider.New(ctx, config)
@@ -259,11 +242,7 @@ func TestDediRegistryProvider_New_InvalidConfig(t *testing.T) {
 	}{
 		{
 			name:   "missing url",
-			config: map[string]string{"registryName": "subscribers.beckn.one", "timeout": "30"},
-		},
-		{
-			name:   "missing registryName",
-			config: map[string]string{"url": "https://test.com/dedi", "timeout": "30"},
+			config: map[string]string{"timeout": "30"},
 		},
 		{
 			name:   "empty config",
@@ -286,9 +265,8 @@ func TestDediRegistryProvider_New_InvalidTimeout(t *testing.T) {
 	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
 	_, _, err := provider.New(context.Background(), map[string]string{
-		"url":          "https://test.com/dedi",
-		"registryName": "subscribers.beckn.one",
-		"timeout":      "invalid",
+		"url":     "https://test.com/dedi",
+		"timeout": "invalid",
 	})
 	if err == nil {
 		t.Fatal("expected New() to return an error for invalid timeout")
@@ -332,8 +310,7 @@ func TestResolveAllowedNetworkIDs_DeprecatedAllowedParentNamespacesErrorsWithout
 func TestResolveAllowedNetworkIDs_AllowedNetworkIDsTakesPrecedence(t *testing.T) {
 	config := map[string]string{
 		"url":                     "https://test.com/dedi",
-		"registryName":            "subscribers.beckn.one",
-		"allowedParentNamespaces": "deprecated-network.org/legacy",
+"allowedParentNamespaces": "deprecated-network.org/legacy",
 		"allowedNetworkIDs":       "commerce-network.org/prod, local-commerce.org/production",
 	}
 
@@ -362,8 +339,7 @@ func TestDediRegistryProvider_New_DeprecatedAllowedParentNamespacesErrorsWithout
 
 	config := map[string]string{
 		"url":                     "https://test.com/dedi",
-		"registryName":            "subscribers.beckn.one",
-		"allowedParentNamespaces": "commerce-network.org",
+"allowedParentNamespaces": "commerce-network.org",
 	}
 
 	_, _, err := provider.New(ctx, config)
@@ -376,8 +352,7 @@ func TestDediRegistryProvider_New_NilContext(t *testing.T) {
 	provider := dediRegistryProvider{}
 
 	config := map[string]string{
-		"url":          "https://test.com/dedi",
-		"registryName": "subscribers.beckn.one",
+		"url": "https://test.com/dedi",
 	}
 
 	_, _, err := provider.New(nil, config)

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -51,24 +51,24 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 		{
 			name: "invalid timeout",
 			config: map[string]string{
-				"url":          "https://test.com/dedi",
-		"timeout":      "abc",
+				"url":     "https://test.com/dedi",
+				"timeout": "abc",
 			},
 			expectedErr: "invalid timeout value 'abc'",
 		},
 		{
 			name: "invalid retry_max",
 			config: map[string]string{
-				"url":          "https://test.com/dedi",
-		"retry_max":    "abc",
+				"url":       "https://test.com/dedi",
+				"retry_max": "abc",
 			},
 			expectedErr: "invalid retry_max value 'abc'",
 		},
 		{
 			name: "negative retry_max",
 			config: map[string]string{
-				"url":          "https://test.com/dedi",
-		"retry_max":    "-1",
+				"url":       "https://test.com/dedi",
+				"retry_max": "-1",
 			},
 			expectedErr: "retry_max must be non-negative",
 		},
@@ -76,7 +76,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid retry_wait_min",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-		"retry_wait_min": "notaduration",
+				"retry_wait_min": "notaduration",
 			},
 			expectedErr: "invalid retry_wait_min value 'notaduration'",
 		},
@@ -84,7 +84,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative retry_wait_min",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-		"retry_wait_min": "-100ms",
+				"retry_wait_min": "-100ms",
 			},
 			expectedErr: "retry_wait_min must be non-negative",
 		},
@@ -92,7 +92,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "invalid retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-		"retry_wait_max": "notaduration",
+				"retry_wait_max": "notaduration",
 			},
 			expectedErr: "invalid retry_wait_max value 'notaduration'",
 		},
@@ -100,23 +100,23 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "negative retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-		"retry_wait_max": "-2s",
+				"retry_wait_max": "-2s",
 			},
 			expectedErr: "retry_wait_max must be non-negative",
 		},
 		{
 			name: "zero timeout",
 			config: map[string]string{
-				"url":          "https://test.com/dedi",
-		"timeout":      "0",
+				"url":     "https://test.com/dedi",
+				"timeout": "0",
 			},
 			expectedErr: "timeout must be positive",
 		},
 		{
 			name: "negative timeout",
 			config: map[string]string{
-				"url":          "https://test.com/dedi",
-		"timeout":      "-5",
+				"url":     "https://test.com/dedi",
+				"timeout": "-5",
 			},
 			expectedErr: "timeout must be positive",
 		},
@@ -124,7 +124,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 			name: "retry_wait_min exceeds retry_wait_max",
 			config: map[string]string{
 				"url":            "https://test.com/dedi",
-		"retry_wait_min": "5s",
+				"retry_wait_min": "5s",
 				"retry_wait_max": "1s",
 			},
 			expectedErr: "retry_wait_min (5s) must not exceed retry_wait_max (1s)",
@@ -310,7 +310,7 @@ func TestResolveAllowedNetworkIDs_DeprecatedAllowedParentNamespacesErrorsWithout
 func TestResolveAllowedNetworkIDs_AllowedNetworkIDsTakesPrecedence(t *testing.T) {
 	config := map[string]string{
 		"url":                     "https://test.com/dedi",
-"allowedParentNamespaces": "deprecated-network.org/legacy",
+		"allowedParentNamespaces": "deprecated-network.org/legacy",
 		"allowedNetworkIDs":       "commerce-network.org/prod, local-commerce.org/production",
 	}
 
@@ -339,7 +339,7 @@ func TestDediRegistryProvider_New_DeprecatedAllowedParentNamespacesErrorsWithout
 
 	config := map[string]string{
 		"url":                     "https://test.com/dedi",
-"allowedParentNamespaces": "commerce-network.org",
+		"allowedParentNamespaces": "commerce-network.org",
 	}
 
 	_, _, err := provider.New(ctx, config)

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -13,10 +13,13 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
+// dediAllRegistriesWildcard is the wildcard constant required by the DeDi registry service
+// to search across all cached registries in Beckn One. This value must not be configured externally.
+const dediAllRegistriesWildcard = "subscribers.beckn.one"
+
 // Config holds configuration parameters for the DeDi registry client.
 type Config struct {
 	URL               string        `yaml:"url" json:"url"`
-	RegistryName      string        `yaml:"registryName" json:"registryName"`
 	AllowedNetworkIDs []string      `yaml:"allowedNetworkIDs" json:"allowedNetworkIDs"`
 	Timeout           int           `yaml:"timeout" json:"timeout"`
 	RetryMax          int           `yaml:"retry_max" json:"retry_max"`
@@ -37,9 +40,6 @@ func validate(cfg *Config) error {
 	}
 	if cfg.URL == "" {
 		return fmt.Errorf("url cannot be empty")
-	}
-	if cfg.RegistryName == "" {
-		return fmt.Errorf("registryName cannot be empty")
 	}
 	return nil
 }
@@ -142,7 +142,7 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 		return nil, fmt.Errorf("key_id is required for DeDi lookup")
 	}
 
-	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL, subscriberID, c.config.RegistryName, keyID)
+	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL, subscriberID, dediAllRegistriesWildcard, keyID)
 
 	data, err := c.fetchDeDiData(ctx, lookupURL, "record lookup")
 	if err != nil {

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -33,19 +33,10 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid config",
 			config: &Config{
-				URL:          "https://test.com/dedi",
-				RegistryName: "subscribers.beckn.one",
-				Timeout:      30,
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing registry name",
-			config: &Config{
 				URL:     "https://test.com/dedi",
 				Timeout: 30,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 
@@ -63,9 +54,8 @@ func TestNew(t *testing.T) {
 	ctx := context.Background()
 
 	validConfig := &Config{
-		URL:          "https://test.com/dedi",
-		RegistryName: "subscribers.beckn.one",
-		Timeout:      30,
+		URL:     "https://test.com/dedi",
+		Timeout: 30,
 	}
 
 	client, closer, err := New(ctx, validConfig)
@@ -89,9 +79,8 @@ func TestNew(t *testing.T) {
 
 	t.Run("should apply custom retry settings", func(t *testing.T) {
 		cfg := &Config{
-			URL:          "http://test.com",
-			RegistryName: "subscribers.beckn.one",
-			RetryMax:     10,
+			URL:      "http://test.com",
+			RetryMax: 10,
 			RetryWaitMin: 100 * time.Millisecond,
 			RetryWaitMax: 1 * time.Second,
 		}
@@ -180,7 +169,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 			Timeout:      30,
 		}
 
@@ -242,7 +230,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:               server.URL + "/dedi",
-			RegistryName:      "subscribers.beckn.one",
 			AllowedNetworkIDs: []string{"commerce-network.org/prod"},
 		}
 
@@ -286,7 +273,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:               server.URL + "/dedi",
-			RegistryName:      "subscribers.beckn.one",
 			AllowedNetworkIDs: []string{"commerce-network/subscriber-references"},
 		}
 
@@ -334,7 +320,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:               server.URL + "/dedi",
-			RegistryName:      "subscribers.beckn.one",
 			AllowedNetworkIDs: []string{"commerce-network.org/prod"},
 		}
 
@@ -360,7 +345,6 @@ func TestLookup(t *testing.T) {
 	t.Run("empty subscriber ID", func(t *testing.T) {
 		config := &Config{
 			URL:          "https://test.com/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -388,7 +372,6 @@ func TestLookup(t *testing.T) {
 	t.Run("empty key ID", func(t *testing.T) {
 		config := &Config{
 			URL:          "https://test.com/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -422,7 +405,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -460,7 +442,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -491,7 +472,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -525,7 +505,6 @@ func TestLookup(t *testing.T) {
 
 		config := &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		}
 
 		client, closer, err := New(ctx, config)
@@ -550,7 +529,6 @@ func TestLookup(t *testing.T) {
 	t.Run("network error", func(t *testing.T) {
 		config := &Config{
 			URL:          "http://invalid-url-that-does-not-exist.local/dedi",
-			RegistryName: "subscribers.beckn.one",
 			Timeout:      1,
 		}
 
@@ -603,7 +581,6 @@ func TestLookupRegistry(t *testing.T) {
 
 		client, closer, err := New(ctx, &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -639,7 +616,6 @@ func TestLookupRegistry(t *testing.T) {
 
 		client, closer, err := New(ctx, &Config{
 			URL:          server.URL,
-			RegistryName: "subscribers.beckn.one",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -668,7 +644,6 @@ func TestLookupRegistry(t *testing.T) {
 
 		client, closer, err := New(ctx, &Config{
 			URL:          server.URL,
-			RegistryName: "subscribers.beckn.one",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -693,7 +668,6 @@ func TestLookupRegistry(t *testing.T) {
 
 		client, closer, err := New(ctx, &Config{
 			URL:          server.URL + "/dedi",
-			RegistryName: "subscribers.beckn.one",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)


### PR DESCRIPTION
## Summary
- Removes the `registryName` field from `Config` struct and all config files — it was always `subscribers.beckn.one` and docs warned users to not change it
- Hardcodes the value as a package-level constant `dediAllRegistriesWildcard` in the lookup URL construction, making the intent clear
- Removes the now-redundant validation check for a non-empty `registryName`

## Why
`subscribers.beckn.one` is a wildcard used in the registry service to search across all cached registries. Exposing it as a required user-configurable field was misleading (implying it's tunable), added setup friction, and risked silent misconfiguration if a user set it to a specific registry name instead of the wildcard.

## Files Changed
- `pkg/plugin/implementation/dediregistry/dediregistry.go` — added constant, removed `Config.RegistryName`, updated URL construction and validation
- `pkg/plugin/implementation/dediregistry/cmd/plugin.go` — removed `RegistryName` from `parseConfig`
- `config/local-beckn-one-bap.yaml`, `config/local-beckn-one-bpp.yaml` — removed `registryName` lines
- `CONFIG.md`, `pkg/plugin/implementation/dediregistry/README.md` — updated docs
- `dediregistry_test.go`, `cmd/plugin_test.go` — removed `RegistryName` from all Config literals, removed "missing registryName" test cases

## Test Plan
- [x] `go test ./pkg/plugin/implementation/dediregistry/...` passes (verified locally)
- [x] Existing lookup URL path assertions still pass (URL still contains `subscribers.beckn.one`, now hardcoded)
- [x] No `registryName` key in any config file or `Config` struct

Closes #719