### PR TITLE
feat(proto-v2): HTTP 409 AckNoCallback response type (#680)

### DIFF
--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -70,36 +70,45 @@ func sendAck(ctx context.Context, w http.ResponseWriter) {
 	}
 }
 
-// nackBecknError maps an error to its Beckn model.Error representation and HTTP
-// status code.
-func nackBecknError(ctx context.Context, err error) (*model.Error, int) {
+// nackBecknError maps an error to its Beckn model.Error representation, HTTP
+// status code, and body-level status string. The body status is StatusNACK for
+// all error types except AckNoCallbackErr on v2+ requests, where it reflects the
+// caller-supplied Status (ACK or NACK).
+func nackBecknError(ctx context.Context, err error) (*model.Error, int, model.Status) {
 	var schemaErr *model.SchemaValidationErr
 	var signErr *model.SignValidationErr
 	var badReqErr *model.BadReqErr
 	var notFoundErr *model.NotFoundErr
+	var ackNoCallbackErr *model.AckNoCallbackErr
 
 	switch {
 	case errors.As(err, &schemaErr):
-		return schemaErr.BecknError(), http.StatusBadRequest
+		return schemaErr.BecknError(), http.StatusBadRequest, model.StatusNACK
 	case errors.As(err, &signErr):
-		return signErr.BecknError(), http.StatusUnauthorized
+		return signErr.BecknError(), http.StatusUnauthorized, model.StatusNACK
 	case errors.As(err, &badReqErr):
-		return badReqErr.BecknError(), http.StatusBadRequest
+		return badReqErr.BecknError(), http.StatusBadRequest, model.StatusNACK
 	case errors.As(err, &notFoundErr):
-		return notFoundErr.BecknError(), http.StatusNotFound
+		return notFoundErr.BecknError(), http.StatusNotFound, model.StatusNACK
+	case errors.As(err, &ackNoCallbackErr):
+		if !isAtLeastV2(ctx) {
+			return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
+		}
+		return ackNoCallbackErr.BecknError(), http.StatusConflict, ackNoCallbackErr.Status
 	default:
-		return internalServerError(ctx), http.StatusInternalServerError
+		return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
 	}
 }
 
-// nackBodyBytes returns the serialised NACK response body for the given Beckn
-// error. The output is identical to the bytes that nack() writes to the wire.
-func nackBodyBytes(ctx context.Context, becknErr *model.Error) []byte {
+// nackBodyBytes returns the serialised response body for the given Beckn error
+// and body-level status. The output is identical to the bytes that nack() writes
+// to the wire.
+func nackBodyBytes(ctx context.Context, becknErr *model.Error, bodyStatus model.Status) []byte {
 	var data []byte
 	if isAtLeastV2(ctx) {
 		resp := &model.Response{
 			Message: model.Message{
-				Status:    model.StatusNACK,
+				Status:    bodyStatus,
 				MessageID: msgID(ctx),
 				Error:     becknErr,
 			},
@@ -108,7 +117,7 @@ func nackBodyBytes(ctx context.Context, becknErr *model.Error) []byte {
 	} else {
 		resp := &preV2Response{
 			Message: preV2Message{
-				Ack:   preV2Ack{Status: model.StatusNACK},
+				Ack:   preV2Ack{Status: bodyStatus},
 				Error: becknErr,
 			},
 		}
@@ -117,36 +126,36 @@ func nackBodyBytes(ctx context.Context, becknErr *model.Error) []byte {
 	return data
 }
 
-// nackBytes returns the NACK response body that sendNack would write for the
-// given error, without actually writing it. Use this to sign the body before
-// it is flushed to the wire (see stdHandler.signNackResponse).
+// nackBytes returns the response body that sendNack would write for the given
+// error, without actually writing it. Use this to sign the body before it is
+// flushed to the wire (see stdHandler.signNackResponse).
 func nackBytes(ctx context.Context, err error) []byte {
-	becknErr, _ := nackBecknError(ctx, err)
-	return nackBodyBytes(ctx, becknErr)
+	becknErr, _, bodyStatus := nackBecknError(ctx, err)
+	return nackBodyBytes(ctx, becknErr, bodyStatus)
 }
 
-// nack sends a NACK response with an error payload.
+// nack writes an error response body with the given HTTP status code.
 // For context.version "2.0.0":
 //
-//	{"message":{"status":"NACK","messageId":"<uuid>","error":{...}}}
+//	{"message":{"status":"<bodyStatus>","messageId":"<uuid>","error":{...}}}
 //
 // All other versions:
 //
-//	{"message":{"ack":{"status":"NACK"},"error":{...}}}
-func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, status int) {
-	data := nackBodyBytes(ctx, becknErr)
+//	{"message":{"ack":{"status":"<bodyStatus>"},"error":{...}}}
+func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, httpStatus int, bodyStatus model.Status) {
+	data := nackBodyBytes(ctx, becknErr, bodyStatus)
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
+	w.WriteHeader(httpStatus)
 	if _, er := w.Write(data); er != nil {
 		log.Debugf(ctx, "Error writing response: %v, MessageID: %s", er, ctx.Value(model.ContextKeyMsgID))
 		http.Error(w, fmt.Sprintf("Internal server error, MessageID: %s", ctx.Value(model.ContextKeyMsgID)), http.StatusInternalServerError)
 	}
 }
 
-// sendNack maps err to its Beckn error type and sends an appropriate NACK response.
+// sendNack maps err to its Beckn error type and sends the appropriate response.
 func sendNack(ctx context.Context, w http.ResponseWriter, err error) {
-	becknErr, status := nackBecknError(ctx, err)
-	nack(ctx, w, becknErr, status)
+	becknErr, httpStatus, bodyStatus := nackBecknError(ctx, err)
+	nack(ctx, w, becknErr, httpStatus, bodyStatus)
 }
 
 // isAtLeastV2 reports whether the request uses Beckn protocol v2.0.0 or later.

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -262,7 +262,8 @@ func TestSendNack(t *testing.T) {
 }
 
 // TestSendNack_AckNoCallback_PreV2_FallsThrough verifies that AckNoCallbackErr on a
-// pre-v2 request is mapped to 500 Internal Server Error, not 409.
+// pre-v2 request is mapped to 500 Internal Server Error with the pre-v2 body shape,
+// not a 409 with the v2 shape.
 func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 	ctx := context.WithValue(context.Background(), model.ContextKeyMsgID, "pre-v2-msg")
 	// No protocol version in context → pre-v2 path.
@@ -275,7 +276,69 @@ func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 	sendNack(ctx, rr, err)
 
 	if rr.Code != http.StatusInternalServerError {
-		t.Errorf("pre-v2 AckNoCallbackErr: want 500, got %d", rr.Code)
+		t.Errorf("pre-v2 AckNoCallbackErr: want status 500, got %d", rr.Code)
+	}
+	// Body must use the pre-v2 envelope with NACK status, not the 409 ACK shape.
+	var body map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse response body: %v", err)
+	}
+	msg, _ := body["message"].(map[string]interface{})
+	if msg == nil {
+		t.Fatal("response body missing 'message' field")
+	}
+	// Pre-v2 shape uses message.ack.status, not message.status.
+	if _, hasStatus := msg["status"]; hasStatus {
+		t.Error("pre-v2 body must not have message.status (v2 field)")
+	}
+	ack, _ := msg["ack"].(map[string]interface{})
+	if ack == nil {
+		t.Fatal("pre-v2 body missing message.ack")
+	}
+	if ack["status"] != "NACK" {
+		t.Errorf("pre-v2 body message.ack.status = %v, want NACK", ack["status"])
+	}
+}
+
+// TestNackBytes_AckNoCallback verifies that nackBytes (used by signNackResponse
+// before the 409 is written to the wire) produces the correct signed body for
+// AckNoCallbackErr — same bytes that sendNack will subsequently write.
+func TestNackBytes_AckNoCallback(t *testing.T) {
+	ctx := v2Ctx("sign-msg-1")
+
+	err := model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
+		Code:    "40901",
+		Message: "no matching catalog",
+	})
+	body := nackBytes(ctx, err)
+
+	var parsed map[string]interface{}
+	if jerr := json.Unmarshal(body, &parsed); jerr != nil {
+		t.Fatalf("nackBytes produced invalid JSON: %v", jerr)
+	}
+	msg, _ := parsed["message"].(map[string]interface{})
+	if msg == nil {
+		t.Fatal("nackBytes body missing 'message'")
+	}
+	if msg["status"] != "ACK" {
+		t.Errorf("nackBytes message.status = %v, want ACK", msg["status"])
+	}
+	if msg["messageId"] != "sign-msg-1" {
+		t.Errorf("nackBytes message.messageId = %v, want sign-msg-1", msg["messageId"])
+	}
+	errField, _ := msg["error"].(map[string]interface{})
+	if errField == nil {
+		t.Fatal("nackBytes body missing message.error")
+	}
+	if errField["code"] != "40901" {
+		t.Errorf("nackBytes error.code = %v, want 40901", errField["code"])
+	}
+
+	// Also verify the body matches what sendNack writes — sign and send must be identical.
+	rr := httptest.NewRecorder()
+	sendNack(ctx, rr, err)
+	if !bytes.Equal(body, rr.Body.Bytes()) {
+		t.Errorf("nackBytes and sendNack produced different bodies:\n  nackBytes: %s\n  sendNack:  %s", body, rr.Body.String())
 	}
 }
 

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -183,6 +183,24 @@ func TestSendNack(t *testing.T) {
 			status:   http.StatusUnauthorized,
 			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"Unauthorized","message":"Signature Validation Error: signature expired"}}}`,
 		},
+		{
+			name: "v2 AckNoCallbackErr ACK status",
+			err: model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
+				Code:    "40901",
+				Message: "no matching catalog",
+			}),
+			status:   http.StatusConflict,
+			expected: `{"message":{"status":"ACK","messageId":"msg-v2-1","error":{"code":"40901","message":"no matching catalog"}}}`,
+		},
+		{
+			name: "v2 AckNoCallbackErr NACK status",
+			err: model.NewAckNoCallbackErr(model.StatusNACK, &model.Error{
+				Code:    "40902",
+				Message: "provider closed",
+			}),
+			status:   http.StatusConflict,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"40902","message":"provider closed"}}}`,
+		},
 	}
 
 	v2Context := v2Ctx("msg-v2-1")
@@ -240,6 +258,24 @@ func TestSendNack(t *testing.T) {
 				t.Errorf("body = %s, want %s", rr.Body.String(), tt.expected)
 			}
 		})
+	}
+}
+
+// TestSendNack_AckNoCallback_PreV2_FallsThrough verifies that AckNoCallbackErr on a
+// pre-v2 request is mapped to 500 Internal Server Error, not 409.
+func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
+	ctx := context.WithValue(context.Background(), model.ContextKeyMsgID, "pre-v2-msg")
+	// No protocol version in context → pre-v2 path.
+
+	rr := httptest.NewRecorder()
+	err := model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
+		Code:    "40901",
+		Message: "no matching catalog",
+	})
+	sendNack(ctx, rr, err)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("pre-v2 AckNoCallbackErr: want 500, got %d", rr.Code)
 	}
 }
 
@@ -317,7 +353,7 @@ func TestNack_1(t *testing.T) {
 				return
 			}
 
-			nack(ctx, w, tt.err, tt.status)
+			nack(ctx, w, tt.err, tt.status, model.StatusNACK)
 			if !tt.useBadWrite {
 				recorder, ok := w.(*httptest.ResponseRecorder)
 				if !ok {

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -111,3 +111,32 @@ func (e *NotFoundErr) BecknError() *Error {
 		Message: "Endpoint not found: " + e.Error(),
 	}
 }
+
+// AckNoCallbackErr is returned by a step when the receiver has authenticated and
+// accepted the request but will not send an async callback — for example, no
+// matching catalog, inventory unavailable, or provider closed. ONIX maps this to
+// HTTP 409 Conflict using the v2 flat response shape. For protocol versions prior
+// to 2.0.0 this error falls through to a 500 Internal Server Error.
+type AckNoCallbackErr struct {
+	// Status is ACK when the request was accepted but no callback will follow,
+	// or NACK when the request was outright rejected.
+	Status Status
+	// Err explains why no callback will be sent. Required by the spec.
+	Err *Error
+}
+
+// NewAckNoCallbackErr constructs an AckNoCallbackErr.
+// Use StatusACK for "accepted but no callback" and StatusNACK for outright rejection.
+func NewAckNoCallbackErr(status Status, err *Error) *AckNoCallbackErr {
+	return &AckNoCallbackErr{Status: status, Err: err}
+}
+
+// Error implements the error interface.
+func (e *AckNoCallbackErr) Error() string {
+	return fmt.Sprintf("AckNoCallback(status=%s): %s", e.Status, e.Err.Error())
+}
+
+// BecknError returns the wrapped *Error payload.
+func (e *AckNoCallbackErr) BecknError() *Error {
+	return e.Err
+}

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -127,7 +127,11 @@ type AckNoCallbackErr struct {
 
 // NewAckNoCallbackErr constructs an AckNoCallbackErr.
 // Use StatusACK for "accepted but no callback" and StatusNACK for outright rejection.
+// Panics if err is nil — the spec requires an error explanation on every 409 response.
 func NewAckNoCallbackErr(status Status, err *Error) *AckNoCallbackErr {
+	if err == nil {
+		panic("AckNoCallbackErr: Err is required")
+	}
 	return &AckNoCallbackErr{Status: status, Err: err}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -199,6 +199,30 @@ func TestSchemaValidationErr_BecknError_NoErrors(t *testing.T) {
 	}
 }
 
+func TestNewAckNoCallbackErr(t *testing.T) {
+	becknErr := &Error{Code: "40901", Message: "no matching catalog"}
+	e := NewAckNoCallbackErr(StatusACK, becknErr)
+
+	if e.Status != StatusACK {
+		t.Errorf("Status = %s, want ACK", e.Status)
+	}
+	if e.BecknError() != becknErr {
+		t.Error("BecknError() did not return the wrapped error")
+	}
+	if e.Error() == "" {
+		t.Error("Error() returned empty string")
+	}
+}
+
+func TestNewAckNoCallbackErr_NilErr_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for nil Err, got none")
+		}
+	}()
+	NewAckNoCallbackErr(StatusACK, nil)
+}
+
 func TestParseContextKey_ValidKeys(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -200,17 +201,40 @@ func TestSchemaValidationErr_BecknError_NoErrors(t *testing.T) {
 }
 
 func TestNewAckNoCallbackErr(t *testing.T) {
-	becknErr := &Error{Code: "40901", Message: "no matching catalog"}
-	e := NewAckNoCallbackErr(StatusACK, becknErr)
+	tests := []struct {
+		name           string
+		status         Status
+		becknErr       *Error
+		wantErrContain string
+	}{
+		{
+			name:           "ACK status",
+			status:         StatusACK,
+			becknErr:       &Error{Code: "40901", Message: "no matching catalog"},
+			wantErrContain: "AckNoCallback(status=ACK)",
+		},
+		{
+			name:           "NACK status",
+			status:         StatusNACK,
+			becknErr:       &Error{Code: "40902", Message: "provider closed"},
+			wantErrContain: "AckNoCallback(status=NACK)",
+		},
+	}
 
-	if e.Status != StatusACK {
-		t.Errorf("Status = %s, want ACK", e.Status)
-	}
-	if e.BecknError() != becknErr {
-		t.Error("BecknError() did not return the wrapped error")
-	}
-	if e.Error() == "" {
-		t.Error("Error() returned empty string")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewAckNoCallbackErr(tt.status, tt.becknErr)
+
+			if e.Status != tt.status {
+				t.Errorf("Status = %s, want %s", e.Status, tt.status)
+			}
+			if e.BecknError() != tt.becknErr {
+				t.Error("BecknError() did not return the wrapped error")
+			}
+			if got := e.Error(); !strings.Contains(got, tt.wantErrContain) {
+				t.Errorf("Error() = %q, want it to contain %q", got, tt.wantErrContain)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Introduces `AckNoCallbackErr` — a new error type pipeline steps can return when the receiver authenticated and accepted a request but will not send an async callback (no matching catalog, inventory unavailable, provider closed)
- ONIX maps this to HTTP 409 Conflict with the v2 LTS flat response shape (`message.status`, `message.messageId`, `message.error`)
- `ackSigner` runs automatically on the 409 path — no new wiring needed
- Pre-v2 requests that encounter `AckNoCallbackErr` fall through to 500 (no-op for legacy)

## What changed

- `pkg/model/error.go` — `AckNoCallbackErr{Status, Err}` with `NewAckNoCallbackErr` constructor; `Status` carries `ACK` (accepted, no callback) or `NACK` (rejected outright) per spec
- `core/module/handler/responsestep.go` — `nackBecknError` returns a third `model.Status` (body-level status); `nackBodyBytes`, `nackBytes`, `nack`, `sendNack` updated to thread it through
- `core/module/handler/responsestep_test.go` — v2 ACK/NACK body status cases added to `TestSendNack`; `TestSendNack_AckNoCallback_PreV2_FallsThrough` added

## Path 1 vs Path 2

**Path 1 (upstream app returns 409):** already worked before this PR. `ackSignerStep.RunOnResponse` signs and forwards transparently — `AckNoCallbackErr` is not involved.

**Path 2 (ONIX pipeline step decides):** what `AckNoCallbackErr` enables. No existing step currently returns it — this PR wires the infrastructure. A follow-up is needed to identify which steps should use it (e.g. a routing step that finds zero matching providers).

## Test plan

- [x] `go test ./core/module/handler/... ./pkg/model/...` passes
- [x] v2 request with step returning `AckNoCallbackErr(StatusACK, ...)` → 409, body `{"message":{"status":"ACK","messageId":"...","error":{...}}}`, `Signature` header set
- [x] v2 request with step returning `AckNoCallbackErr(StatusNACK, ...)` → 409, body `{"message":{"status":"NACK",...}}`
- [x] Pre-v2 request with step returning `AckNoCallbackErr` → 500 (fallthrough)
- [x] Upstream app returning 409 on URL-routing path → forwarded unchanged (Path 1 regression)

Closes #680