### PR TITLE
fix(schemav2validator): support GET/DELETE bodyless requests

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -107,6 +107,10 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 // requests it validates the JSON payload against the indexed action schema.
 func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data []byte) error {
 	if len(data) == 0 {
+		if reqURL == nil {
+			return model.NewBadReqErr(fmt.Errorf("request URL is required for bodyless validation"))
+		}
+
 		v.specMutex.RLock()
 		spec := v.spec
 		v.specMutex.RUnlock()
@@ -115,6 +119,12 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 		}
 
+		// Key is the full path without its leading slash, matching the index built in
+		// buildActionIndex. strings.TrimPrefix is used (not path.Base) so that
+		// multi-segment paths like /catalog/subscription are preserved verbatim.
+		// Note: the check is path-only — it does not distinguish HTTP methods. A POST
+		// with an empty body to a bodyless-indexed path would pass here. Method-aware
+		// validation requires the Option C StepContext refactor.
 		key := strings.TrimPrefix(reqURL.Path, "/")
 		if _, ok := spec.bodylessActions[key]; !ok {
 			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", key))
@@ -376,7 +386,9 @@ func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.
 			continue
 		}
 
-		// Body-bearing operations: extract action from the requestBody schema.
+		// Pass 1: body-bearing operations (any verb that declares a requestBody).
+		// All five standard verbs are checked so that unusual specs (e.g. GET with
+		// body) are still indexed correctly.
 		for _, op := range []*openapi3.Operation{item.Post, item.Get, item.Put, item.Patch, item.Delete} {
 			if op == nil || op.RequestBody == nil || op.RequestBody.Value == nil {
 				continue
@@ -392,9 +404,11 @@ func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.
 			}
 		}
 
-		// Bodyless operations: GET and DELETE without a requestBody.
+		// Pass 2: bodyless operations — GET and DELETE that declare no requestBody.
+		// A separate loop (rather than sharing pass 1) keeps the two indexing concerns
+		// independent and avoids complicating the guard logic for body-bearing ops.
 		// Key is the spec path without its leading slash so it matches
-		// strings.TrimPrefix(reqURL.Path, "/") in ValidateBodyless.
+		// strings.TrimPrefix(reqURL.Path, "/") in Validate's bodyless branch.
 		for _, op := range []*openapi3.Operation{item.Get, item.Delete} {
 			if op == nil || op.RequestBody != nil {
 				continue

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -32,9 +32,10 @@ type schemav2Validator struct {
 
 // cachedSpec holds a cached OpenAPI spec.
 type cachedSpec struct {
-	doc           *openapi3.T
-	actionSchemas map[string]*openapi3.SchemaRef // O(1) action lookup
-	loadedAt      time.Time
+	doc             *openapi3.T
+	actionSchemas   map[string]*openapi3.SchemaRef // body operations: action → schema (O(1) lookup)
+	bodylessActions map[string]struct{}             // bodyless operations: path without leading slash → exists
+	loadedAt        time.Time
 }
 
 // Config struct for Schemav2Validator.
@@ -100,7 +101,29 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 }
 
 // Validate validates the given data against the OpenAPI schema.
+// When the request body is empty (GET/DELETE) it performs an O(1) lookup in
+// the pre-built bodylessActions index to confirm the path is a known bodyless
+// endpoint, then returns without body schema validation. For body-bearing
+// requests it validates the JSON payload against the indexed action schema.
 func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data []byte) error {
+	if len(data) == 0 {
+		v.specMutex.RLock()
+		spec := v.spec
+		v.specMutex.RUnlock()
+
+		if spec == nil || spec.doc == nil {
+			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
+		}
+
+		key := strings.TrimPrefix(reqURL.Path, "/")
+		if _, ok := spec.bodylessActions[key]; !ok {
+			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", key))
+		}
+
+		log.Debugf(ctx, "bodyless request to %s: skipping body schema validation", reqURL.Path)
+		return nil
+	}
+
 	var payloadData payload
 	err := json.Unmarshal(data, &payloadData)
 	if err != nil {
@@ -201,18 +224,20 @@ func (v *schemav2Validator) loadSpec(ctx context.Context) error {
 		log.Debugf(ctx, "Spec validation passed")
 	}
 
-	// Build action→schema index for O(1) lookup
-	actionSchemas := v.buildActionIndex(ctx, doc)
+	// Build action→schema index (body operations) and bodyless action set (GET/DELETE)
+	actionSchemas, bodylessActions := v.buildActionIndex(ctx, doc)
 
 	v.specMutex.Lock()
 	v.spec = &cachedSpec{
-		doc:           doc,
-		actionSchemas: actionSchemas,
-		loadedAt:      time.Now(),
+		doc:             doc,
+		actionSchemas:   actionSchemas,
+		bodylessActions: bodylessActions,
+		loadedAt:        time.Now(),
 	}
 	v.specMutex.Unlock()
 
-	log.Debugf(ctx, "Loaded OpenAPI spec from %s: %s with %d actions indexed", v.config.Type, v.config.Location, len(actionSchemas))
+	log.Debugf(ctx, "Loaded OpenAPI spec from %s: %s with %d body actions and %d bodyless actions indexed",
+		v.config.Type, v.config.Location, len(actionSchemas), len(bodylessActions))
 	return nil
 }
 
@@ -337,15 +362,21 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 	}
 }
 
-// buildActionIndex builds a map of action→schema for O(1) lookup.
-func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.T) map[string]*openapi3.SchemaRef {
+// buildActionIndex builds two indexes from the loaded OpenAPI spec:
+//   - actionSchemas: body-bearing operations (POST/PUT/PATCH) keyed by context.action value
+//   - bodylessActions: GET/DELETE operations without a requestBody, keyed by path without leading slash
+//
+// Both are built in a single pass over the spec paths for efficiency.
+func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.T) (map[string]*openapi3.SchemaRef, map[string]struct{}) {
 	actionSchemas := make(map[string]*openapi3.SchemaRef)
+	bodylessActions := make(map[string]struct{})
 
-	for path, item := range doc.Paths.Map() {
+	for specPath, item := range doc.Paths.Map() {
 		if item == nil {
 			continue
 		}
-		// Check all HTTP methods
+
+		// Body-bearing operations: extract action from the requestBody schema.
 		for _, op := range []*openapi3.Operation{item.Post, item.Get, item.Put, item.Patch, item.Delete} {
 			if op == nil || op.RequestBody == nil || op.RequestBody.Value == nil {
 				continue
@@ -354,17 +385,27 @@ func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.
 			if content == nil || content.Schema == nil || content.Schema.Value == nil {
 				continue
 			}
-
-			// Extract action from schema
 			action := v.extractActionFromSchema(content.Schema.Value)
 			if action != "" {
 				actionSchemas[action] = content.Schema
-				log.Debugf(ctx, "Indexed action '%s' from path %s", action, path)
+				log.Debugf(ctx, "Indexed body action '%s' from path %s", action, specPath)
 			}
+		}
+
+		// Bodyless operations: GET and DELETE without a requestBody.
+		// Key is the spec path without its leading slash so it matches
+		// strings.TrimPrefix(reqURL.Path, "/") in ValidateBodyless.
+		for _, op := range []*openapi3.Operation{item.Get, item.Delete} {
+			if op == nil || op.RequestBody != nil {
+				continue
+			}
+			key := strings.TrimPrefix(specPath, "/")
+			bodylessActions[key] = struct{}{}
+			log.Debugf(ctx, "Indexed bodyless action '%s' from path %s", key, specPath)
 		}
 	}
 
-	return actionSchemas
+	return actionSchemas, bodylessActions
 }
 
 // extractActionFromSchema extracts the action value from a schema.

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -292,6 +292,7 @@ func TestValidate_BodylessRequest(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
+		nilURL  bool // pass nil *url.URL instead of parsing path
 		wantErr bool
 		errMsg  string
 	}{
@@ -317,6 +318,22 @@ func TestValidate_BodylessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Query string must not pollute the path key — reqURL.Path strips RawQuery,
+			// so /catalog/subscription?subscriptionId=abc resolves to the same map key
+			// as /catalog/subscription and must pass.
+			name:    "GET with query string — query params do not affect path match",
+			path:    "/catalog/subscription?subscriptionId=abc-123",
+			wantErr: false,
+		},
+		{
+			// nil reqURL with empty body must return an error, not panic.
+			// Guards the reqURL == nil check added in the self-review.
+			name:    "nil URL with empty body returns error",
+			nilURL:  true,
+			wantErr: true,
+			errMsg:  "request URL is required for bodyless validation",
+		},
+		{
 			// /search only has a POST with requestBody — not in bodylessActions.
 			name:    "POST-only endpoint /search with empty body is rejected",
 			path:    "/search",
@@ -334,7 +351,11 @@ func TestValidate_BodylessRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.Validate(context.Background(), mustURL(tt.path), []byte{})
+			var reqURL *url.URL
+			if !tt.nilURL {
+				reqURL = mustURL(tt.path)
+			}
+			err := validator.Validate(context.Background(), reqURL, []byte{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -4,9 +4,81 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 )
+
+// testSpecBodyless mirrors the Beckn 2.0 /catalog/subscription path which
+// carries GET and DELETE (both bodyless) alongside POST (body-bearing).
+// It also includes /search (POST-only) for rejection-case coverage.
+const testSpecBodyless = `openapi: 3.1.0
+info:
+  title: Test API (bodyless)
+  version: 1.0.0
+paths:
+  /catalog/subscription:
+    get:
+      summary: Get subscriptions (no body — query params only)
+      parameters:
+        - in: query
+          name: subscriptionId
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+    delete:
+      summary: Deactivate subscription (no body — query param only)
+      parameters:
+        - in: query
+          name: subscriptionId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+    post:
+      summary: Create subscription (body required)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context, message]
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: catalog/subscription
+                message:
+                  type: object
+      responses:
+        "200":
+          description: OK
+  /search:
+    post:
+      summary: Search (body required — no GET/DELETE defined)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context]
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: search
+      responses:
+        "200":
+          description: OK
+`
 
 const testSpec = `openapi: 3.1.0
 info:
@@ -185,6 +257,78 @@ func TestValidate_NestedValidation(t *testing.T) {
 			err := validator.Validate(context.Background(), nil, []byte(tt.payload))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_BodylessRequest covers GET/DELETE requests (Beckn 2.0
+// catalog/subscription verbs) that carry no body. Validate() detects
+// len(data)==0, looks up the path in the pre-built bodylessActions index,
+// and either passes (known bodyless endpoint) or rejects (unknown/body-only).
+func TestValidate_BodylessRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpecBodyless))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	mustURL := func(raw string) *url.URL {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", raw, err)
+		}
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			// Multi-segment path with GET — indexed in bodylessActions, must pass.
+			name:    "GET /catalog/subscription — empty body passes",
+			path:    "/catalog/subscription",
+			wantErr: false,
+		},
+		{
+			// Same path, DELETE is also indexed as bodyless.
+			name:    "DELETE /catalog/subscription — empty body passes",
+			path:    "/catalog/subscription",
+			wantErr: false,
+		},
+		{
+			// /search only has a POST with requestBody — not in bodylessActions.
+			name:    "POST-only endpoint /search with empty body is rejected",
+			path:    "/search",
+			wantErr: true,
+			errMsg:  "unsupported bodyless request for endpoint: search",
+		},
+		{
+			// Path absent from spec entirely.
+			name:    "unknown endpoint /nonsense with empty body is rejected",
+			path:    "/nonsense",
+			wantErr: true,
+			errMsg:  "unsupported bodyless request for endpoint: nonsense",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.Validate(context.Background(), mustURL(tt.path), []byte{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errMsg != "" && err != nil {
+				if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.errMsg)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -285,6 +285,10 @@ func TestValidate_BodylessRequest(t *testing.T) {
 		return u
 	}
 
+	// NOTE: bodylessActions is keyed by path only — it does not distinguish HTTP
+	// methods. GET, DELETE, and even an empty-body POST to the same path all resolve
+	// to the same map key. Method-aware validation requires the Option C StepContext
+	// refactor. The "known limitation" case below documents this current behaviour.
 	tests := []struct {
 		name    string
 		path    string
@@ -298,8 +302,17 @@ func TestValidate_BodylessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Same path, DELETE is also indexed as bodyless.
+			// Same path, DELETE is also indexed as bodyless (path-only key, no
+			// method distinction at this layer).
 			name:    "DELETE /catalog/subscription — empty body passes",
+			path:    "/catalog/subscription",
+			wantErr: false,
+		},
+		{
+			// Known limitation (Option A): bodylessActions is path-only. An empty-body
+			// POST to a bodyless-indexed path passes through without body validation.
+			// This will become wantErr:true once the Option C StepContext refactor lands.
+			name:    "empty-body POST to bodyless-indexed path passes (known limitation)",
 			path:    "/catalog/subscription",
 			wantErr: false,
 		},


### PR DESCRIPTION
## Summary

- Fixes the crash when \`schemav2validator\` receives a GET or DELETE request with no body (\`unexpected end of JSON input\`)
- Extends \`buildActionIndex\` to also index bodyless operations (GET/DELETE without \`requestBody\`) into a new \`bodylessActions\` map
- \`Validate\` now routes empty-body requests through an O(1) spec-existence check before returning — only paths explicitly defined in the OpenAPI spec with a GET or DELETE operation pass through

## What changed

**\`schemav2validator.go\`**
- \`cachedSpec\` gains a \`bodylessActions map[string]struct{}\` field
- \`buildActionIndex\` extended: two-pass loop over spec paths populates both \`actionSchemas\` (body operations, unchanged) and \`bodylessActions\` (GET/DELETE without \`requestBody\`, keyed by path without leading slash e.g. \`"catalog/subscription"\`)
- \`Validate\`: new \`len(data) == 0\` guard — nil-checks \`reqURL\` first, then O(1) lookup in \`bodylessActions\` using \`strings.TrimPrefix(reqURL.Path, "/")\`. Rejects unknown/body-only endpoints; passes known bodyless endpoints cleanly. All existing body-bearing logic is untouched.
- Comments explain: why \`strings.TrimPrefix\` is used over \`path.Base\` (multi-segment path correctness), and the two-pass structure in \`buildActionIndex\`

**\`schemav2validator_test.go\`**
- New \`testSpecBodyless\` fixture mirrors Beckn 2.0 \`PR#168\`: \`/catalog/subscription\` (GET + DELETE + POST) and \`/search\` (POST only)
- \`TestValidate_BodylessRequest\` covers: multi-segment bodyless path passes, POST-only endpoint rejected, unknown endpoint rejected, and one known-limitation case (see below)

No interface changes. \`schemavalidator\` v1 and \`step.go\` are untouched.

## Known Limitations

**Method-agnostic bodyless check (Option A trade-off):** \`bodylessActions\` is keyed by path only — it does not distinguish HTTP methods. The \`SchemaValidator\` interface signature is \`Validate(ctx, *url.URL, []byte)\` and carries no HTTP method. As a consequence, an empty-body POST to \`/catalog/subscription\` would pass the bodyless guard (the path is indexed because GET/DELETE exist there) without body schema validation.

This is the inherent limitation of Option A (no interface change). It is documented with an inline code comment and a dedicated \`"known limitation"\` test case. The long-term fix is the **Option C StepContext refactor** (changing the interface to accept \`*model.StepContext\`, which carries \`*http.Request\` and therefore the HTTP method). That work is tracked separately.

In practice this gap is low-risk: an empty-body POST is a malformed Beckn request that will fail downstream (router, signer) regardless.

## Motivation

Beckn Protocol v2.0 (PR [#168](https://github.com/beckn/protocol-specifications-v2/pull/168)) introduces \`GET /catalog/subscription\` and \`DELETE /catalog/subscription\` — the first bodyless verbs in the spec. The existing pipeline assumed every request carries a JSON body with \`context.action\`, causing an immediate 400 NACK for any GET/DELETE.

## Related issues

Closes #735
Closes #737