### PR TITLE
feat(observability): add InstrumentedResponseStep for response pipeline telemetry

### DIFF
--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -541,7 +541,13 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			if concreteAS, ok := as.(*ackSignerStep); ok {
 				h.ackSigner = concreteAS
 			}
-			h.responseSteps = append(h.responseSteps, as)
+			instrumentedAS, wrapErr := NewInstrumentedResponseStep(as, step, h.moduleName)
+			if wrapErr != nil {
+				log.Warnf(ctx, "Failed to instrument response step %s: %v", step, wrapErr)
+				h.responseSteps = append(h.responseSteps, as)
+				continue
+			}
+			h.responseSteps = append(h.responseSteps, instrumentedAS)
 			continue
 		case "validateAckSign":
 			// validateAckSign is a ResponseStep — verifies the Signature header
@@ -550,7 +556,13 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			if rsErr != nil {
 				return rsErr
 			}
-			h.responseSteps = append(h.responseSteps, rs)
+			instrumentedRS, wrapErr := NewInstrumentedResponseStep(rs, step, h.moduleName)
+			if wrapErr != nil {
+				log.Warnf(ctx, "Failed to instrument response step %s: %v", step, wrapErr)
+				h.responseSteps = append(h.responseSteps, rs)
+				continue
+			}
+			h.responseSteps = append(h.responseSteps, instrumentedRS)
 			continue
 		case "sign":
 			s, err = newSignStep(h.signer, h.km, h.payloadStore)

--- a/core/module/handler/step_instrumentor.go
+++ b/core/module/handler/step_instrumentor.go
@@ -100,3 +100,82 @@ func (is *InstrumentedStep) Run(ctx *model.StepContext) error {
 	ctx.WithContext(stepCtx.Context)
 	return err
 }
+
+// ---------------------------------------------------------------------------
+// InstrumentedResponseStep
+// ---------------------------------------------------------------------------
+
+// ResponseStepRunner is the minimal contract required for response step instrumentation.
+type ResponseStepRunner interface {
+	RunOnResponse(*model.StepContext, *model.ResponseStepContext) error
+}
+
+// InstrumentedResponseStep wraps a response processing step with telemetry instrumentation.
+type InstrumentedResponseStep struct {
+	step       ResponseStepRunner
+	stepName   string
+	moduleName string
+	metrics    *StepMetrics
+}
+
+// NewInstrumentedResponseStep returns a telemetry-enabled wrapper around a definition.ResponseStep.
+func NewInstrumentedResponseStep(step ResponseStepRunner, stepName, moduleName string) (*InstrumentedResponseStep, error) {
+	metrics, err := GetStepMetrics(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return &InstrumentedResponseStep{
+		step:       step,
+		stepName:   stepName,
+		moduleName: moduleName,
+		metrics:    metrics,
+	}, nil
+}
+
+// RunOnResponse executes the underlying response step and records RED style metrics.
+//
+// Note: validateAckSign is a soft-failure step — it returns nil even on signature
+// verification failures (degraded-trust design). onix_step_errors_total will never
+// increment for that step; its own log.Warnf calls are the only signal for soft failures.
+func (is *InstrumentedResponseStep) RunOnResponse(ctx *model.StepContext, rctx *model.ResponseStepContext) error {
+	if is.metrics == nil {
+		return is.step.RunOnResponse(ctx, rctx)
+	}
+
+	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
+	spanCtx, span := tracer.Start(ctx.Context, "response-step:"+is.stepName)
+	defer span.End()
+
+	stepCtx := *ctx
+	stepCtx.Context = spanCtx
+
+	start := time.Now()
+	err := is.step.RunOnResponse(&stepCtx, rctx)
+	duration := time.Since(start).Seconds()
+
+	attrs := []attribute.KeyValue{
+		telemetry.AttrModule.String(is.moduleName),
+		telemetry.AttrStep.String(is.stepName),
+		telemetry.AttrRole.String(string(stepCtx.Role)),
+	}
+
+	is.metrics.StepExecutionTotal.Add(stepCtx.Context, 1, metric.WithAttributes(attrs...))
+	is.metrics.StepExecutionDuration.Record(stepCtx.Context, duration, metric.WithAttributes(attrs...))
+
+	if err != nil {
+		errorType := fmt.Sprintf("%T", err)
+		var becknErr becknError
+		if errors.As(err, &becknErr) {
+			if be := becknErr.BecknError(); be != nil && be.Code != "" {
+				errorType = be.Code
+			}
+		}
+
+		errorAttrs := append(attrs, telemetry.AttrErrorType.String(errorType))
+		is.metrics.StepErrorsTotal.Add(stepCtx.Context, 1, metric.WithAttributes(errorAttrs...))
+		log.Errorf(stepCtx.Context, err, "Response step %s failed", is.stepName)
+	}
+
+	ctx.WithContext(stepCtx.Context)
+	return err
+}

--- a/core/module/handler/step_instrumentor_test.go
+++ b/core/module/handler/step_instrumentor_test.go
@@ -50,3 +50,70 @@ func TestInstrumentedStepError(t *testing.T) {
 	require.Error(t, step.Run(stepCtx))
 }
 
+// ---------------------------------------------------------------------------
+// InstrumentedResponseStep tests
+// ---------------------------------------------------------------------------
+
+type stubResponseStep struct {
+	err     error
+	gotRctx *model.ResponseStepContext
+}
+
+func (s *stubResponseStep) RunOnResponse(_ *model.StepContext, rctx *model.ResponseStepContext) error {
+	s.gotRctx = rctx
+	return s.err
+}
+
+func TestInstrumentedResponseStepSuccess(t *testing.T) {
+	ctx := context.Background()
+	provider, err := telemetry.NewTestProvider(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(context.Background())
+
+	step, err := NewInstrumentedResponseStep(&stubResponseStep{}, "signAck", "test-module")
+	require.NoError(t, err)
+
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Role:    model.RoleBAP,
+	}
+	require.NoError(t, step.RunOnResponse(stepCtx, nil))
+}
+
+func TestInstrumentedResponseStepError(t *testing.T) {
+	ctx := context.Background()
+	provider, err := telemetry.NewTestProvider(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(context.Background())
+
+	step, err := NewInstrumentedResponseStep(&stubResponseStep{err: errors.New("sign failed")}, "signAck", "test-module")
+	require.NoError(t, err)
+
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Role:    model.RoleBAP,
+	}
+	require.Error(t, step.RunOnResponse(stepCtx, nil))
+}
+
+// TestInstrumentedResponseStepPassesRctx verifies that the wrapper forwards
+// the *model.ResponseStepContext to the inner step unchanged (URL-routing path).
+func TestInstrumentedResponseStepPassesRctx(t *testing.T) {
+	ctx := context.Background()
+	provider, err := telemetry.NewTestProvider(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(context.Background())
+
+	stub := &stubResponseStep{}
+	step, err := NewInstrumentedResponseStep(stub, "validateAckSign", "test-module")
+	require.NoError(t, err)
+
+	rctx := &model.ResponseStepContext{StatusCode: 200, Body: []byte(`{"message":{"status":"ACK"}}`)}
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Role:    model.RoleBPP,
+	}
+	require.NoError(t, step.RunOnResponse(stepCtx, rctx))
+	require.Equal(t, rctx, stub.gotRctx)
+}
+


### PR DESCRIPTION
## Summary

- Adds `InstrumentedResponseStep` to `step_instrumentor.go` — single file for all step instrumentation (inbound and response)
- Wraps `signAck` and `validateAckSign` in `initSteps` with OTel spans and RED metrics, matching the existing `InstrumentedStep` pattern
- No `net/http` import in `step_instrumentor.go` — made possible by #729 which replaced `*http.Response` with `*model.ResponseStepContext` in the `ResponseStep` interface

## What you'll see in telemetry

**Traces:** each response step produces a child span named `response-step:signAck` / `response-step:validateAckSign` nested under the parent request span, visible alongside the existing inbound `step:*` spans.

**Metrics** (same instruments, new step labels):
| Metric | Labels |
|---|---|
| `onix_step_executions_total` | `module`, `step=signAck\|validateAckSign`, `role` |
| `onix_step_execution_duration_seconds` | same |
| `onix_step_errors_total` | + `error_type` |

> Note: `validateAckSign` is a soft-failure step by design — it returns nil on signature failures and emits `log.Warnf` instead. `onix_step_errors_total` will never increment for it; the warn logs are the signal for degraded-trust events.

## Test plan

- [ ] `go test ./core/module/handler/` passes clean
- [ ] `TestInstrumentedResponseStepSuccess` — nil rctx (publisher path), no error, span + execution counter recorded
- [ ] `TestInstrumentedResponseStepError` — inner step errors, error metric incremented, error logged
- [ ] `TestInstrumentedResponseStepPassesRctx` — non-nil rctx forwarded to inner step unchanged (URL-routing path)

## Depends on

#729 (merged) — `ResponseStepContext` replaces `*http.Response` in the `ResponseStep` interface.

Closes #713