### PR TITLE
fix(router): support compound action paths and bodyless requests

### DIFF
--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -317,8 +317,16 @@ func (r *Router) extractEndpoint(urlPath string) string {
 // routeBodyless handles routing for GET/DELETE requests that carry no body.
 // Since domain and version cannot be read from a missing payload, the version
 // registered in the v2 wildcard config ("*") is used for the rules lookup.
-// Dynamic BAP/BPP URI routing is not supported for bodyless requests because
-// the target URI would normally come from the request body.
+//
+// Supported target types:
+//   - url:       routed to the configured static URL (primary use case).
+//   - publisher: technically permitted — the empty-body message is forwarded
+//     to the queue as-is. No known protocol use case exists for routing
+//     catalog GET/DELETE requests through a message queue; this is allowed
+//     rather than rejected to avoid unnecessary constraint, but operators
+//     should not configure publisher targets for bodyless endpoints.
+//   - bpp / bap: rejected — the target URI is read from the request body,
+//     which is absent for bodyless requests.
 func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 	v2Rules, ok := r.rules["*"]
 	if !ok {

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -17,6 +17,13 @@ import (
 // Config holds the configuration for the Router plugin.
 type Config struct {
 	RoutingConfig string `json:"routingConfig"`
+	// BasePath is the HTTP path prefix at which this adapter module is mounted
+	// (e.g. "/bap/caller/"). When set, it is stripped from the incoming request
+	// URL before extracting the action endpoint, enabling compound action paths
+	// like "catalog/push" to be matched correctly against routing rules.
+	// If unset, the router falls back to path.Base behaviour (last URL segment
+	// only), which supports single-word actions but not compound ones.
+	BasePath string `json:"basePath,omitempty"`
 }
 
 // RoutingConfig represents the structure of the routing configuration file.
@@ -26,7 +33,8 @@ type routingConfig struct {
 
 // Router implements Router interface.
 type Router struct {
-	rules map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
+	rules    map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
+	basePath string                                        // module mount prefix stripped before endpoint lookup
 }
 
 // RoutingRule represents a single routing rule.
@@ -62,7 +70,8 @@ func New(ctx context.Context, config *Config) (*Router, func() error, error) {
 		return nil, nil, fmt.Errorf("config cannot be nil")
 	}
 	router := &Router{
-		rules: make(map[string]map[string]map[string]*model.Route),
+		rules:    make(map[string]map[string]map[string]*model.Route),
+		basePath: config.BasePath,
 	}
 
 	// Load rules at bootup
@@ -214,7 +223,17 @@ func getContextString(ctx map[string]interface{}, snakeKey, camelKey string) str
 
 // Route determines the routing destination based on the request context.
 func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.Route, error) {
-	// Parse domain and version via typed struct — unchanged from original.
+	// Extract the endpoint from the URL, stripping the module base path so that
+	// compound action paths like "catalog/push" are preserved verbatim.
+	endpoint := r.extractEndpoint(url.Path)
+
+	// Bodyless requests (GET/DELETE) carry no JSON body; domain, version, and
+	// BAP/BPP URIs are not available. Route using the v2 config version.
+	if len(body) == 0 {
+		return r.routeBodyless(endpoint)
+	}
+
+	// Parse domain and version via typed struct.
 	var requestBody struct {
 		Context struct {
 			Domain  string `json:"domain"`
@@ -238,9 +257,6 @@ func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.R
 	}
 	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri")
 	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri")
-
-	// Extract the endpoint from the URL
-	endpoint := path.Base(url.Path)
 
 	// For v2.x.x, ignore domain and use wildcard; for v1.x.x, use actual domain
 	domain := requestBody.Context.Domain
@@ -281,6 +297,46 @@ func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.R
 		return handleProtocolMapping(route, bapURI, endpoint)
 	}
 	return route, nil
+}
+
+// extractEndpoint derives the action endpoint key from the incoming URL path.
+// When basePath is configured (e.g. "/bap/caller/"), it is stripped first so
+// that compound paths like "/bap/caller/catalog/push" → "catalog/push".
+// Without basePath, the function falls back to path.Base (last URL segment),
+// preserving backward compatibility for deployments that only use single-word
+// actions and have not set basePath.
+func (r *Router) extractEndpoint(urlPath string) string {
+	if r.basePath != "" {
+		// Strip the module mount prefix, then any residual leading slash.
+		stripped := strings.TrimPrefix(urlPath, r.basePath)
+		return strings.TrimPrefix(stripped, "/")
+	}
+	return path.Base(urlPath)
+}
+
+// routeBodyless handles routing for GET/DELETE requests that carry no body.
+// Since domain and version cannot be read from a missing payload, the version
+// registered in the v2 wildcard config ("*") is used for the rules lookup.
+// Dynamic BAP/BPP URI routing is not supported for bodyless requests because
+// the target URI would normally come from the request body.
+func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
+	v2Rules, ok := r.rules["*"]
+	if !ok {
+		return nil, fmt.Errorf("no v2 routing rules found; bodyless requests require a v2 config")
+	}
+
+	for version, versionRules := range v2Rules {
+		route, ok := versionRules[endpoint]
+		if !ok {
+			continue
+		}
+		if route.TargetType == targetTypeBPP || route.TargetType == targetTypeBAP {
+			return nil, fmt.Errorf("bodyless endpoint '%s' (version %s) is configured with target type '%s': dynamic BAP/BPP URI routing is not supported for bodyless requests", endpoint, version, route.TargetType)
+		}
+		return route, nil
+	}
+
+	return nil, fmt.Errorf("endpoint '%s' is not supported in v2 routing config", endpoint)
 }
 
 // handleProtocolMapping handles both BPP and BAP routing with proper URL construction

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -996,7 +996,11 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	}
 }
 
-// TestRouteBodyless tests GET/DELETE request routing where the body is empty.
+// TestRouteBodyless tests routing where the body is empty (GET/DELETE requests).
+// The router receives only the URL and a nil body — it does not see the HTTP
+// method. Method-level distinction (GET vs DELETE on the same path) is the
+// handler's responsibility, not the router's. A single bodyless success case
+// therefore covers both methods.
 func TestRouteBodyless(t *testing.T) {
 	ctx := context.Background()
 
@@ -1008,14 +1012,9 @@ func TestRouteBodyless(t *testing.T) {
 		wantErr    string
 	}{
 		{
-			name:       "bodyless GET to catalog/subscription succeeds",
-			configFile: "v2_catalog_url.yaml",
-			basePath:   "/bap/receiver/",
-			url:        "https://example.com/bap/receiver/catalog/subscription",
-			wantErr:    "",
-		},
-		{
-			name:       "bodyless DELETE to catalog/subscription succeeds",
+			// Covers both GET and DELETE: the router sees only the URL and nil body;
+			// HTTP method distinction is handled upstream by the request pipeline.
+			name:       "bodyless request to catalog/subscription succeeds",
 			configFile: "v2_catalog_url.yaml",
 			basePath:   "/bap/receiver/",
 			url:        "https://example.com/bap/receiver/catalog/subscription",

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -876,3 +876,191 @@ func TestV1DomainRequired(t *testing.T) {
 		t.Errorf("loadRules() error = %v, want error containing %q", err, expectedErr)
 	}
 }
+
+// setupRouterWithBasePath is a helper that creates a Router with a basePath set.
+func setupRouterWithBasePath(t *testing.T, configFile, basePath string) (*Router, string) {
+	t.Helper()
+	rulesFilePath := setupTestConfig(t, configFile)
+	config := &Config{
+		RoutingConfig: rulesFilePath,
+		BasePath:      basePath,
+	}
+	router, _, err := New(context.Background(), config)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	return router, rulesFilePath
+}
+
+// TestExtractEndpoint tests the endpoint extraction helper for both basePath
+// and fallback (path.Base) modes.
+func TestExtractEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		urlPath  string
+		want     string
+	}{
+		{
+			name:     "no basePath - single-word action falls back to path.Base",
+			basePath: "",
+			urlPath:  "/bap/caller/search",
+			want:     "search",
+		},
+		{
+			name:     "no basePath - root-level single-word action",
+			basePath: "",
+			urlPath:  "/search",
+			want:     "search",
+		},
+		{
+			name:     "basePath with trailing slash - single-word action",
+			basePath: "/bap/caller/",
+			urlPath:  "/bap/caller/search",
+			want:     "search",
+		},
+		{
+			name:     "basePath without trailing slash - single-word action",
+			basePath: "/bap/caller",
+			urlPath:  "/bap/caller/search",
+			want:     "search",
+		},
+		{
+			name:     "basePath - two-segment compound action",
+			basePath: "/bap/caller/",
+			urlPath:  "/bap/caller/catalog/push",
+			want:     "catalog/push",
+		},
+		{
+			name:     "basePath - two-segment compound action (subscription)",
+			basePath: "/bap/receiver/",
+			urlPath:  "/bap/receiver/catalog/subscription",
+			want:     "catalog/subscription",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Router{basePath: tt.basePath}
+			got := r.extractEndpoint(tt.urlPath)
+			if got != tt.want {
+				t.Errorf("extractEndpoint(%q) with basePath=%q = %q, want %q",
+					tt.urlPath, tt.basePath, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRouteCompoundEndpointSuccess tests that compound action paths are routed
+// correctly when basePath is configured.
+func TestRouteCompoundEndpointSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		basePath string
+		url      string
+		body     string
+	}{
+		{
+			name:     "compound endpoint catalog/push routed via url target",
+			basePath: "/bap/caller/",
+			url:      "https://example.com/bap/caller/catalog/push",
+			body:     `{"context": {"version": "2.0.0"}}`,
+		},
+		{
+			name:     "compound endpoint catalog/subscription (POST) routed via url target",
+			basePath: "/bap/caller/",
+			url:      "https://example.com/bap/caller/catalog/subscription",
+			body:     `{"context": {"version": "2.0.0"}}`,
+		},
+		{
+			name:     "compound endpoint catalog/search routed via url target",
+			basePath: "/bap/caller/",
+			url:      "https://example.com/bap/caller/catalog/search",
+			body:     `{"context": {"version": "2.0.0"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, rulesFilePath := setupRouterWithBasePath(t, "v2_catalog_url.yaml", tt.basePath)
+			defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+			parsedURL, _ := url.Parse(tt.url)
+			_, err := router.Route(ctx, parsedURL, []byte(tt.body))
+			if err != nil {
+				t.Errorf("Route() = %v, want nil error", err)
+			}
+		})
+	}
+}
+
+// TestRouteBodyless tests GET/DELETE request routing where the body is empty.
+func TestRouteBodyless(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		configFile string
+		basePath   string
+		url        string
+		wantErr    string
+	}{
+		{
+			name:       "bodyless GET to catalog/subscription succeeds",
+			configFile: "v2_catalog_url.yaml",
+			basePath:   "/bap/receiver/",
+			url:        "https://example.com/bap/receiver/catalog/subscription",
+			wantErr:    "",
+		},
+		{
+			name:       "bodyless DELETE to catalog/subscription succeeds",
+			configFile: "v2_catalog_url.yaml",
+			basePath:   "/bap/receiver/",
+			url:        "https://example.com/bap/receiver/catalog/subscription",
+			wantErr:    "",
+		},
+		{
+			name:       "bodyless to unsupported endpoint returns clear error",
+			configFile: "v2_catalog_url.yaml",
+			basePath:   "/bap/receiver/",
+			url:        "https://example.com/bap/receiver/catalog/unknown",
+			wantErr:    "endpoint 'catalog/unknown' is not supported in v2 routing config",
+		},
+		{
+			name:       "bodyless to BPP target type returns error",
+			configFile: "v2_catalog_bpp.yaml",
+			basePath:   "/bap/receiver/",
+			url:        "https://example.com/bap/receiver/catalog/subscription",
+			wantErr:    "dynamic BAP/BPP URI routing is not supported for bodyless requests",
+		},
+		{
+			name:       "bodyless request with no v2 rules returns error",
+			configFile: "bpp_receiver.yaml",
+			basePath:   "/bap/receiver/",
+			url:        "https://example.com/bap/receiver/catalog/subscription",
+			wantErr:    "no v2 routing rules found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, rulesFilePath := setupRouterWithBasePath(t, tt.configFile, tt.basePath)
+			defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+			parsedURL, _ := url.Parse(tt.url)
+			_, err := router.Route(ctx, parsedURL, nil)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Route() = %v, want nil error", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Route() = %v, want error containing %q", err, tt.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugin/implementation/router/testData/v2_catalog_bpp.yaml
+++ b/pkg/plugin/implementation/router/testData/v2_catalog_bpp.yaml
@@ -1,0 +1,5 @@
+routingRules:
+  - version: 2.0.0
+    targetType: bpp
+    endpoints:
+      - catalog/subscription

--- a/pkg/plugin/implementation/router/testData/v2_catalog_url.yaml
+++ b/pkg/plugin/implementation/router/testData/v2_catalog_url.yaml
@@ -1,0 +1,13 @@
+routingRules:
+  - version: 2.0.0
+    targetType: url
+    target:
+      url: https://catalog.example.com
+    endpoints:
+      - catalog/publish
+      - catalog/on_publish
+      - catalog/push
+      - catalog/subscription
+      - catalog/pull
+      - catalog/on_pull
+      - catalog/search


### PR DESCRIPTION
## Summary

Fixes [#741](https://github.com/beckn/beckn-onix/issues/741) — two failure modes in the router plugin that prevent it from handling the compound/nested action verbs and bodyless (GET/DELETE) endpoints introduced in protocol-spec v2 (`core-v2.0.0-lts-rc3`).

- **Compound path truncation** — `path.Base("/bap/caller/catalog/push")` was silently returning `"push"`, discarding the `catalog/` prefix and causing a guaranteed rules-map miss for every compound verb. Replaced with `extractEndpoint()` which strips the module's configured `basePath` first, then any residual leading `/`, preserving the full `"catalog/push"` key.

- **Bodyless request crash** — `json.Unmarshal(body, ...)` was called unconditionally; `GET`/`DELETE` requests with an empty body returned `unexpected end of JSON input` before any routing logic ran. A `len(body) == 0` guard now dispatches to `routeBodyless()`, which resolves the version from the v2 wildcard config already loaded at startup.

## Changes

| File | What changed |
|---|---|
| `router.go` | `BasePath` added to `Config`; `extractEndpoint()` and `routeBodyless()` helpers added; `Route()` updated with bodyless guard and `extractEndpoint` call |
| `router_test.go` | `TestExtractEndpoint` (6 cases), `TestRouteCompoundEndpointSuccess` (3 cases), `TestRouteBodyless` (5 cases), `setupRouterWithBasePath` helper |
| `testData/v2_catalog_url.yaml` | All 7 compound catalog endpoints from rc3, `targetType: url` |
| `testData/v2_catalog_bpp.yaml` | `catalog/subscription` with `targetType: bpp` for bodyless error path test |

## Config migration

Deployments that need compound verb routing must add `basePath` to the router plugin config, matching the module's `path:` setting:

```yaml
# e.g. config/generic-bap.yaml — bap/caller module
plugins:
  router:
    routingConfig: /path/to/routing.yaml
    basePath: /bap/caller/
```

Deployments using only single-word actions and no `basePath` are unaffected — `extractEndpoint` falls back to the previous `path.Base` behaviour.

## Test plan

- [x] All existing tests pass (`go test ./pkg/plugin/implementation/router/...`)
- [x] `TestExtractEndpoint` — basePath stripping with/without trailing slash, compound paths, fallback
- [x] `TestRouteCompoundEndpointSuccess` — `catalog/push`, `catalog/subscription` POST, `catalog/search`
- [x] `TestRouteBodyless` — GET/DELETE success, unsupported endpoint error, BPP target error, no-v2-rules error