### PR TITLE
fix(proto-v2): change AckNoCallback HTTP status from 409 to 202

### DIFF
--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -92,7 +92,7 @@ func nackBecknError(ctx context.Context, err error) (*model.Error, int, model.St
 		if !isAtLeastV2(ctx) {
 			return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
 		}
-		return ackNoCallbackErr.BecknError(), http.StatusConflict, ackNoCallbackErr.Status
+		return ackNoCallbackErr.BecknError(), http.StatusAccepted, ackNoCallbackErr.Status
 	default:
 		return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
 	}

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -330,7 +330,7 @@ func TestNackBytes_AckNoCallback(t *testing.T) {
 		t.Fatal("nackBytes body missing message.error")
 	}
 	if errField["code"] != "NO_CATALOG" {
-		t.Errorf("nackBytes error.code = %v, want 40901", errField["code"])
+		t.Errorf("nackBytes error.code = %v, want NO_CATALOG", errField["code"])
 	}
 
 	// Also verify the body matches what sendNack writes — sign and send must be identical.

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -188,7 +188,7 @@ func TestSendNack(t *testing.T) {
 				Code:    "40901",
 				Message: "no matching catalog",
 			}),
-			status:   http.StatusConflict,
+			status:   http.StatusAccepted,
 			expected: `{"message":{"status":"ACK","messageId":"msg-v2-1","error":{"code":"40901","message":"no matching catalog"}}}`,
 		},
 		{
@@ -197,7 +197,7 @@ func TestSendNack(t *testing.T) {
 				Code:    "40902",
 				Message: "provider closed",
 			}),
-			status:   http.StatusConflict,
+			status:   http.StatusAccepted,
 			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"40902","message":"provider closed"}}}`,
 		},
 	}
@@ -262,7 +262,7 @@ func TestSendNack(t *testing.T) {
 
 // TestSendNack_AckNoCallback_PreV2_FallsThrough verifies that AckNoCallbackErr on a
 // pre-v2 request is mapped to 500 Internal Server Error with the pre-v2 body shape,
-// not a 409 with the v2 shape.
+// not a 202 with the v2 shape.
 func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 	ctx := context.WithValue(context.Background(), model.ContextKeyMsgID, "pre-v2-msg")
 	// No protocol version in context → pre-v2 path.
@@ -277,7 +277,7 @@ func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 	if rr.Code != http.StatusInternalServerError {
 		t.Errorf("pre-v2 AckNoCallbackErr: want status 500, got %d", rr.Code)
 	}
-	// Body must use the pre-v2 envelope with NACK status, not the 409 ACK shape.
+	// Body must use the pre-v2 envelope with NACK status, not the 202 ACK shape.
 	var body map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
 		t.Fatalf("failed to parse response body: %v", err)
@@ -300,7 +300,7 @@ func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 }
 
 // TestNackBytes_AckNoCallback verifies that nackBytes (used by signNackResponse
-// before the 409 is written to the wire) produces the correct signed body for
+// before the 202 is written to the wire) produces the correct signed body for
 // AckNoCallbackErr — same bytes that sendNack will subsequently write.
 func TestNackBytes_AckNoCallback(t *testing.T) {
 	ctx := v2Ctx("sign-msg-1")
@@ -687,31 +687,31 @@ func TestNewAckSignerStep_NilKM_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestAckSignerStep_URLRoutingPath_409_SetsSignatureOnResponse(t *testing.T) {
-	// 409 AckNoCallback: app decides, ONIX relays. ackSigner must still sign
+func TestAckSignerStep_URLRoutingPath_202_SetsSignatureOnResponse(t *testing.T) {
+	// 202 AckNoCallback: app decides, ONIX relays. ackSigner must still sign
 	// the response so the caller can verify the Signature header regardless of
 	// status code.
-	signer := &mockSigner{returnSig: "sig409=="}
-	km := &mockKM{keyset: &model.Keyset{UniqueKeyID: "key-409", SigningPrivate: "priv"}}
+	signer := &mockSigner{returnSig: "sig202=="}
+	km := &mockKM{keyset: &model.Keyset{UniqueKeyID: "key-202", SigningPrivate: "priv"}}
 
 	step, err := newAckSignerStep(signer, km)
 	if err != nil {
 		t.Fatalf("newAckSignerStep() unexpected error: %v", err)
 	}
 
-	ctx := makeStepCtx("2.0.0", "msg-409", "bpp.example.com", "inboundSig==")
+	ctx := makeStepCtx("2.0.0", "msg-202", "bpp.example.com", "inboundSig==")
 	body := `{"message":{"status":"ACK","error":{"code":"40901","message":"no matching catalog"}}}`
-	rctx := makeResponseStepContext(http.StatusConflict, body, "")
+	rctx := makeResponseStepContext(http.StatusAccepted, body, "")
 
 	if err := step.RunOnResponse(ctx, rctx); err != nil {
-		t.Fatalf("RunOnResponse() unexpected error on 409: %v", err)
+		t.Fatalf("RunOnResponse() unexpected error on 202: %v", err)
 	}
 
 	if !signer.signAckCalled {
-		t.Error("expected SignAck to be called for 409 response")
+		t.Error("expected SignAck to be called for 202 response")
 	}
 	if rctx.Header.Get("Signature") == "" {
-		t.Fatal("expected Signature header on 409 response")
+		t.Fatal("expected Signature header on 202 response")
 	}
 }
 
@@ -888,7 +888,7 @@ func TestValidateAckSignatureStep_ValidatorError_Degrades(t *testing.T) {
 }
 
 // TestValidateAckSignatureStep_MissingSignature_AllStatusCodes_Degrades verifies
-// that a missing Signature header on ANY status code (200, 4xx, 409, 500) causes
+// that a missing Signature header on ANY status code (200, 202, 4xx, 500) causes
 // a degrade warning — not a rejection. Per NFH-007 CON-004-02 every synchronous
 // response MUST carry a Signature; per conformance SHOULD NOT invalidate the
 // transaction when it is absent.
@@ -904,7 +904,7 @@ func TestValidateAckSignatureStep_MissingSignature_AllStatusCodes_Degrades(t *te
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 		http.StatusNotFound,
-		http.StatusConflict,       // 409 AckNoCallback
+		http.StatusAccepted,        // 202 AckNoCallback
 		http.StatusInternalServerError,
 	}
 	for _, code := range codes {
@@ -926,13 +926,13 @@ func TestValidateAckSignatureStep_ValidSignature_AllStatusCodes(t *testing.T) {
 	km := &mockKMWithLookup{publicKey: "pubKey=="}
 
 	step, _ := newValidateAckSignatureStep(sv, km)
-	ctx := makeCallerStepCtx("2.0.0", "msg-409", "bap.example.com", `Signature keyId="bap.example.com|key-1|ed25519",signature="outSig=="`)
+	ctx := makeCallerStepCtx("2.0.0", "msg-202", "bap.example.com", `Signature keyId="bap.example.com|key-1|ed25519",signature="outSig=="`)
 
 	codes := []int{
 		http.StatusOK,
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
-		http.StatusConflict, // 409 AckNoCallback
+		http.StatusAccepted, // 202 AckNoCallback
 		http.StatusInternalServerError,
 	}
 	for _, code := range codes {

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -185,20 +185,20 @@ func TestSendNack(t *testing.T) {
 		{
 			name: "v2 AckNoCallbackErr ACK status",
 			err: model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
-				Code:    "40901",
+				Code:    "NO_CATALOG",
 				Message: "no matching catalog",
 			}),
 			status:   http.StatusAccepted,
-			expected: `{"message":{"status":"ACK","messageId":"msg-v2-1","error":{"code":"40901","message":"no matching catalog"}}}`,
+			expected: `{"message":{"status":"ACK","messageId":"msg-v2-1","error":{"code":"NO_CATALOG","message":"no matching catalog"}}}`,
 		},
 		{
 			name: "v2 AckNoCallbackErr NACK status",
 			err: model.NewAckNoCallbackErr(model.StatusNACK, &model.Error{
-				Code:    "40902",
+				Code:    "PROVIDER_CLOSED",
 				Message: "provider closed",
 			}),
 			status:   http.StatusAccepted,
-			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"40902","message":"provider closed"}}}`,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"PROVIDER_CLOSED","message":"provider closed"}}}`,
 		},
 	}
 
@@ -269,7 +269,7 @@ func TestSendNack_AckNoCallback_PreV2_FallsThrough(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	err := model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
-		Code:    "40901",
+		Code:    "NO_CATALOG",
 		Message: "no matching catalog",
 	})
 	sendNack(ctx, rr, err)
@@ -306,7 +306,7 @@ func TestNackBytes_AckNoCallback(t *testing.T) {
 	ctx := v2Ctx("sign-msg-1")
 
 	err := model.NewAckNoCallbackErr(model.StatusACK, &model.Error{
-		Code:    "40901",
+		Code:    "NO_CATALOG",
 		Message: "no matching catalog",
 	})
 	body := nackBytes(ctx, err)
@@ -329,7 +329,7 @@ func TestNackBytes_AckNoCallback(t *testing.T) {
 	if errField == nil {
 		t.Fatal("nackBytes body missing message.error")
 	}
-	if errField["code"] != "40901" {
+	if errField["code"] != "NO_CATALOG" {
 		t.Errorf("nackBytes error.code = %v, want 40901", errField["code"])
 	}
 
@@ -700,7 +700,7 @@ func TestAckSignerStep_URLRoutingPath_202_SetsSignatureOnResponse(t *testing.T) 
 	}
 
 	ctx := makeStepCtx("2.0.0", "msg-202", "bpp.example.com", "inboundSig==")
-	body := `{"message":{"status":"ACK","error":{"code":"40901","message":"no matching catalog"}}}`
+	body := `{"message":{"status":"ACK","error":{"code":"NO_CATALOG","message":"no matching catalog"}}}`
 	rctx := makeResponseStepContext(http.StatusAccepted, body, "")
 
 	if err := step.RunOnResponse(ctx, rctx); err != nil {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -764,17 +764,17 @@ func TestStepCtx_ProtocolVersion(t *testing.T) {
 	}
 }
 
-// TestProxy_ModifyResponse_409_InvokesResponseSteps verifies that the thin
-// ModifyResponse dispatcher in proxy() fires responseSteps on a 409 upstream
-// response. This covers the AckNoCallback relay path: app sends 409, ONIX
+// TestProxy_ModifyResponse_202_InvokesResponseSteps verifies that the thin
+// ModifyResponse dispatcher in proxy() fires responseSteps on a 202 upstream
+// response. This covers the AckNoCallback relay path: app sends 202, ONIX
 // relays it, ackSigner (or any ResponseStep) runs via ModifyResponse.
-func TestProxy_ModifyResponse_409_InvokesResponseSteps(t *testing.T) {
+func TestProxy_ModifyResponse_202_InvokesResponseSteps(t *testing.T) {
 	const ackBody = `{"message":{"status":"ACK","error":{"code":"40901","message":"no catalog"}}}`
 
-	// Upstream app: returns 409 with AckNoCallback body.
+	// Upstream app: returns 202 with AckNoCallback body.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
+		w.WriteHeader(http.StatusAccepted)
 		fmt.Fprint(w, ackBody)
 	}))
 	defer upstream.Close()
@@ -793,11 +793,11 @@ func TestProxy_ModifyResponse_409_InvokesResponseSteps(t *testing.T) {
 
 	proxy(stepCtx, req, rr, http.DefaultClient, []definition.ResponseStep{respStep})
 
-	if rr.Code != http.StatusConflict {
-		t.Errorf("expected upstream 409 to be relayed, got %d", rr.Code)
+	if rr.Code != http.StatusAccepted {
+		t.Errorf("expected upstream 202 to be relayed, got %d", rr.Code)
 	}
 	if !respStep.called {
-		t.Error("expected ResponseStep to be called via ModifyResponse on 409 upstream response")
+		t.Error("expected ResponseStep to be called via ModifyResponse on 202 upstream response")
 	}
 	if rr.Body.String() != ackBody {
 		t.Errorf("expected upstream body to be relayed unchanged: got %q", rr.Body.String())

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -769,7 +769,7 @@ func TestStepCtx_ProtocolVersion(t *testing.T) {
 // response. This covers the AckNoCallback relay path: app sends 202, ONIX
 // relays it, ackSigner (or any ResponseStep) runs via ModifyResponse.
 func TestProxy_ModifyResponse_202_InvokesResponseSteps(t *testing.T) {
-	const ackBody = `{"message":{"status":"ACK","error":{"code":"40901","message":"no catalog"}}}`
+	const ackBody = `{"message":{"status":"ACK","error":{"code":"NO_CATALOG","message":"no catalog"}}}`
 
 	// Upstream app: returns 202 with AckNoCallback body.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -115,7 +115,7 @@ func (e *NotFoundErr) BecknError() *Error {
 // AckNoCallbackErr is returned by a step when the receiver has authenticated and
 // accepted the request but will not send an async callback — for example, no
 // matching catalog, inventory unavailable, or provider closed. ONIX maps this to
-// HTTP 409 Conflict using the v2 flat response shape. For protocol versions prior
+// HTTP 202 Accepted using the v2 flat response shape. For protocol versions prior
 // to 2.0.0 this error falls through to a 500 Internal Server Error.
 type AckNoCallbackErr struct {
 	// Status is ACK when the request was accepted but no callback will follow,
@@ -127,7 +127,7 @@ type AckNoCallbackErr struct {
 
 // NewAckNoCallbackErr constructs an AckNoCallbackErr.
 // Use StatusACK for "accepted but no callback" and StatusNACK for outright rejection.
-// Panics if err is nil — the spec requires an error explanation on every 409 response.
+// Panics if err is nil — the spec requires an error explanation on every AckNoCallback (202) response.
 func NewAckNoCallbackErr(status Status, err *Error) *AckNoCallbackErr {
 	if err == nil {
 		panic("AckNoCallbackErr: Err is required")

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -210,13 +210,13 @@ func TestNewAckNoCallbackErr(t *testing.T) {
 		{
 			name:           "ACK status",
 			status:         StatusACK,
-			becknErr:       &Error{Code: "40901", Message: "no matching catalog"},
+			becknErr:       &Error{Code: "NO_CATALOG", Message: "no matching catalog"},
 			wantErrContain: "AckNoCallback(status=ACK)",
 		},
 		{
 			name:           "NACK status",
 			status:         StatusNACK,
-			becknErr:       &Error{Code: "40902", Message: "provider closed"},
+			becknErr:       &Error{Code: "PROVIDER_CLOSED", Message: "provider closed"},
 			wantErrContain: "AckNoCallback(status=NACK)",
 		},
 	}


### PR DESCRIPTION
Per protocol-specifications-v2 PR #168, AckNoCallback moves from HTTP 409 Conflict to HTTP 202 Accepted. The response body shape is unchanged. Updates the single status code mapping in nackBecknError, two comments in error.go, and all affected test assertions and names.

Closes #734