### PR TITLE
refactor(definition): replace *http.Response in ResponseStep with ResponseStepContext

### DIFF
--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -1,12 +1,10 @@
 package handler
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -227,18 +225,19 @@ func (a *ackSignerStep) signBodyAndSetHeader(ctx *model.StepContext, body []byte
 
 // RunOnResponse signs the Ack response and sets the Signature header.
 //
-// resp is nil on the publisher path: ONIX controls the ACK body, so the digest
+// rctx is nil on the publisher path: ONIX controls the ACK body, so the digest
 // is computed over the deterministic body that sendAck will write.
-// resp is non-nil on the URL-routing path: the body comes from the upstream
-// app via ReverseProxy, so the digest covers the actual bytes the caller
-// receives. In both cases the Signature header value is identical in structure.
+// rctx is non-nil on the URL-routing path: the body was pre-read by the handler
+// and is available in rctx.Body. rctx.Header is a shared reference to
+// resp.Header, so setting Signature here is forwarded by ReverseProxy without
+// any explicit write-back.
 //
 // This step signs ALL upstream responses including any status code — per
 // NFH-007 CON-004-02 every synchronous response MUST carry a Signature header.
 // ONIX-generated pipeline NACKs are signed separately via stdHandler.signNackResponse
 // (called before sendNack) because the pipelineErr guard prevents
 // response steps from running on pipeline failures.
-func (a *ackSignerStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
+func (a *ackSignerStep) RunOnResponse(ctx *model.StepContext, rctx *model.ResponseStepContext) error {
 	if !model.IsAtLeastV2(ctx.ProtocolVersion) {
 		return nil
 	}
@@ -246,33 +245,20 @@ func (a *ackSignerStep) RunOnResponse(ctx *model.StepContext, resp *http.Respons
 		return model.NewBadReqErr(fmt.Errorf("subscriberID not set"))
 	}
 
-	var ackBody []byte
-	var err error
-
-	if resp != nil {
-		// URL-routing path: sign the actual upstream response body so the
-		// digest covers exactly what the caller will receive.
-		ackBody, err = io.ReadAll(resp.Body)
+	if rctx != nil {
+		// URL-routing path: body is pre-read; rctx.Header is a shared reference
+		// to resp.Header so the Signature reaches ReverseProxy automatically.
+		sigHeader, err := a.computeSigHeader(ctx, rctx.Body)
 		if err != nil {
-			return fmt.Errorf("ackSigner: failed to read upstream response body: %w", err)
+			return err
 		}
-		// Restore the body so the proxy can forward it unchanged.
-		resp.Body = io.NopCloser(bytes.NewReader(ackBody))
-
-		// Set Signature on the upstream response so ReverseProxy forwards it
-		// to the caller. Do NOT set ctx.RespHeader on this path — that header
-		// map belongs to the current handler's own response, not the proxied one.
-		sigHeader, serr := a.computeSigHeader(ctx, ackBody)
-		if serr != nil {
-			return serr
-		}
-		resp.Header.Set("Signature", sigHeader)
+		rctx.Header.Set("Signature", sigHeader)
 		return nil
 	}
 
 	// Publisher / no-route path: ONIX writes the ACK — build the deterministic
 	// body that sendAck will write so the digest matches.
-	ackBody, err = buildAckBody(ctx.ProtocolVersion, ctx.MessageID)
+	ackBody, err := buildAckBody(ctx.ProtocolVersion, ctx.MessageID)
 	if err != nil {
 		return fmt.Errorf("ackSigner: failed to build ack body: %w", err)
 	}
@@ -361,19 +347,19 @@ func newValidateAckSignatureStep(sv definition.SignValidator, km definition.KeyM
 // (log a warning and continue) rather than hard-rejecting.
 //
 // No-ops:
-//   - publisher path (resp == nil) — async ACKs have no Signature header
+//   - publisher path (rctx == nil) — async ACKs have no Signature header
 //   - protocol version < 2.0.0 — pre-v2 flows are unaffected
-func (v *validateAckSignatureStep) RunOnResponse(ctx *model.StepContext, resp *http.Response) error {
-	if resp == nil {
+func (v *validateAckSignatureStep) RunOnResponse(ctx *model.StepContext, rctx *model.ResponseStepContext) error {
+	if rctx == nil {
 		return nil
 	}
 	if !model.IsAtLeastV2(ctx.ProtocolVersion) {
 		return nil
 	}
 
-	sigHeader := resp.Header.Get("Signature")
+	sigHeader := rctx.Header.Get("Signature")
 	if sigHeader == "" {
-		log.Warnf(ctx, "validateAckSign: missing Signature response header on v2 response (status=%d) — degraded trust", resp.StatusCode)
+		log.Warnf(ctx, "validateAckSign: missing Signature response header on v2 response (status=%d) — degraded trust", rctx.StatusCode)
 		return nil
 	}
 
@@ -381,13 +367,6 @@ func (v *validateAckSignatureStep) RunOnResponse(ctx *model.StepContext, resp *h
 	// (step.go signStep.Run). In ModifyResponse, ctx is captured from ServeHTTP
 	// so the header value is the one sent to the upstream BPP/BAP.
 	outboundAuth := extractAuthSignature(ctx.Request.Header.Get(model.AuthHeaderSubscriber))
-
-	ackBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Warnf(ctx, "validateAckSign: failed to read response body: %v — degraded trust", err)
-		return nil
-	}
-	resp.Body = io.NopCloser(bytes.NewReader(ackBody))
 
 	parsed, err := parseHeader(sigHeader)
 	if err != nil {
@@ -401,11 +380,11 @@ func (v *validateAckSignatureStep) RunOnResponse(ctx *model.StepContext, resp *h
 		return nil
 	}
 
-	if err := v.signValidator.ValidateAck(ctx, ackBody, sigHeader, outboundAuth, publicKey); err != nil {
-		log.Warnf(ctx, "validateAckSign: Signature verification failed (status=%d): %v — degraded trust", resp.StatusCode, err)
+	if err := v.signValidator.ValidateAck(ctx, rctx.Body, sigHeader, outboundAuth, publicKey); err != nil {
+		log.Warnf(ctx, "validateAckSign: Signature verification failed (status=%d): %v — degraded trust", rctx.StatusCode, err)
 		return nil
 	}
 
-	log.Debugf(ctx, "validateAckSign: Signature verified OK (status=%d)", resp.StatusCode)
+	log.Debugf(ctx, "validateAckSign: Signature verified OK (status=%d)", rctx.StatusCode)
 	return nil
 }

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -436,17 +435,18 @@ func makeCallerStepCtx(protocolVersion, messageID, subID, outboundAuth string) *
 	}
 }
 
-// makeAckResponse builds a synthetic upstream ACK *http.Response for testing.
-func makeAckResponse(body string, sig string) *http.Response {
-	resp := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
+// makeResponseStepContext builds a synthetic ResponseStepContext for testing,
+// mirroring what the handler constructs from *http.Response in modifyResponse.
+func makeResponseStepContext(statusCode int, body string, sig string) *model.ResponseStepContext {
+	h := http.Header{}
 	if sig != "" {
-		resp.Header.Set("Signature", sig)
+		h.Set("Signature", sig)
 	}
-	return resp
+	return &model.ResponseStepContext{
+		StatusCode: statusCode,
+		Header:     h,
+		Body:       []byte(body),
+	}
 }
 
 const testSigHeader = `Signature keyId="bpp.example.com|key-1|ed25519",algorithm="ed25519",created="1700000000",expires="1700000300",headers="(created) (expires) digest request-signature",signature="dGVzdA=="`
@@ -601,28 +601,18 @@ func TestAckSignerStep_URLRoutingPath_409_SetsSignatureOnResponse(t *testing.T) 
 	}
 
 	ctx := makeStepCtx("2.0.0", "msg-409", "bpp.example.com", "inboundSig==")
-
 	body := `{"message":{"status":"ACK","error":{"code":"40901","message":"no matching catalog"}}}`
-	resp := &http.Response{
-		StatusCode: http.StatusConflict,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}
+	rctx := makeResponseStepContext(http.StatusConflict, body, "")
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("RunOnResponse() unexpected error on 409: %v", err)
 	}
 
 	if !signer.signAckCalled {
 		t.Error("expected SignAck to be called for 409 response")
 	}
-	if resp.Header.Get("Signature") == "" {
+	if rctx.Header.Get("Signature") == "" {
 		t.Fatal("expected Signature header on 409 response")
-	}
-	// Body must be restored so ReverseProxy forwards the original 409 body.
-	restored, _ := io.ReadAll(resp.Body)
-	if string(restored) != body {
-		t.Errorf("resp.Body not restored: got %q, want %q", restored, body)
 	}
 }
 
@@ -636,31 +626,21 @@ func TestAckSignerStep_URLRoutingPath_SetsSignatureOnResponse(t *testing.T) {
 	}
 
 	ctx := makeStepCtx("2.0.0", "msg-url", "bpp.url.com", "inboundSig==")
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"ack":{"status":"ACK"}}}`, "")
 
-	body := `{"message":{"ack":{"status":"ACK"}}}`
-	resp := &http.Response{
-		Header: http.Header{},
-		Body:   io.NopCloser(strings.NewReader(body)),
-	}
-
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("RunOnResponse() unexpected error: %v", err)
 	}
 
 	if !signer.signAckCalled {
 		t.Error("expected SignAck to be called on URL-routing path")
 	}
-	// Signature header must be on the upstream response, not ctx.RespHeader.
-	if resp.Header.Get("Signature") == "" {
-		t.Fatal("expected Signature header on upstream response")
+	// Signature must be on rctx.Header (shared ref to resp.Header), not ctx.RespHeader.
+	if rctx.Header.Get("Signature") == "" {
+		t.Fatal("expected Signature header on rctx.Header")
 	}
 	if ctx.RespHeader.Get("Signature") != "" {
 		t.Error("expected Signature header NOT set on ctx.RespHeader for URL-routing path")
-	}
-	// Body must be restored so the proxy can forward it.
-	restored, _ := io.ReadAll(resp.Body)
-	if string(restored) != body {
-		t.Errorf("resp.Body not restored: got %q, want %q", restored, body)
 	}
 }
 
@@ -701,19 +681,14 @@ func TestValidateAckSignatureStep_V2_ValidSignature(t *testing.T) {
 	}
 
 	ctx := makeCallerStepCtx("2.0.0", "msg-001", "bap.example.com", `Signature keyId="bap.example.com|key-1|ed25519",signature="outboundSig=="`)
-	resp := makeAckResponse(`{"message":{"status":"ACK","messageId":"msg-001"}}`, testSigHeader)
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"status":"ACK","messageId":"msg-001"}}`, testSigHeader)
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("RunOnResponse() unexpected error: %v", err)
 	}
 
 	if !sv.validateAckCalled {
 		t.Error("expected ValidateAck to be called")
-	}
-	// Body must be restored.
-	restored, _ := io.ReadAll(resp.Body)
-	if len(restored) == 0 {
-		t.Error("expected resp.Body to be restored after read")
 	}
 }
 
@@ -739,9 +714,9 @@ func TestValidateAckSignatureStep_PreV2Version_Skips(t *testing.T) {
 
 	step, _ := newValidateAckSignatureStep(sv, km)
 	ctx := makeCallerStepCtx("1.1.0", "msg-003", "bap.example.com", "outboundAuth==")
-	resp := makeAckResponse(`{"message":{"ack":{"status":"ACK"}}}`, "")
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"ack":{"status":"ACK"}}}`, "")
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("RunOnResponse() unexpected error on pre-v2 version: %v", err)
 	}
 	if sv.validateAckCalled {
@@ -758,9 +733,9 @@ func TestValidateAckSignatureStep_MissingSignatureHeader_Degrades(t *testing.T) 
 
 	step, _ := newValidateAckSignatureStep(sv, km)
 	ctx := makeCallerStepCtx("2.0.0", "msg-004", "bap.example.com", "outboundAuth==")
-	resp := makeAckResponse(`{"message":{"status":"ACK"}}`, "") // no Signature header
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"status":"ACK"}}`, "") // no Signature header
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("expected nil (degrade) for missing Signature header, got: %v", err)
 	}
 	if sv.validateAckCalled {
@@ -776,9 +751,9 @@ func TestValidateAckSignatureStep_InvalidSignatureHeader_Degrades(t *testing.T) 
 
 	step, _ := newValidateAckSignatureStep(sv, km)
 	ctx := makeCallerStepCtx("2.0.0", "msg-005", "bap.example.com", "outboundAuth==")
-	resp := makeAckResponse(`{"message":{"status":"ACK"}}`, "malformed-header-no-keyId")
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"status":"ACK"}}`, "malformed-header-no-keyId")
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("expected nil (degrade) for malformed Signature header, got: %v", err)
 	}
 }
@@ -791,9 +766,9 @@ func TestValidateAckSignatureStep_KeyManagerError_Degrades(t *testing.T) {
 
 	step, _ := newValidateAckSignatureStep(sv, km)
 	ctx := makeCallerStepCtx("2.0.0", "msg-006", "bap.example.com", "outboundAuth==")
-	resp := makeAckResponse(`{"message":{"status":"ACK"}}`, testSigHeader)
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"status":"ACK"}}`, testSigHeader)
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("expected nil (degrade) when KeyManager lookup fails, got: %v", err)
 	}
 }
@@ -806,9 +781,9 @@ func TestValidateAckSignatureStep_ValidatorError_Degrades(t *testing.T) {
 
 	step, _ := newValidateAckSignatureStep(sv, km)
 	ctx := makeCallerStepCtx("2.0.0", "msg-007", "bap.example.com", "outboundAuth==")
-	resp := makeAckResponse(`{"message":{"status":"ACK"}}`, testSigHeader)
+	rctx := makeResponseStepContext(http.StatusOK, `{"message":{"status":"ACK"}}`, testSigHeader)
 
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("expected nil (degrade) when ValidateAck fails, got: %v", err)
 	}
 }
@@ -834,12 +809,8 @@ func TestValidateAckSignatureStep_MissingSignature_AllStatusCodes_Degrades(t *te
 		http.StatusInternalServerError,
 	}
 	for _, code := range codes {
-		resp := &http.Response{
-			StatusCode: code,
-			Header:     http.Header{},
-			Body:       io.NopCloser(strings.NewReader(`{"message":{"ack":{"status":"NACK"}}}`)),
-		}
-		if err := step.RunOnResponse(ctx, resp); err != nil {
+		rctx := makeResponseStepContext(code, `{"message":{"ack":{"status":"NACK"}}}`, "")
+		if err := step.RunOnResponse(ctx, rctx); err != nil {
 			t.Errorf("status %d: expected nil (degrade), got %v", code, err)
 		}
 		if sv.validateAckCalled {
@@ -867,12 +838,8 @@ func TestValidateAckSignatureStep_ValidSignature_AllStatusCodes(t *testing.T) {
 	}
 	for _, code := range codes {
 		sv.validateAckCalled = false
-		resp := &http.Response{
-			StatusCode: code,
-			Header:     http.Header{"Signature": []string{testSigHeader}},
-			Body:       io.NopCloser(strings.NewReader(`{"message":{"status":"ACK"}}`)),
-		}
-		if err := step.RunOnResponse(ctx, resp); err != nil {
+		rctx := makeResponseStepContext(code, `{"message":{"status":"ACK"}}`, testSigHeader)
+		if err := step.RunOnResponse(ctx, rctx); err != nil {
 			t.Errorf("status %d: unexpected error: %v", code, err)
 		}
 		if !sv.validateAckCalled {
@@ -890,19 +857,15 @@ func TestAckSignerStep_UpstreamApp_4xx_Signs(t *testing.T) {
 
 	step, _ := newAckSignerStep(signer, km)
 	ctx := makeStepCtx("2.0.0", "msg-nack", "bpp.example.com", "inboundSig==")
+	rctx := makeResponseStepContext(http.StatusBadRequest, `{"message":{"ack":{"status":"NACK"}}}`, "")
 
-	resp := &http.Response{
-		StatusCode: http.StatusBadRequest,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader(`{"message":{"ack":{"status":"NACK"}}}`)),
-	}
-	if err := step.RunOnResponse(ctx, resp); err != nil {
+	if err := step.RunOnResponse(ctx, rctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !signer.signAckCalled {
 		t.Error("expected SignAck to be called even for upstream 4xx")
 	}
-	if resp.Header.Get("Signature") == "" {
+	if rctx.Header.Get("Signature") == "" {
 		t.Error("expected Signature header to be set on upstream 4xx response")
 	}
 }

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -339,12 +339,23 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		log.Request(req.Context(), req, ctx.Body)
 	}
 
-	// modifyResponse is a thin dispatcher — zero business logic. It iterates
-	// response steps with the upstream *http.Response so each step can read
-	// the actual response body (e.g. for digest computation in ackSigner).
+	// modifyResponse pre-reads the upstream response body once, constructs a
+	// ResponseStepContext, then runs all response steps. Body restoration for
+	// ReverseProxy happens here — individual steps read from rctx.Body and do
+	// not need to touch resp.Body directly.
 	modifyResponse := func(resp *http.Response) error {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("modifyResponse: failed to read upstream response body: %w", err)
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		rctx := &model.ResponseStepContext{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header,
+			Body:       body,
+		}
 		for _, step := range responseSteps {
-			if err := step.RunOnResponse(ctx, resp); err != nil {
+			if err := step.RunOnResponse(ctx, rctx); err != nil {
 				return err
 			}
 		}

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -483,7 +483,7 @@ type mockResponseStep struct {
 	err    error
 }
 
-func (m *mockResponseStep) RunOnResponse(_ *model.StepContext, _ *http.Response) error {
+func (m *mockResponseStep) RunOnResponse(_ *model.StepContext, _ *model.ResponseStepContext) error {
 	m.called = true
 	return m.err
 }
@@ -605,7 +605,7 @@ type mockOrderResponseStep struct {
 	order *[]string
 }
 
-func (m *mockOrderResponseStep) RunOnResponse(_ *model.StepContext, _ *http.Response) error {
+func (m *mockOrderResponseStep) RunOnResponse(_ *model.StepContext, _ *model.ResponseStepContext) error {
 	*m.order = append(*m.order, m.name)
 	return nil
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -207,6 +207,22 @@ func (ctx *StepContext) WithContext(newCtx context.Context) {
 	ctx.Context = newCtx
 }
 
+// ResponseStepContext carries response-phase data for the response step pipeline.
+// It is constructed by the handler from *http.Response before response steps run,
+// keeping transport types out of the ResponseStep interface.
+//
+// A nil ResponseStepContext signals the publisher path — ONIX writes the ACK
+// itself and there is no upstream response to inspect.
+//
+// Header is a shared reference to resp.Header; mutations made by steps (e.g.
+// writing the Signature header) are visible to the handler and forwarded by
+// ReverseProxy without any explicit write-back.
+type ResponseStepContext struct {
+	StatusCode int
+	Header     http.Header // shared reference — step mutations visible to caller
+	Body       []byte      // pre-read response body; nil on publisher path
+}
+
 // Status represents the acknowledgment status in a response.
 type Status string
 

--- a/pkg/plugin/definition/step.go
+++ b/pkg/plugin/definition/step.go
@@ -2,7 +2,6 @@ package definition
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
@@ -15,13 +14,12 @@ type Step interface {
 // ResponseStep is executed after all inbound Steps succeed, before the
 // synchronous ACK is written back to the caller.
 //
-// resp is nil on the publisher path (ONIX writes the ACK itself); on the
-// URL-routing path resp is the upstream HTTP response so implementations can
-// read and restore the actual response body (e.g. for digest computation).
-// Implementations set response headers either on ctx.RespHeader (publisher
-// path) or on resp.Header (URL-routing path).
+// rctx is nil on the publisher path (ONIX writes the ACK itself); on the
+// URL-routing path rctx carries the pre-read upstream response body, headers,
+// and status code. Header is a shared reference — mutations (e.g. writing a
+// Signature header) are forwarded by ReverseProxy without explicit write-back.
 type ResponseStep interface {
-	RunOnResponse(ctx *model.StepContext, resp *http.Response) error
+	RunOnResponse(ctx *model.StepContext, rctx *model.ResponseStepContext) error
 }
 
 type StepProvider interface {


### PR DESCRIPTION
## Summary

- Introduces `model.ResponseStepContext` — a small domain struct (`StatusCode`, `Header`, `Body`) that replaces `*http.Response` in the `ResponseStep` interface
- `pkg/plugin/definition/step.go` loses its `net/http` import entirely; the interface now deals only in domain types
- Body read/restore is centralised in `stdHandler.proxy`'s `modifyResponse` — individual step implementations no longer each do their own `io.ReadAll` + `io.NopCloser(bytes.NewReader(...))` dance

## Motivation

Closes #728. The original `RunOnResponse(*model.StepContext, *http.Response)` signature leaked a transport-layer type into every layer that touched `ResponseStep`, including pure cross-cutting wrappers like the planned `InstrumentedResponseStep` (#713). The wrapper never used `*http.Response` for anything — it only forwarded it — yet was forced to import `net/http`.

## Test plan

- [ ] `go test ./core/module/handler/ ./pkg/model/ ./pkg/plugin/definition/` passes clean
- [ ] All existing `ackSignerStep` and `validateAckSignatureStep` tests updated to use `makeResponseStepContext` helper — body-restore assertions removed from step tests (that responsibility now lives in the handler)
- [ ] `mockResponseStep` and `mockOrderResponseStep` in `stdHandler_test.go` updated to match new interface

## Migration note

Any external implementation of `definition.ResponseStep` must update its `RunOnResponse` signature from `*http.Response` to `*model.ResponseStepContext`. The nil-check semantics are preserved: `rctx == nil` signals the publisher path, identical to the former `resp == nil`.

## Unblocks

#713 — `InstrumentedResponseStep` can now be added to `step_instrumentor.go` without importing `net/http`.