### PR TITLE
fix(manifestloader): resolve cache-miss log noise and Redis fault tolerance

### DIFF
--- a/benchmarks/tools/generate_report.go
+++ b/benchmarks/tools/generate_report.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // generate_report.go — Fills REPORT_TEMPLATE.md with data from a completed
 // benchmark run and writes BENCHMARK_REPORT.md to the results directory.
 //
@@ -51,8 +53,6 @@
 //	__CACHE_DELTA__       formatted warm-vs-cold delta string
 //	__THROUGHPUT_TABLE__  generated markdown table from throughput_report.csv
 //	__BENCHSTAT_SUMMARY__ raw contents of benchstat_summary.txt
-
-//go:build ignore
 
 package main
 

--- a/benchmarks/tools/generate_report.go
+++ b/benchmarks/tools/generate_report.go
@@ -51,6 +51,9 @@
 //	__CACHE_DELTA__       formatted warm-vs-cold delta string
 //	__THROUGHPUT_TABLE__  generated markdown table from throughput_report.csv
 //	__BENCHSTAT_SUMMARY__ raw contents of benchstat_summary.txt
+
+//go:build ignore
+
 package main
 
 import (

--- a/benchmarks/tools/parse_results.go
+++ b/benchmarks/tools/parse_results.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // parse_results.go — Parses raw go test -bench output from the benchmark results
 // directory and produces two CSV files for analysis and reporting.
 //
@@ -11,8 +13,6 @@
 //
 //	latency_report.csv    — per-benchmark mean, p50, p95, p99 latency, allocs
 //	throughput_report.csv — RPS and mean latency at each GOMAXPROCS level from the parallel sweep
-
-//go:build ignore
 
 package main
 

--- a/benchmarks/tools/parse_results.go
+++ b/benchmarks/tools/parse_results.go
@@ -11,6 +11,9 @@
 //
 //	latency_report.csv    — per-benchmark mean, p50, p95, p99 latency, allocs
 //	throughput_report.csv — RPS and mean latency at each GOMAXPROCS level from the parallel sweep
+
+//go:build ignore
+
 package main
 
 import (

--- a/pkg/plugin/implementation/cache/cache.go
+++ b/pkg/plugin/implementation/cache/cache.go
@@ -137,8 +137,13 @@ func (c *Cache) Get(ctx context.Context, key string) (string, error) {
 		}
 	}
 	if errors.Is(err, redis.Nil) {
+		// redis.Nil means the key does not exist — a normal cache miss, not an error.
+		// Callers distinguish a miss from a hit by checking whether the returned string is
+		// empty; they must not treat a non-nil error as the only miss signal.
 		return "", nil
 	}
+	// go-redis guarantees result == "" whenever err != nil, so returning result here is
+	// equivalent to returning "" on any error path.
 	return result, err
 }
 

--- a/pkg/plugin/implementation/manifestloader/manifestloader.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader.go
@@ -99,7 +99,7 @@ func (l *Loader) GetByNetworkID(ctx context.Context, networkID string) (*model.M
 		} else if err != nil {
 			log.Warnf(ctx, "ManifestLoader: cache error for networkID=%q key=%q: %v", networkID, networkKey, err)
 		} else {
-			log.Infof(ctx, "ManifestLoader: cache miss for networkID=%q key=%q", networkID, networkKey)
+			log.Debugf(ctx, "ManifestLoader: cache miss for networkID=%q key=%q", networkID, networkKey)
 		}
 	} else {
 		log.Infof(ctx, "ManifestLoader: bypassing cache for networkID=%q", networkID)
@@ -146,7 +146,7 @@ func (l *Loader) getByMetadata(ctx context.Context, metadata model.ManifestMetad
 		} else if err != nil {
 			log.Warnf(ctx, "ManifestLoader: metadata cache error for source=%s key=%q: %v", metadata.ManifestURL, cacheKey, err)
 		} else {
-			log.Infof(ctx, "ManifestLoader: metadata cache miss for source=%s key=%q", metadata.ManifestURL, cacheKey)
+			log.Debugf(ctx, "ManifestLoader: metadata cache miss for source=%s key=%q", metadata.ManifestURL, cacheKey)
 		}
 	} else {
 		log.Infof(ctx, "ManifestLoader: bypassing metadata cache for source=%s", metadata.ManifestURL)

--- a/pkg/plugin/implementation/manifestloader/manifestloader.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader.go
@@ -93,11 +93,13 @@ func (l *Loader) GetByNetworkID(ctx context.Context, networkID string) (*model.M
 	networkKey := networkCacheKey(networkID)
 	bypassCache := l.shouldBypassCache(networkKey)
 	if !bypassCache {
-		if doc, err := l.loadFromCache(ctx, networkKey); err == nil {
+		if doc, err := l.loadFromCache(ctx, networkKey); err == nil && doc != nil {
 			log.Infof(ctx, "ManifestLoader: cache hit for networkID=%q fetchedAt=%s source=%s", networkID, doc.FetchedAt.Format(time.RFC3339), doc.SourceURL)
 			return doc, nil
+		} else if err != nil {
+			log.Warnf(ctx, "ManifestLoader: cache error for networkID=%q key=%q: %v", networkID, networkKey, err)
 		} else {
-			log.Debugf(ctx, "ManifestLoader: cache miss for networkID=%q key=%q: %v", networkID, networkKey, err)
+			log.Infof(ctx, "ManifestLoader: cache miss for networkID=%q key=%q", networkID, networkKey)
 		}
 	} else {
 		log.Infof(ctx, "ManifestLoader: bypassing cache for networkID=%q", networkID)
@@ -138,11 +140,13 @@ func (l *Loader) getByMetadata(ctx context.Context, metadata model.ManifestMetad
 	}
 	cacheKey := metadataCacheKey(metadata)
 	if !bypassCache {
-		if doc, err := l.loadFromCache(ctx, cacheKey); err == nil {
+		if doc, err := l.loadFromCache(ctx, cacheKey); err == nil && doc != nil {
 			log.Infof(ctx, "ManifestLoader: metadata cache hit for source=%s fetchedAt=%s", metadata.ManifestURL, doc.FetchedAt.Format(time.RFC3339))
 			return doc, nil
+		} else if err != nil {
+			log.Warnf(ctx, "ManifestLoader: metadata cache error for source=%s key=%q: %v", metadata.ManifestURL, cacheKey, err)
 		} else {
-			log.Debugf(ctx, "ManifestLoader: metadata cache miss for source=%s key=%q: %v", metadata.ManifestURL, cacheKey, err)
+			log.Infof(ctx, "ManifestLoader: metadata cache miss for source=%s key=%q", metadata.ManifestURL, cacheKey)
 		}
 	} else {
 		log.Infof(ctx, "ManifestLoader: bypassing metadata cache for source=%s", metadata.ManifestURL)
@@ -216,6 +220,9 @@ func (l *Loader) loadFromCache(ctx context.Context, key string) (*model.Manifest
 	if err != nil {
 		return nil, err
 	}
+	if raw == "" {
+		return nil, nil
+	}
 	var doc model.ManifestDocument
 	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
 		return nil, err
@@ -232,9 +239,18 @@ func (l *Loader) store(ctx context.Context, key string, doc *model.ManifestDocum
 	}
 	payload, err := json.Marshal(doc)
 	if err != nil {
+		// Marshal failure is a code bug (ManifestDocument contains a non-serialisable type),
+		// not a transient infrastructure problem — surface it immediately.
 		return err
 	}
-	return l.cache.Set(ctx, key, string(payload), l.config.CacheTTL)
+	if err := l.cache.Set(ctx, key, string(payload), l.config.CacheTTL); err != nil {
+		// A write failure means the next request will be a cache miss and re-fetch from the
+		// registry, which is acceptable degraded behaviour. Propagating the error would cause
+		// the caller to return nothing to the client even though the manifest was successfully
+		// fetched and verified — that trade-off is wrong.
+		log.Warnf(ctx, "ManifestLoader: failed to cache manifest key=%q: %v", key, err)
+	}
+	return nil
 }
 
 func (l *Loader) shouldBypassCache(key string) bool {

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -26,7 +26,7 @@ func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
 	}
 	value, ok := m.store[key]
 	if !ok {
-		return "", errors.New("cache miss")
+		return "", nil
 	}
 	return value, nil
 }
@@ -146,6 +146,20 @@ func TestGetByNetworkIDRejectsUnverifiedCacheEntry(t *testing.T) {
 	}
 	if _, err := loader.loadFromCache(context.Background(), networkCacheKey("nfo.example.org/network")); err == nil || !strings.Contains(err.Error(), "not marked verified") {
 		t.Fatalf("expected unverified cache rejection, got %v", err)
+	}
+}
+
+func TestLoadFromCacheOnCacheMissReturnsNilNil(t *testing.T) {
+	loader, _, err := New(context.Background(), &mockCache{store: map[string]string{}}, &mockRegistry{}, &Config{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	doc, err := loader.loadFromCache(context.Background(), "any-key")
+	if err != nil {
+		t.Fatalf("expected nil error on cache miss, got %v", err)
+	}
+	if doc != nil {
+		t.Fatalf("expected nil doc on cache miss, got %+v", doc)
 	}
 }
 

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 type mockCache struct {
-	store map[string]string
-	err   error
+	store  map[string]string
+	err    error // injected into every operation
+	setErr error // injected into Set only; Get still works
 }
 
 func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
@@ -33,6 +34,9 @@ func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
 func (m *mockCache) Set(ctx context.Context, key, value string, ttl time.Duration) error {
 	if m.err != nil {
 		return m.err
+	}
+	if m.setErr != nil {
+		return m.setErr
 	}
 	m.store[key] = value
 	return nil
@@ -213,6 +217,101 @@ func TestGetByNetworkIDResolvesMetadata(t *testing.T) {
 	}
 	if _, ok := cache.store[networkCacheKey("nfo.example.org/network")]; !ok {
 		t.Fatal("expected network-specific cache key to be populated")
+	}
+}
+
+func TestGetByMetadata_CacheWriteErrorStillReturnsManifest(t *testing.T) {
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	manifest := []byte("manifest: true")
+	signature := ed25519.Sign(privateKey, manifest)
+
+	originalHTTPClientFunc := httpClientFunc
+	httpClientFunc = func(timeout time.Duration) *http.Client {
+		return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://example.org/manifest":
+				return response(200, string(manifest), "application/yaml"), nil
+			case "https://example.org/manifest.sig":
+				return response(200, base64.StdEncoding.EncodeToString(signature), "text/plain"), nil
+			case "https://example.org/pubkey":
+				return response(200, base64.StdEncoding.EncodeToString(publicKey), "text/plain"), nil
+			default:
+				return response(404, "not found", "text/plain"), nil
+			}
+		})}
+	}
+	defer func() { httpClientFunc = originalHTTPClientFunc }()
+
+	cache := &mockCache{store: map[string]string{}, setErr: errors.New("redis: connection refused")}
+	loader, _, err := New(context.Background(), cache, &mockRegistry{}, &Config{CacheTTL: time.Hour, FetchTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	doc, err := loader.GetByMetadata(context.Background(), model.ManifestMetadata{
+		ManifestURL:               "https://example.org/manifest",
+		ManifestSignatureURL:      "https://example.org/manifest.sig",
+		SigningPublicKeyLookupURL: "https://example.org/pubkey",
+	})
+	if err != nil {
+		t.Fatalf("expected manifest despite cache write error, got: %v", err)
+	}
+	if string(doc.Content) != string(manifest) {
+		t.Fatalf("unexpected manifest content: %q", string(doc.Content))
+	}
+	if len(cache.store) != 0 {
+		t.Errorf("expected nothing written to cache when Set fails, store had %d keys", len(cache.store))
+	}
+}
+
+func TestGetByNetworkID_CacheWriteErrorStillReturnsManifest(t *testing.T) {
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	manifest := []byte("hello")
+	signature := ed25519.Sign(privateKey, manifest)
+
+	originalHTTPClientFunc := httpClientFunc
+	httpClientFunc = func(timeout time.Duration) *http.Client {
+		return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://example.org/manifest":
+				return response(200, string(manifest), "text/plain"), nil
+			case "https://example.org/manifest.sig":
+				return response(200, base64.StdEncoding.EncodeToString(signature), "text/plain"), nil
+			case "https://example.org/pubkey":
+				return response(200, `{"data":{"details":{"signing_public_key":"`+base64.StdEncoding.EncodeToString(publicKey)+`"}}}`, "application/json"), nil
+			default:
+				return response(404, "not found", "text/plain"), nil
+			}
+		})}
+	}
+	defer func() { httpClientFunc = originalHTTPClientFunc }()
+
+	cache := &mockCache{store: map[string]string{}, setErr: errors.New("redis: connection refused")}
+	registry := &mockRegistry{
+		meta: &model.RegistryMetadata{
+			NamespaceIdentifier: "nfo.example.org",
+			RegistryName:        "network",
+			RawMeta: map[string]string{
+				"manifest_url":                  "https://example.org/manifest",
+				"manifest_signature_url":        "https://example.org/manifest.sig",
+				"signing_public_key_lookup_url": "https://example.org/pubkey",
+			},
+		},
+	}
+	loader, _, err := New(context.Background(), cache, registry, &Config{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	doc, err := loader.GetByNetworkID(context.Background(), "nfo.example.org/network")
+	if err != nil {
+		t.Fatalf("expected manifest despite cache write error, got: %v", err)
+	}
+	if doc.NetworkID != "nfo.example.org/network" {
+		t.Fatalf("expected networkID to be set on returned document")
+	}
+	if len(cache.store) != 0 {
+		t.Errorf("expected nothing written to cache when Set fails, store had %d keys", len(cache.store))
 	}
 }
 

--- a/pkg/plugin/implementation/payloadstore/payloadstore_test.go
+++ b/pkg/plugin/implementation/payloadstore/payloadstore_test.go
@@ -22,9 +22,21 @@ type stubCache struct {
 func (c *stubCache) Get(_ context.Context, key string) (string, error) {
 	v, ok := c.mu.Load(key)
 	if !ok {
-		return "", nil
+		return "", nil // miss — matches real cache.Get contract (no error on key-not-found)
 	}
 	return v.(string), nil
+}
+
+// errGetCache wraps stubCache and injects a fixed error on every Get call,
+// simulating a Redis connection failure. Set/Delete/Clear still work so Store
+// can persist after Exists fails.
+type errGetCache struct {
+	stubCache
+	err error
+}
+
+func (c *errGetCache) Get(_ context.Context, _ string) (string, error) {
+	return "", c.err
 }
 
 func (c *stubCache) Set(_ context.Context, key, value string, _ time.Duration) error {
@@ -536,5 +548,39 @@ func TestGetByTransactionID_EmptyTransactionID(t *testing.T) {
 	entries, err := s.GetByTransactionID(context.Background(), "")
 	if err != nil || entries != nil {
 		t.Errorf("expected nil, nil for empty transaction_id; got %v, %v", entries, err)
+	}
+}
+
+func TestExists_CacheErrorPropagated(t *testing.T) {
+	cacheErr := fmt.Errorf("redis: connection refused")
+	ec := &errGetCache{err: cacheErr}
+	s, _, err := New(context.Background(), ec, testNamespace, map[string]string{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ok, err := s.Exists(context.Background(), "any")
+	if err == nil {
+		t.Error("expected error from Exists when cache.Get fails, got nil")
+	}
+	if ok {
+		t.Error("expected false from Exists when cache.Get fails")
+	}
+}
+
+func TestStore_ContinuesAfterExistsCacheError(t *testing.T) {
+	// When cache.Get fails, Exists returns an error and duplicate detection is
+	// skipped — but Store must still persist the entry rather than aborting.
+	ec := &errGetCache{err: fmt.Errorf("redis: connection refused")}
+	s, _, err := New(context.Background(), ec, testNamespace, map[string]string{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := s.Store(sampleStepCtx("msgErrExists", "txnErrExists")); err != nil {
+		t.Errorf("Store should succeed despite Exists cache error, got: %v", err)
+	}
+	// Verify the entry was written: peek directly at the underlying stubCache.
+	raw, _ := ec.stubCache.Get(context.Background(), msgKey(testNamespace, "msgErrExists"))
+	if raw == "" {
+		t.Error("expected msg key to be stored even when Exists returned a cache error")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes issue #724, a regression introduced by #717 which changed `cache.Get` to return `("", nil)` on a Redis key-not-found instead of propagating `redis.Nil`. Three related problems are fixed together, along with test coverage improvements and a build-tag fix.

### Problem 1 — Spurious `"unexpected end of JSON input"` on every cache miss
`loadFromCache` had no guard for an empty raw string before calling `json.Unmarshal`. After #717, every cold-start miss hit `json.Unmarshal([]byte(""), ...)` and logged a misleading data-corruption error. Functionally harmless, but noisy and alarming for operators.

**Fix:** return `(nil, nil)` on empty raw; callers updated to check `doc != nil` before treating the result as a hit.

### Problem 2 — Redis write failure caused the entire load to fail
`store()` propagated `cache.Set` errors back to the caller. A Redis outage would cause `GetByNetworkID` / `getByMetadata` to return an error even after successfully fetching and verifying the manifest from the remote registry.

**Fix:** `store()` now logs a `Warn` and returns `nil` on a write failure — the next request gets a cache miss and re-fetches, which is acceptable degraded behaviour.

### Test coverage improvements
- **`manifestloader`**: Updated `mockCache.Get` to return `("", nil)` on miss, matching the real post-#717 cache contract so this class of regression is caught by tests going forward. Added `TestLoadFromCacheOnCacheMissReturnsNilNil` to directly exercise the fixed path.
- **`payloadstore`**: Added `errGetCache` stub for cache error injection. Added `TestExists_CacheErrorPropagated` (verifies `Exists` surfaces real errors to callers) and `TestStore_ContinuesAfterExistsCacheError` (verifies `Store` still persists the entry when duplicate-detection fails due to a cache error).

### Additional: `benchmarks/tools` build failure under `go test ./...`
`parse_results.go` and `generate_report.go` each declare `func main()`, causing a `main redeclared` build error. Added `//go:build ignore` to both — `go test ./...` skips them, `go run file.go` still works unchanged.

## Test plan
- [x] `go test ./pkg/plugin/implementation/manifestloader/...` — all pass, including new `TestLoadFromCacheOnCacheMissReturnsNilNil`
- [x] `go test ./pkg/plugin/implementation/cache/...` — all pass
- [x] `go test ./pkg/plugin/implementation/payloadstore/...` — all pass, including new `TestExists_CacheErrorPropagated` and `TestStore_ContinuesAfterExistsCacheError`
- [x] `go test ./benchmarks/tools/...` — no longer fails with build error
- [x] `go test ./...` — no longer has any failures
- [x] `go run benchmarks/tools/parse_results.go --help` and `go run benchmarks/tools/generate_report.go --help` — tools still run normally


Fixes #724.