### PR TITLE
fix: strip module base path in step layer before plugin URL lookup

### DIFF
--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -121,4 +121,8 @@ type Config struct {
 	Role             model.Role
 	SubscriberID     string           `yaml:"subscriberId"`
 	HttpClientConfig HttpClientConfig `yaml:"httpClientConfig"`
+	// BasePath is the HTTP path prefix at which this module is mounted (e.g.
+	// "/bap/receiver/"). Set by the module layer from module.Config.Path; not
+	// read from YAML. Steps use it to strip the prefix before calling plugins.
+	BasePath string `yaml:"-"`
 }

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -49,6 +49,7 @@ type stdHandler struct {
 	ackSigner    *ackSignerStep
 	SubscriberID string
 	role         model.Role
+	basePath     string
 	httpClient   *http.Client
 	moduleName   string
 }
@@ -88,6 +89,7 @@ func NewStdHandler(ctx context.Context, mgr PluginManager, cfg *Config, moduleNa
 		responseSteps: []definition.ResponseStep{},
 		SubscriberID:  cfg.SubscriberID,
 		role:          cfg.Role,
+		basePath:      cfg.BasePath,
 		moduleName:    moduleName,
 	}
 	// Initialize plugins.
@@ -588,9 +590,9 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 		case "validateSign":
 			s, err = newValidateSignStep(h.signValidator, h.km, h.payloadStore)
 		case "validateSchema":
-			s, err = newValidateSchemaStep(h.schemaValidator)
+			s, err = newValidateSchemaStep(h.schemaValidator, h.basePath)
 		case "addRoute":
-			s, err = newAddRouteStep(h.router)
+			s, err = newAddRouteStep(h.router, h.basePath)
 		case "checkPolicy":
 			s, err = newCheckPolicyStep(h.policyChecker)
 		case "transformPayload":

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -359,14 +360,31 @@ func parseHeader(header string) (*authHeader, error) {
 	}, nil
 }
 
+// stripBasePath returns a shallow copy of u with basePath stripped from the
+// front of its Path, then re-adding a leading slash so the URL remains valid.
+// When basePath is empty or u is nil the original pointer is returned unchanged.
+func stripBasePath(u *url.URL, basePath string) *url.URL {
+	if basePath == "" || u == nil {
+		return u
+	}
+	stripped := *u
+	p := strings.TrimPrefix(u.Path, basePath)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	stripped.Path = p
+	return &stripped
+}
+
 // validateSchemaStep represents the schema validation step.
 type validateSchemaStep struct {
 	validator definition.SchemaValidator
+	basePath  string
 	metrics   *HandlerMetrics
 }
 
 // newValidateSchemaStep creates and returns the validateSchema step after validation.
-func newValidateSchemaStep(schemaValidator definition.SchemaValidator) (definition.Step, error) {
+func newValidateSchemaStep(schemaValidator definition.SchemaValidator, basePath string) (definition.Step, error) {
 	if schemaValidator == nil {
 		return nil, fmt.Errorf("invalid config: SchemaValidator plugin not configured")
 	}
@@ -374,13 +392,14 @@ func newValidateSchemaStep(schemaValidator definition.SchemaValidator) (definiti
 	metrics, _ := GetHandlerMetrics(context.Background())
 	return &validateSchemaStep{
 		validator: schemaValidator,
+		basePath:  basePath,
 		metrics:   metrics,
 	}, nil
 }
 
 // Run executes the schema validation step.
 func (s *validateSchemaStep) Run(ctx *model.StepContext) error {
-	err := s.validator.Validate(ctx, ctx.Request.URL, ctx.Body)
+	err := s.validator.Validate(ctx, stripBasePath(ctx.Request.URL, s.basePath), ctx.Body)
 	if err != nil {
 		err = fmt.Errorf("schema validation failed: %w", err)
 	}
@@ -406,25 +425,27 @@ func (s *validateSchemaStep) recordMetrics(ctx *model.StepContext, err error) {
 
 // addRouteStep represents the route determination step.
 type addRouteStep struct {
-	router  definition.Router
-	metrics *HandlerMetrics
+	router   definition.Router
+	basePath string
+	metrics  *HandlerMetrics
 }
 
 // newAddRouteStep creates and returns the addRoute step after validation.
-func newAddRouteStep(router definition.Router) (definition.Step, error) {
+func newAddRouteStep(router definition.Router, basePath string) (definition.Step, error) {
 	if router == nil {
 		return nil, fmt.Errorf("invalid config: Router plugin not configured")
 	}
 	metrics, _ := GetHandlerMetrics(context.Background())
 	return &addRouteStep{
-		router:  router,
-		metrics: metrics,
+		router:   router,
+		basePath: basePath,
+		metrics:  metrics,
 	}, nil
 }
 
 // Run executes the routing step.
 func (s *addRouteStep) Run(ctx *model.StepContext) error {
-	route, err := s.router.Route(ctx, ctx.Request.URL, ctx.Body)
+	route, err := s.router.Route(ctx, stripBasePath(ctx.Request.URL, s.basePath), ctx.Body)
 	if err != nil {
 		return fmt.Errorf("failed to determine route: %w", err)
 	}

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -361,18 +361,16 @@ func parseHeader(header string) (*authHeader, error) {
 }
 
 // stripBasePath returns a shallow copy of u with basePath stripped from the
-// front of its Path, then re-adding a leading slash so the URL remains valid.
-// When basePath is empty or u is nil the original pointer is returned unchanged.
+// front of its Path and the leading slash removed, leaving the clean endpoint
+// action (e.g. "search" or "catalog/subscription") in Path.Path.
+// Returns nil when u is nil.
 func stripBasePath(u *url.URL, basePath string) *url.URL {
-	if basePath == "" || u == nil {
-		return u
+	if u == nil {
+		return nil
 	}
 	stripped := *u
 	p := strings.TrimPrefix(u.Path, basePath)
-	if !strings.HasPrefix(p, "/") {
-		p = "/" + p
-	}
-	stripped.Path = p
+	stripped.Path = strings.TrimPrefix(p, "/")
 	return &stripped
 }
 

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -452,75 +452,81 @@ func TestLookupRequestSignature_StoreError_ReturnsEmpty(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// stripBasePath unit tests (gap 1)
+// stripBasePath unit tests
 // ---------------------------------------------------------------------------
 
 func TestStripBasePath_NilURL_ReturnsNil(t *testing.T) {
 	if got := stripBasePath(nil, "/bap/receiver/"); got != nil {
-		t.Errorf("expected nil for nil URL, got %v", got)
+		t.Errorf("expected nil for nil URL, got %+v", got)
 	}
 }
 
-func TestStripBasePath_EmptyBasePath_ReturnsOriginal(t *testing.T) {
-	u, _ := url.Parse("/bap/receiver/catalog/subscription")
+func TestStripBasePath_EmptyBasePath_StripsLeadingSlash(t *testing.T) {
+	u, _ := url.Parse("/search")
 	got := stripBasePath(u, "")
-	if got != u {
-		t.Errorf("expected original pointer for empty basePath")
+	if got.Path != "search" {
+		t.Errorf("stripBasePath() Path = %q, want %q", got.Path, "search")
 	}
 }
 
-func TestStripBasePath_WithTrailingSlash(t *testing.T) {
-	u, _ := url.Parse("/bap/receiver/catalog/subscription")
-	got := stripBasePath(u, "/bap/receiver/")
-	if got.Path != "/catalog/subscription" {
-		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/catalog/subscription")
-	}
-}
-
-func TestStripBasePath_WithoutTrailingSlash(t *testing.T) {
+func TestStripBasePath_SingleWordAction(t *testing.T) {
 	u, _ := url.Parse("/bap/receiver/search")
 	got := stripBasePath(u, "/bap/receiver/")
-	if got.Path != "/search" {
-		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/search")
+	if got.Path != "search" {
+		t.Errorf("stripBasePath() Path = %q, want %q", got.Path, "search")
 	}
 }
 
-func TestStripBasePath_URLEqualsBasePath_ReturnsSlash(t *testing.T) {
+func TestStripBasePath_CompoundAction(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/catalog/subscription")
+	got := stripBasePath(u, "/bap/receiver/")
+	if got.Path != "catalog/subscription" {
+		t.Errorf("stripBasePath() Path = %q, want %q", got.Path, "catalog/subscription")
+	}
+}
+
+func TestStripBasePath_BasePathWithoutTrailingSlash(t *testing.T) {
+	// basePath without trailing slash: TrimPrefix leaves a leading "/" which is
+	// then stripped by the second TrimPrefix.
+	u, _ := url.Parse("/bap/receiver/search")
+	got := stripBasePath(u, "/bap/receiver")
+	if got.Path != "search" {
+		t.Errorf("stripBasePath() Path = %q, want %q", got.Path, "search")
+	}
+}
+
+func TestStripBasePath_URLEqualsBasePath_ReturnsEmpty(t *testing.T) {
 	u, _ := url.Parse("/bap/receiver/")
 	got := stripBasePath(u, "/bap/receiver/")
-	if got.Path != "/" {
-		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/")
+	if got.Path != "" {
+		t.Errorf("stripBasePath() Path = %q, want empty string", got.Path)
 	}
 }
 
-func TestStripBasePath_QueryStringPreserved(t *testing.T) {
+func TestStripBasePath_QueryParamsNotIncluded(t *testing.T) {
+	// url.URL.Path does not include the query string, so the returned Path is
+	// never polluted by query parameters.
 	u, _ := url.Parse("/bap/receiver/catalog/subscription?subscriptionId=abc-123")
 	got := stripBasePath(u, "/bap/receiver/")
-	if got.Path != "/catalog/subscription" {
-		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/catalog/subscription")
-	}
-	if got.RawQuery != "subscriptionId=abc-123" {
-		t.Errorf("stripBasePath() query = %q, want %q", got.RawQuery, "subscriptionId=abc-123")
+	if got.Path != "catalog/subscription" {
+		t.Errorf("stripBasePath() Path = %q, want %q", got.Path, "catalog/subscription")
 	}
 }
 
-func TestStripBasePath_DoesNotMutateOriginal(t *testing.T) {
+func TestStripBasePath_DoesNotMutateURL(t *testing.T) {
 	u, _ := url.Parse("/bap/receiver/search")
 	original := u.Path
-	got := stripBasePath(u, "/bap/receiver/")
+	stripBasePath(u, "/bap/receiver/")
 	if u.Path != original {
-		t.Errorf("stripBasePath() mutated original URL path: %q", u.Path)
-	}
-	if got == u {
-		t.Errorf("stripBasePath() returned same pointer — expected a copy")
+		t.Errorf("stripBasePath() mutated original URL.Path: %q", u.Path)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Mocks for validateSchemaStep / addRouteStep tests (gap 2)
+// Mocks for validateSchemaStep / addRouteStep wiring tests
 // ---------------------------------------------------------------------------
 
-// mockRecordingValidator records the URL passed to Validate.
+// mockRecordingValidator records the *url.URL passed to Validate.
 type mockRecordingValidator struct {
 	gotURL *url.URL
 	retErr error
@@ -531,7 +537,7 @@ func (m *mockRecordingValidator) Validate(_ context.Context, u *url.URL, _ []byt
 	return m.retErr
 }
 
-// mockRecordingRouter records the URL passed to Route.
+// mockRecordingRouter records the *url.URL passed to Route.
 type mockRecordingRouter struct {
 	gotURL *url.URL
 	retErr error
@@ -557,7 +563,7 @@ func makeStepCtxWithURL(rawURL string) *model.StepContext {
 }
 
 // ---------------------------------------------------------------------------
-// validateSchemaStep constructor + stripBasePath-wiring tests (gap 2)
+// validateSchemaStep constructor + stripBasePath wiring tests
 // ---------------------------------------------------------------------------
 
 func TestNewValidateSchemaStep_NilValidator_ReturnsError(t *testing.T) {
@@ -566,7 +572,7 @@ func TestNewValidateSchemaStep_NilValidator_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestValidateSchemaStep_Run_StripsBasePath(t *testing.T) {
+func TestValidateSchemaStep_Run_ExtractsAction(t *testing.T) {
 	mv := &mockRecordingValidator{}
 	step, err := newValidateSchemaStep(mv, "/bap/receiver/")
 	if err != nil {
@@ -574,26 +580,23 @@ func TestValidateSchemaStep_Run_StripsBasePath(t *testing.T) {
 	}
 	ctx := makeStepCtxWithURL("http://localhost/bap/receiver/catalog/subscription")
 	_ = step.Run(ctx)
-	if mv.gotURL == nil {
-		t.Fatal("validator was not called")
-	}
-	if mv.gotURL.Path != "/catalog/subscription" {
-		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "/catalog/subscription")
+	if mv.gotURL == nil || mv.gotURL.Path != "catalog/subscription" {
+		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "catalog/subscription")
 	}
 }
 
-func TestValidateSchemaStep_Run_NoBasePath_PassesFullPath(t *testing.T) {
+func TestValidateSchemaStep_Run_NoBasePath_UsesRawAction(t *testing.T) {
 	mv := &mockRecordingValidator{}
 	step, _ := newValidateSchemaStep(mv, "")
 	ctx := makeStepCtxWithURL("http://localhost/search")
 	_ = step.Run(ctx)
-	if mv.gotURL == nil || mv.gotURL.Path != "/search" {
-		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "/search")
+	if mv.gotURL == nil || mv.gotURL.Path != "search" {
+		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "search")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// addRouteStep constructor + stripBasePath-wiring tests (gap 2)
+// addRouteStep constructor + stripBasePath wiring tests
 // ---------------------------------------------------------------------------
 
 func TestNewAddRouteStep_NilRouter_ReturnsError(t *testing.T) {
@@ -602,7 +605,7 @@ func TestNewAddRouteStep_NilRouter_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestAddRouteStep_Run_StripsBasePath(t *testing.T) {
+func TestAddRouteStep_Run_ExtractsAction(t *testing.T) {
 	mr := &mockRecordingRouter{}
 	step, err := newAddRouteStep(mr, "/bpp/caller/")
 	if err != nil {
@@ -612,22 +615,19 @@ func TestAddRouteStep_Run_StripsBasePath(t *testing.T) {
 	if err := step.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
-	if mr.gotURL == nil {
-		t.Fatal("router was not called")
-	}
-	if mr.gotURL.Path != "/catalog/subscription" {
-		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "/catalog/subscription")
+	if mr.gotURL == nil || mr.gotURL.Path != "catalog/subscription" {
+		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "catalog/subscription")
 	}
 }
 
-func TestAddRouteStep_Run_NoBasePath_PassesFullPath(t *testing.T) {
+func TestAddRouteStep_Run_NoBasePath_UsesRawAction(t *testing.T) {
 	mr := &mockRecordingRouter{}
 	step, _ := newAddRouteStep(mr, "")
 	ctx := makeStepCtxWithURL("http://localhost/search")
 	if err := step.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
-	if mr.gotURL == nil || mr.gotURL.Path != "/search" {
-		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "/search")
+	if mr.gotURL == nil || mr.gotURL.Path != "search" {
+		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "search")
 	}
 }

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -447,5 +448,186 @@ func TestLookupRequestSignature_StoreError_ReturnsEmpty(t *testing.T) {
 	// Store error is non-fatal — should degrade to empty request-signature.
 	if got := s.lookupRequestSignature(ctx); got != "" {
 		t.Errorf("expected empty on store error, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stripBasePath unit tests (gap 1)
+// ---------------------------------------------------------------------------
+
+func TestStripBasePath_NilURL_ReturnsNil(t *testing.T) {
+	if got := stripBasePath(nil, "/bap/receiver/"); got != nil {
+		t.Errorf("expected nil for nil URL, got %v", got)
+	}
+}
+
+func TestStripBasePath_EmptyBasePath_ReturnsOriginal(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/catalog/subscription")
+	got := stripBasePath(u, "")
+	if got != u {
+		t.Errorf("expected original pointer for empty basePath")
+	}
+}
+
+func TestStripBasePath_WithTrailingSlash(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/catalog/subscription")
+	got := stripBasePath(u, "/bap/receiver/")
+	if got.Path != "/catalog/subscription" {
+		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/catalog/subscription")
+	}
+}
+
+func TestStripBasePath_WithoutTrailingSlash(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/search")
+	got := stripBasePath(u, "/bap/receiver/")
+	if got.Path != "/search" {
+		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/search")
+	}
+}
+
+func TestStripBasePath_URLEqualsBasePath_ReturnsSlash(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/")
+	got := stripBasePath(u, "/bap/receiver/")
+	if got.Path != "/" {
+		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/")
+	}
+}
+
+func TestStripBasePath_QueryStringPreserved(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/catalog/subscription?subscriptionId=abc-123")
+	got := stripBasePath(u, "/bap/receiver/")
+	if got.Path != "/catalog/subscription" {
+		t.Errorf("stripBasePath() path = %q, want %q", got.Path, "/catalog/subscription")
+	}
+	if got.RawQuery != "subscriptionId=abc-123" {
+		t.Errorf("stripBasePath() query = %q, want %q", got.RawQuery, "subscriptionId=abc-123")
+	}
+}
+
+func TestStripBasePath_DoesNotMutateOriginal(t *testing.T) {
+	u, _ := url.Parse("/bap/receiver/search")
+	original := u.Path
+	got := stripBasePath(u, "/bap/receiver/")
+	if u.Path != original {
+		t.Errorf("stripBasePath() mutated original URL path: %q", u.Path)
+	}
+	if got == u {
+		t.Errorf("stripBasePath() returned same pointer — expected a copy")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mocks for validateSchemaStep / addRouteStep tests (gap 2)
+// ---------------------------------------------------------------------------
+
+// mockRecordingValidator records the URL passed to Validate.
+type mockRecordingValidator struct {
+	gotURL *url.URL
+	retErr error
+}
+
+func (m *mockRecordingValidator) Validate(_ context.Context, u *url.URL, _ []byte) error {
+	m.gotURL = u
+	return m.retErr
+}
+
+// mockRecordingRouter records the URL passed to Route.
+type mockRecordingRouter struct {
+	gotURL *url.URL
+	retErr error
+}
+
+func (m *mockRecordingRouter) Route(_ context.Context, u *url.URL, _ []byte) (*model.Route, error) {
+	m.gotURL = u
+	if m.retErr != nil {
+		return nil, m.retErr
+	}
+	return &model.Route{TargetType: "url"}, nil
+}
+
+// makeStepCtxWithURL builds a minimal StepContext with the given raw URL string.
+func makeStepCtxWithURL(rawURL string) *model.StepContext {
+	req, _ := http.NewRequest(http.MethodPost, rawURL, nil)
+	return &model.StepContext{
+		Context:    context.Background(),
+		Request:    req,
+		Body:       []byte(`{"context":{"action":"search"}}`),
+		RespHeader: http.Header{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateSchemaStep constructor + stripBasePath-wiring tests (gap 2)
+// ---------------------------------------------------------------------------
+
+func TestNewValidateSchemaStep_NilValidator_ReturnsError(t *testing.T) {
+	if _, err := newValidateSchemaStep(nil, ""); err == nil {
+		t.Fatal("expected error for nil SchemaValidator")
+	}
+}
+
+func TestValidateSchemaStep_Run_StripsBasePath(t *testing.T) {
+	mv := &mockRecordingValidator{}
+	step, err := newValidateSchemaStep(mv, "/bap/receiver/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx := makeStepCtxWithURL("http://localhost/bap/receiver/catalog/subscription")
+	_ = step.Run(ctx)
+	if mv.gotURL == nil {
+		t.Fatal("validator was not called")
+	}
+	if mv.gotURL.Path != "/catalog/subscription" {
+		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "/catalog/subscription")
+	}
+}
+
+func TestValidateSchemaStep_Run_NoBasePath_PassesFullPath(t *testing.T) {
+	mv := &mockRecordingValidator{}
+	step, _ := newValidateSchemaStep(mv, "")
+	ctx := makeStepCtxWithURL("http://localhost/search")
+	_ = step.Run(ctx)
+	if mv.gotURL == nil || mv.gotURL.Path != "/search" {
+		t.Errorf("validator received path %q, want %q", mv.gotURL.Path, "/search")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// addRouteStep constructor + stripBasePath-wiring tests (gap 2)
+// ---------------------------------------------------------------------------
+
+func TestNewAddRouteStep_NilRouter_ReturnsError(t *testing.T) {
+	if _, err := newAddRouteStep(nil, ""); err == nil {
+		t.Fatal("expected error for nil Router")
+	}
+}
+
+func TestAddRouteStep_Run_StripsBasePath(t *testing.T) {
+	mr := &mockRecordingRouter{}
+	step, err := newAddRouteStep(mr, "/bpp/caller/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx := makeStepCtxWithURL("http://localhost/bpp/caller/catalog/subscription")
+	if err := step.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if mr.gotURL == nil {
+		t.Fatal("router was not called")
+	}
+	if mr.gotURL.Path != "/catalog/subscription" {
+		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "/catalog/subscription")
+	}
+}
+
+func TestAddRouteStep_Run_NoBasePath_PassesFullPath(t *testing.T) {
+	mr := &mockRecordingRouter{}
+	step, _ := newAddRouteStep(mr, "")
+	ctx := makeStepCtxWithURL("http://localhost/search")
+	if err := step.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if mr.gotURL == nil || mr.gotURL.Path != "/search" {
+		t.Errorf("router received path %q, want %q", mr.gotURL.Path, "/search")
 	}
 }

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -40,6 +40,7 @@ func Register(ctx context.Context, mCfgs []Config, mux *http.ServeMux, mgr handl
 		if !ok {
 			return fmt.Errorf("invalid module : %s", c.Name)
 		}
+		c.Handler.BasePath = c.Path
 		h, err := rmp(ctx, mgr, &c.Handler, c.Name)
 		if err != nil {
 			return fmt.Errorf("%s : %w", c.Name, err)

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -213,11 +213,10 @@ func getContextString(ctx map[string]interface{}, snakeKey, camelKey string) str
 }
 
 // Route determines the routing destination based on the request context.
-func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.Route, error) {
-	// Extract the endpoint from the URL, stripping the module base path so that
-	// compound action paths like "catalog/push" are preserved verbatim.
-	endpoint := r.extractEndpoint(url.Path)
-
+// reqURL.Path holds the Beckn endpoint action already stripped of the module
+// base path by the step layer (e.g. "search" or "catalog/subscription").
+func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*model.Route, error) {
+	endpoint := reqURL.Path
 	// Bodyless requests (GET/DELETE) carry no JSON body; domain, version, and
 	// BAP/BPP URIs are not available. Route using the v2 config version.
 	if len(body) == 0 {
@@ -288,14 +287,6 @@ func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.R
 		return handleProtocolMapping(route, bapURI, endpoint)
 	}
 	return route, nil
-}
-
-// extractEndpoint derives the action endpoint key from the URL path.
-// The step layer is responsible for stripping the module base path before
-// calling Route, so urlPath is expected to be of the form "/action" or
-// "/compound/action". The leading slash is removed to produce the map key.
-func (r *Router) extractEndpoint(urlPath string) string {
-	return strings.TrimPrefix(urlPath, "/")
 }
 
 // routeBodyless handles routing for GET/DELETE requests that carry no body.

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -17,13 +17,6 @@ import (
 // Config holds the configuration for the Router plugin.
 type Config struct {
 	RoutingConfig string `json:"routingConfig"`
-	// BasePath is the HTTP path prefix at which this adapter module is mounted
-	// (e.g. "/bap/caller/"). When set, it is stripped from the incoming request
-	// URL before extracting the action endpoint, enabling compound action paths
-	// like "catalog/push" to be matched correctly against routing rules.
-	// If unset, the router falls back to path.Base behaviour (last URL segment
-	// only), which supports single-word actions but not compound ones.
-	BasePath string `json:"basePath,omitempty"`
 }
 
 // RoutingConfig represents the structure of the routing configuration file.
@@ -33,8 +26,7 @@ type routingConfig struct {
 
 // Router implements Router interface.
 type Router struct {
-	rules    map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
-	basePath string                                        // module mount prefix stripped before endpoint lookup
+	rules map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
 }
 
 // RoutingRule represents a single routing rule.
@@ -70,8 +62,7 @@ func New(ctx context.Context, config *Config) (*Router, func() error, error) {
 		return nil, nil, fmt.Errorf("config cannot be nil")
 	}
 	router := &Router{
-		rules:    make(map[string]map[string]map[string]*model.Route),
-		basePath: config.BasePath,
+		rules: make(map[string]map[string]map[string]*model.Route),
 	}
 
 	// Load rules at bootup
@@ -299,19 +290,12 @@ func (r *Router) Route(ctx context.Context, url *url.URL, body []byte) (*model.R
 	return route, nil
 }
 
-// extractEndpoint derives the action endpoint key from the incoming URL path.
-// When basePath is configured (e.g. "/bap/caller/"), it is stripped first so
-// that compound paths like "/bap/caller/catalog/push" → "catalog/push".
-// Without basePath, the function falls back to path.Base (last URL segment),
-// preserving backward compatibility for deployments that only use single-word
-// actions and have not set basePath.
+// extractEndpoint derives the action endpoint key from the URL path.
+// The step layer is responsible for stripping the module base path before
+// calling Route, so urlPath is expected to be of the form "/action" or
+// "/compound/action". The leading slash is removed to produce the map key.
 func (r *Router) extractEndpoint(urlPath string) string {
-	if r.basePath != "" {
-		// Strip the module mount prefix, then any residual leading slash.
-		stripped := strings.TrimPrefix(urlPath, r.basePath)
-		return strings.TrimPrefix(stripped, "/")
-	}
-	return path.Base(urlPath)
+	return strings.TrimPrefix(urlPath, "/")
 }
 
 // routeBodyless handles routing for GET/DELETE requests that carry no body.

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -427,61 +427,60 @@ func TestValidateRulesFailure(t *testing.T) {
 func TestRouteSuccess(t *testing.T) {
 	ctx := context.Background()
 
-	// Define success test cases
 	tests := []struct {
-		name       string
-		configFile string
-		url        string
-		body       string
+		name           string
+		configFile     string
+		endpointAction string
+		body           string
 	}{
 		{
-			name:       "Valid domain, version, and endpoint (bpp routing with gateway URL)",
-			configFile: "bap_caller.yaml",
-			url:        "https://example.com/search",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			name:           "Valid domain, version, and endpoint (bpp routing with gateway URL)",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "search",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
-			name:       "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
-			configFile: "bap_caller.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
+			name:           "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
 		},
 		{
-			name:       "Valid domain, version, and endpoint (url routing)",
-			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			name:           "Valid domain, version, and endpoint (url routing)",
+			configFile:     "bpp_receiver.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
-			name:       "Valid domain, version, and endpoint (publisher routing)",
-			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/search",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			name:           "Valid domain, version, and endpoint (publisher routing)",
+			configFile:     "bpp_receiver.yaml",
+			endpointAction: "search",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
-			name:       "Valid domain, version, and endpoint (bap routing with bap_uri)",
-			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/on_select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bap_uri": "https://bap1.example.com"}}`,
+			name:           "Valid domain, version, and endpoint (bap routing with bap_uri)",
+			configFile:     "bpp_caller.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bap_uri": "https://bap1.example.com"}}`,
 		},
 		{
-			name:       "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
-			configFile: "bap_receiver.yaml",
-			url:        "https://example.com/on_select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
+			name:           "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
+			configFile:     "bap_receiver.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
 		},
 		// camelCase variants (beckn spec camelCase migration)
 		{
-			name:       "camelCase: bppUri in context is resolved for bpp routing",
-			configFile: "bap_caller.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bppUri": "https://bpp1.example.com"}}`,
+			name:           "camelCase: bppUri in context is resolved for bpp routing",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bppUri": "https://bpp1.example.com"}}`,
 		},
 		{
-			name:       "camelCase: bapUri in context is resolved for bap routing",
-			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/on_select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bapUri": "https://bap1.example.com"}}`,
+			name:           "camelCase: bapUri in context is resolved for bap routing",
+			configFile:     "bpp_caller.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bapUri": "https://bap1.example.com"}}`,
 		},
 	}
 
@@ -490,12 +489,9 @@ func TestRouteSuccess(t *testing.T) {
 			router, _, rulesFilePath := setupRouter(t, tt.configFile)
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-			parsedURL, _ := url.Parse(tt.url)
-			_, err := router.Route(ctx, parsedURL, []byte(tt.body))
-
-			// Ensure no error occurred
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
 			if err != nil {
-				t.Errorf("router.Route(%v, %v, %v) = %v, want nil error", ctx, parsedURL, []byte(tt.body), err)
+				t.Errorf("router.Route() = %v, want nil error", err)
 			}
 		})
 	}
@@ -505,48 +501,47 @@ func TestRouteSuccess(t *testing.T) {
 func TestRouteFailure(t *testing.T) {
 	ctx := context.Background()
 
-	// Define failure test cases
 	tests := []struct {
-		name       string
-		configFile string
-		url        string
-		body       string
-		wantErr    string
+		name           string
+		configFile     string
+		endpointAction string
+		body           string
+		wantErr        string
 	}{
 		{
-			name:       "Unsupported endpoint",
-			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/unsupported",
-			body:       `{"context": {"domain": "ONDC:TRV11", "version": "1.1.0"}}`,
-			wantErr:    "endpoint 'unsupported' is not supported for domain ONDC:TRV11 and version 1.1.0",
+			name:           "Unsupported endpoint",
+			configFile:     "bpp_receiver.yaml",
+			endpointAction: "unsupported",
+			body:           `{"context": {"domain": "ONDC:TRV11", "version": "1.1.0"}}`,
+			wantErr:        "endpoint 'unsupported' is not supported for domain ONDC:TRV11 and version 1.1.0",
 		},
 		{
-			name:       "No matching rule",
-			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:SRV11", "version": "1.1.0"}}`,
-			wantErr:    "no routing rules found for domain ONDC:SRV11",
+			name:           "No matching rule",
+			configFile:     "bpp_receiver.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:SRV11", "version": "1.1.0"}}`,
+			wantErr:        "no routing rules found for domain ONDC:SRV11",
 		},
 		{
-			name:       "Missing bap_uri for bap routing",
-			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/on_search",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
-			wantErr:    "could not determine destination for endpoint 'on_search': neither request contained a BAP URI nor was a default URL configured in routing rules",
+			name:           "Missing bap_uri for bap routing",
+			configFile:     "bpp_caller.yaml",
+			endpointAction: "on_search",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			wantErr:        "could not determine destination for endpoint 'on_search': neither request contained a BAP URI nor was a default URL configured in routing rules",
 		},
 		{
-			name:       "Missing bpp_uri for bpp routing",
-			configFile: "bap_caller.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
-			wantErr:    "could not determine destination for endpoint 'select': neither request contained a BPP URI nor was a default URL configured in routing rules",
+			name:           "Missing bpp_uri for bpp routing",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			wantErr:        "could not determine destination for endpoint 'select': neither request contained a BPP URI nor was a default URL configured in routing rules",
 		},
 		{
-			name:       "Invalid bpp_uri format in request",
-			configFile: "bap_caller.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "htp:// invalid-url"}}`, // Invalid scheme (htp instead of http)
-			wantErr:    `invalid BPP URI - htp:// invalid-url in request body for select: parse "htp:// invalid-url": invalid character " " in host name`,
+			name:           "Invalid bpp_uri format in request",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "htp:// invalid-url"}}`,
+			wantErr:        `invalid BPP URI - htp:// invalid-url in request body for select: parse "htp:// invalid-url": invalid character " " in host name`,
 		},
 	}
 
@@ -555,12 +550,9 @@ func TestRouteFailure(t *testing.T) {
 			router, _, rulesFilePath := setupRouter(t, tt.configFile)
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-			parsedURL, _ := url.Parse(tt.url)
-			_, err := router.Route(ctx, parsedURL, []byte(tt.body))
-
-			// Check for expected error
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("Route(%q, %q) = %v, want error containing %q", tt.url, tt.body, err, tt.wantErr)
+				t.Errorf("Route(%q, %q) = %v, want error containing %q", tt.endpointAction, tt.body, err, tt.wantErr)
 			}
 		})
 	}
@@ -701,28 +693,28 @@ func TestV2RouteSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name       string
-		configFile string
-		url        string
-		body       string
+		name           string
+		configFile     string
+		endpointAction string
+		body           string
 	}{
 		{
-			name:       "v2 BAP caller - domain ignored",
-			configFile: "v2_bap_caller.yaml",
-			url:        "https://example.com/search",
-			body:       `{"context": {"domain": "any_domain", "version": "2.0.0"}}`,
+			name:           "v2 BAP caller - domain ignored",
+			configFile:     "v2_bap_caller.yaml",
+			endpointAction: "search",
+			body:           `{"context": {"domain": "any_domain", "version": "2.0.0"}}`,
 		},
 		{
-			name:       "v2 BPP receiver - domain ignored",
-			configFile: "v2_bpp_receiver.yaml",
-			url:        "https://example.com/select",
-			body:       `{"context": {"domain": "different_domain", "version": "2.0.0"}}`,
+			name:           "v2 BPP receiver - domain ignored",
+			configFile:     "v2_bpp_receiver.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "different_domain", "version": "2.0.0"}}`,
 		},
 		{
-			name:       "v2 request without domain field",
-			configFile: "v2_bap_caller.yaml",
-			url:        "https://example.com/search",
-			body:       `{"context": {"version": "2.0.0"}}`,
+			name:           "v2 request without domain field",
+			configFile:     "v2_bap_caller.yaml",
+			endpointAction: "search",
+			body:           `{"context": {"version": "2.0.0"}}`,
 		},
 	}
 
@@ -731,9 +723,7 @@ func TestV2RouteSuccess(t *testing.T) {
 			router, _, rulesFilePath := setupRouter(t, tt.configFile)
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-			parsedURL, _ := url.Parse(tt.url)
-			_, err := router.Route(ctx, parsedURL, []byte(tt.body))
-
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
 			if err != nil {
 				t.Errorf("router.Route() = %v, want nil (domain should be ignored for v2)", err)
 			}
@@ -839,9 +829,7 @@ func TestRouteNilContext(t *testing.T) {
 	router, _, rulesFilePath := setupRouter(t, "bap_caller.yaml")
 	defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-	parsedURL, _ := url.Parse("https://example.com/select")
-	_, err := router.Route(ctx, parsedURL, []byte(`{"message": {}}`))
-
+	_, err := router.Route(ctx, &url.URL{Path: "select"}, []byte(`{"message": {}}`))
 	if err == nil || !strings.Contains(err.Error(), "context field not found or invalid") {
 		t.Errorf("Route() with missing context = %v, want error containing 'context field not found or invalid'", err)
 	}
@@ -877,68 +865,30 @@ func TestV1DomainRequired(t *testing.T) {
 	}
 }
 
-// TestExtractEndpoint tests the endpoint extraction helper.
-// The step layer strips the module base path before calling Route, so the
-// router always receives paths of the form "/action" or "/compound/action".
-func TestExtractEndpoint(t *testing.T) {
-	r := &Router{}
-	tests := []struct {
-		name    string
-		urlPath string
-		want    string
-	}{
-		{
-			name:    "single-word action",
-			urlPath: "/search",
-			want:    "search",
-		},
-		{
-			name:    "compound two-segment action",
-			urlPath: "/catalog/subscription",
-			want:    "catalog/subscription",
-		},
-		{
-			name:    "compound two-segment action (push)",
-			urlPath: "/catalog/push",
-			want:    "catalog/push",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := r.extractEndpoint(tt.urlPath)
-			if got != tt.want {
-				t.Errorf("extractEndpoint(%q) = %q, want %q", tt.urlPath, got, tt.want)
-			}
-		})
-	}
-}
-
 // TestRouteCompoundEndpointSuccess tests that compound action paths are routed
-// correctly. The step layer strips the module base path before calling Route,
-// so the router receives pre-stripped URLs like "/catalog/push".
+// correctly. The step layer provides the action string directly (e.g. "catalog/push").
 func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name string
-		url  string
-		body string
+		name           string
+		endpointAction string
+		body           string
 	}{
 		{
-			name: "compound endpoint catalog/push routed via url target",
-			url:  "https://example.com/catalog/push",
-			body: `{"context": {"version": "2.0.0"}}`,
+			name:           "compound endpoint catalog/push routed via url target",
+			endpointAction: "catalog/push",
+			body:           `{"context": {"version": "2.0.0"}}`,
 		},
 		{
-			name: "compound endpoint catalog/subscription (POST) routed via url target",
-			url:  "https://example.com/catalog/subscription",
-			body: `{"context": {"version": "2.0.0"}}`,
+			name:           "compound endpoint catalog/subscription (POST) routed via url target",
+			endpointAction: "catalog/subscription",
+			body:           `{"context": {"version": "2.0.0"}}`,
 		},
 		{
-			name: "compound endpoint catalog/search routed via url target",
-			url:  "https://example.com/catalog/search",
-			body: `{"context": {"version": "2.0.0"}}`,
+			name:           "compound endpoint catalog/search routed via url target",
+			endpointAction: "catalog/search",
+			body:           `{"context": {"version": "2.0.0"}}`,
 		},
 	}
 
@@ -947,8 +897,7 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 			router, _, rulesFilePath := setupRouter(t, "v2_catalog_url.yaml")
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-			parsedURL, _ := url.Parse(tt.url)
-			_, err := router.Route(ctx, parsedURL, []byte(tt.body))
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
 			if err != nil {
 				t.Errorf("Route() = %v, want nil error", err)
 			}
@@ -956,45 +905,43 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	}
 }
 
-// TestRouteBodyless tests routing where the body is empty (GET/DELETE requests).
-// The router receives only the URL and a nil body — it does not see the HTTP
-// method. Method-level distinction (GET vs DELETE on the same path) is the
-// handler's responsibility, not the router's. URLs are pre-stripped of the
-// module base path by the step layer before reaching the router.
+// TestRouteBodyless tests routing for GET/DELETE requests (empty body).
+// The router receives only the endpointAction and a nil body — it does not see
+// the HTTP method. Method-level distinction is the handler's responsibility.
 func TestRouteBodyless(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name       string
-		configFile string
-		url        string
-		wantErr    string
+		name           string
+		configFile     string
+		endpointAction string
+		wantErr        string
 	}{
 		{
-			// Covers both GET and DELETE: the router sees only the URL and nil body;
-			// HTTP method distinction is handled upstream by the request pipeline.
-			name:       "bodyless request to catalog/subscription succeeds",
-			configFile: "v2_catalog_url.yaml",
-			url:        "https://example.com/catalog/subscription",
-			wantErr:    "",
+			// Covers both GET and DELETE: the router sees only the endpointAction and
+			// nil body; HTTP method distinction is handled upstream by the pipeline.
+			name:           "bodyless request to catalog/subscription succeeds",
+			configFile:     "v2_catalog_url.yaml",
+			endpointAction: "catalog/subscription",
+			wantErr:        "",
 		},
 		{
-			name:       "bodyless to unsupported endpoint returns clear error",
-			configFile: "v2_catalog_url.yaml",
-			url:        "https://example.com/catalog/unknown",
-			wantErr:    "endpoint 'catalog/unknown' is not supported in v2 routing config",
+			name:           "bodyless to unsupported endpoint returns clear error",
+			configFile:     "v2_catalog_url.yaml",
+			endpointAction: "catalog/unknown",
+			wantErr:        "endpoint 'catalog/unknown' is not supported in v2 routing config",
 		},
 		{
-			name:       "bodyless to BPP target type returns error",
-			configFile: "v2_catalog_bpp.yaml",
-			url:        "https://example.com/catalog/subscription",
-			wantErr:    "dynamic BAP/BPP URI routing is not supported for bodyless requests",
+			name:           "bodyless to BPP target type returns error",
+			configFile:     "v2_catalog_bpp.yaml",
+			endpointAction: "catalog/subscription",
+			wantErr:        "dynamic BAP/BPP URI routing is not supported for bodyless requests",
 		},
 		{
-			name:       "bodyless request with no v2 rules returns error",
-			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/catalog/subscription",
-			wantErr:    "no v2 routing rules found",
+			name:           "bodyless request with no v2 rules returns error",
+			configFile:     "bpp_receiver.yaml",
+			endpointAction: "catalog/subscription",
+			wantErr:        "no v2 routing rules found",
 		},
 	}
 
@@ -1003,9 +950,7 @@ func TestRouteBodyless(t *testing.T) {
 			router, _, rulesFilePath := setupRouter(t, tt.configFile)
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-			parsedURL, _ := url.Parse(tt.url)
-			_, err := router.Route(ctx, parsedURL, nil)
-
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, nil)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Errorf("Route() = %v, want nil error", err)

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -437,50 +437,50 @@ func TestRouteSuccess(t *testing.T) {
 		{
 			name:       "Valid domain, version, and endpoint (bpp routing with gateway URL)",
 			configFile: "bap_caller.yaml",
-			url:        "https://example.com/v1/ondc/search",
+			url:        "https://example.com/search",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
 			name:       "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
 			configFile: "bap_caller.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
 		},
 		{
 			name:       "Valid domain, version, and endpoint (url routing)",
 			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
 			name:       "Valid domain, version, and endpoint (publisher routing)",
 			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/v1/ondc/search",
+			url:        "https://example.com/search",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 		},
 		{
 			name:       "Valid domain, version, and endpoint (bap routing with bap_uri)",
 			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/v1/ondc/on_select",
+			url:        "https://example.com/on_select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bap_uri": "https://bap1.example.com"}}`,
 		},
 		{
 			name:       "Valid domain, version, and endpoint (bpp routing with bpp_uri)",
 			configFile: "bap_receiver.yaml",
-			url:        "https://example.com/v1/ondc/on_select",
+			url:        "https://example.com/on_select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
 		},
 		// camelCase variants (beckn spec camelCase migration)
 		{
 			name:       "camelCase: bppUri in context is resolved for bpp routing",
 			configFile: "bap_caller.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bppUri": "https://bpp1.example.com"}}`,
 		},
 		{
 			name:       "camelCase: bapUri in context is resolved for bap routing",
 			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/v1/ondc/on_select",
+			url:        "https://example.com/on_select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bapUri": "https://bap1.example.com"}}`,
 		},
 	}
@@ -516,35 +516,35 @@ func TestRouteFailure(t *testing.T) {
 		{
 			name:       "Unsupported endpoint",
 			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/v1/ondc/unsupported",
+			url:        "https://example.com/unsupported",
 			body:       `{"context": {"domain": "ONDC:TRV11", "version": "1.1.0"}}`,
 			wantErr:    "endpoint 'unsupported' is not supported for domain ONDC:TRV11 and version 1.1.0",
 		},
 		{
 			name:       "No matching rule",
 			configFile: "bpp_receiver.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:SRV11", "version": "1.1.0"}}`,
 			wantErr:    "no routing rules found for domain ONDC:SRV11",
 		},
 		{
 			name:       "Missing bap_uri for bap routing",
 			configFile: "bpp_caller.yaml",
-			url:        "https://example.com/v1/ondc/on_search",
+			url:        "https://example.com/on_search",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 			wantErr:    "could not determine destination for endpoint 'on_search': neither request contained a BAP URI nor was a default URL configured in routing rules",
 		},
 		{
 			name:       "Missing bpp_uri for bpp routing",
 			configFile: "bap_caller.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
 			wantErr:    "could not determine destination for endpoint 'select': neither request contained a BPP URI nor was a default URL configured in routing rules",
 		},
 		{
 			name:       "Invalid bpp_uri format in request",
 			configFile: "bap_caller.yaml",
-			url:        "https://example.com/v1/ondc/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "htp:// invalid-url"}}`, // Invalid scheme (htp instead of http)
 			wantErr:    `invalid BPP URI - htp:// invalid-url in request body for select: parse "htp:// invalid-url": invalid character " " in host name`,
 		},
@@ -709,19 +709,19 @@ func TestV2RouteSuccess(t *testing.T) {
 		{
 			name:       "v2 BAP caller - domain ignored",
 			configFile: "v2_bap_caller.yaml",
-			url:        "https://example.com/v2/search",
+			url:        "https://example.com/search",
 			body:       `{"context": {"domain": "any_domain", "version": "2.0.0"}}`,
 		},
 		{
 			name:       "v2 BPP receiver - domain ignored",
 			configFile: "v2_bpp_receiver.yaml",
-			url:        "https://example.com/v2/select",
+			url:        "https://example.com/select",
 			body:       `{"context": {"domain": "different_domain", "version": "2.0.0"}}`,
 		},
 		{
 			name:       "v2 request without domain field",
 			configFile: "v2_bap_caller.yaml",
-			url:        "https://example.com/v2/search",
+			url:        "https://example.com/search",
 			body:       `{"context": {"version": "2.0.0"}}`,
 		},
 	}
@@ -839,7 +839,7 @@ func TestRouteNilContext(t *testing.T) {
 	router, _, rulesFilePath := setupRouter(t, "bap_caller.yaml")
 	defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-	parsedURL, _ := url.Parse("https://example.com/v1/ondc/select")
+	parsedURL, _ := url.Parse("https://example.com/select")
 	_, err := router.Route(ctx, parsedURL, []byte(`{"message": {}}`))
 
 	if err == nil || !strings.Contains(err.Error(), "context field not found or invalid") {
@@ -877,114 +877,74 @@ func TestV1DomainRequired(t *testing.T) {
 	}
 }
 
-// setupRouterWithBasePath is a helper that creates a Router with a basePath set.
-func setupRouterWithBasePath(t *testing.T, configFile, basePath string) (*Router, string) {
-	t.Helper()
-	rulesFilePath := setupTestConfig(t, configFile)
-	config := &Config{
-		RoutingConfig: rulesFilePath,
-		BasePath:      basePath,
-	}
-	router, _, err := New(context.Background(), config)
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-	return router, rulesFilePath
-}
-
-// TestExtractEndpoint tests the endpoint extraction helper for both basePath
-// and fallback (path.Base) modes.
+// TestExtractEndpoint tests the endpoint extraction helper.
+// The step layer strips the module base path before calling Route, so the
+// router always receives paths of the form "/action" or "/compound/action".
 func TestExtractEndpoint(t *testing.T) {
+	r := &Router{}
 	tests := []struct {
-		name     string
-		basePath string
-		urlPath  string
-		want     string
+		name    string
+		urlPath string
+		want    string
 	}{
 		{
-			name:     "no basePath - single-word action falls back to path.Base",
-			basePath: "",
-			urlPath:  "/bap/caller/search",
-			want:     "search",
+			name:    "single-word action",
+			urlPath: "/search",
+			want:    "search",
 		},
 		{
-			name:     "no basePath - root-level single-word action",
-			basePath: "",
-			urlPath:  "/search",
-			want:     "search",
+			name:    "compound two-segment action",
+			urlPath: "/catalog/subscription",
+			want:    "catalog/subscription",
 		},
 		{
-			name:     "basePath with trailing slash - single-word action",
-			basePath: "/bap/caller/",
-			urlPath:  "/bap/caller/search",
-			want:     "search",
-		},
-		{
-			name:     "basePath without trailing slash - single-word action",
-			basePath: "/bap/caller",
-			urlPath:  "/bap/caller/search",
-			want:     "search",
-		},
-		{
-			name:     "basePath - two-segment compound action",
-			basePath: "/bap/caller/",
-			urlPath:  "/bap/caller/catalog/push",
-			want:     "catalog/push",
-		},
-		{
-			name:     "basePath - two-segment compound action (subscription)",
-			basePath: "/bap/receiver/",
-			urlPath:  "/bap/receiver/catalog/subscription",
-			want:     "catalog/subscription",
+			name:    "compound two-segment action (push)",
+			urlPath: "/catalog/push",
+			want:    "catalog/push",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &Router{basePath: tt.basePath}
 			got := r.extractEndpoint(tt.urlPath)
 			if got != tt.want {
-				t.Errorf("extractEndpoint(%q) with basePath=%q = %q, want %q",
-					tt.urlPath, tt.basePath, got, tt.want)
+				t.Errorf("extractEndpoint(%q) = %q, want %q", tt.urlPath, got, tt.want)
 			}
 		})
 	}
 }
 
 // TestRouteCompoundEndpointSuccess tests that compound action paths are routed
-// correctly when basePath is configured.
+// correctly. The step layer strips the module base path before calling Route,
+// so the router receives pre-stripped URLs like "/catalog/push".
 func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name     string
-		basePath string
-		url      string
-		body     string
+		name string
+		url  string
+		body string
 	}{
 		{
-			name:     "compound endpoint catalog/push routed via url target",
-			basePath: "/bap/caller/",
-			url:      "https://example.com/bap/caller/catalog/push",
-			body:     `{"context": {"version": "2.0.0"}}`,
+			name: "compound endpoint catalog/push routed via url target",
+			url:  "https://example.com/catalog/push",
+			body: `{"context": {"version": "2.0.0"}}`,
 		},
 		{
-			name:     "compound endpoint catalog/subscription (POST) routed via url target",
-			basePath: "/bap/caller/",
-			url:      "https://example.com/bap/caller/catalog/subscription",
-			body:     `{"context": {"version": "2.0.0"}}`,
+			name: "compound endpoint catalog/subscription (POST) routed via url target",
+			url:  "https://example.com/catalog/subscription",
+			body: `{"context": {"version": "2.0.0"}}`,
 		},
 		{
-			name:     "compound endpoint catalog/search routed via url target",
-			basePath: "/bap/caller/",
-			url:      "https://example.com/bap/caller/catalog/search",
-			body:     `{"context": {"version": "2.0.0"}}`,
+			name: "compound endpoint catalog/search routed via url target",
+			url:  "https://example.com/catalog/search",
+			body: `{"context": {"version": "2.0.0"}}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router, rulesFilePath := setupRouterWithBasePath(t, "v2_catalog_url.yaml", tt.basePath)
+			router, _, rulesFilePath := setupRouter(t, "v2_catalog_url.yaml")
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
 			parsedURL, _ := url.Parse(tt.url)
@@ -999,15 +959,14 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 // TestRouteBodyless tests routing where the body is empty (GET/DELETE requests).
 // The router receives only the URL and a nil body — it does not see the HTTP
 // method. Method-level distinction (GET vs DELETE on the same path) is the
-// handler's responsibility, not the router's. A single bodyless success case
-// therefore covers both methods.
+// handler's responsibility, not the router's. URLs are pre-stripped of the
+// module base path by the step layer before reaching the router.
 func TestRouteBodyless(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
 		name       string
 		configFile string
-		basePath   string
 		url        string
 		wantErr    string
 	}{
@@ -1016,36 +975,32 @@ func TestRouteBodyless(t *testing.T) {
 			// HTTP method distinction is handled upstream by the request pipeline.
 			name:       "bodyless request to catalog/subscription succeeds",
 			configFile: "v2_catalog_url.yaml",
-			basePath:   "/bap/receiver/",
-			url:        "https://example.com/bap/receiver/catalog/subscription",
+			url:        "https://example.com/catalog/subscription",
 			wantErr:    "",
 		},
 		{
 			name:       "bodyless to unsupported endpoint returns clear error",
 			configFile: "v2_catalog_url.yaml",
-			basePath:   "/bap/receiver/",
-			url:        "https://example.com/bap/receiver/catalog/unknown",
+			url:        "https://example.com/catalog/unknown",
 			wantErr:    "endpoint 'catalog/unknown' is not supported in v2 routing config",
 		},
 		{
 			name:       "bodyless to BPP target type returns error",
 			configFile: "v2_catalog_bpp.yaml",
-			basePath:   "/bap/receiver/",
-			url:        "https://example.com/bap/receiver/catalog/subscription",
+			url:        "https://example.com/catalog/subscription",
 			wantErr:    "dynamic BAP/BPP URI routing is not supported for bodyless requests",
 		},
 		{
 			name:       "bodyless request with no v2 rules returns error",
 			configFile: "bpp_receiver.yaml",
-			basePath:   "/bap/receiver/",
-			url:        "https://example.com/bap/receiver/catalog/subscription",
+			url:        "https://example.com/catalog/subscription",
 			wantErr:    "no v2 routing rules found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router, rulesFilePath := setupRouterWithBasePath(t, tt.configFile, tt.basePath)
+			router, _, rulesFilePath := setupRouter(t, tt.configFile)
 			defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
 			parsedURL, _ := url.Parse(tt.url)

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -119,12 +119,14 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 		}
 
-		// Key is the full path without its leading slash, matching the index built in
-		// buildActionIndex. strings.TrimPrefix is used (not path.Base) so that
-		// multi-segment paths like /catalog/subscription are preserved verbatim.
-		// Note: the check is path-only — it does not distinguish HTTP methods. A POST
-		// with an empty body to a bodyless-indexed path would pass here. Method-aware
-		// validation requires the Option C StepContext refactor.
+		// The step layer strips the module base path before calling Validate, so
+		// reqURL.Path is of the form "/catalog/subscription". Remove the leading
+		// slash to match the index keys built in buildActionIndex.
+		// strings.TrimPrefix is used (not path.Base) so multi-segment compound
+		// paths are preserved verbatim (e.g. "catalog/subscription").
+		// Note: the check is path-only — it does not distinguish HTTP methods. A
+		// POST with an empty body to a bodyless-indexed path would pass here.
+		// Method-aware validation is tracked in issue #740.
 		key := strings.TrimPrefix(reqURL.Path, "/")
 		if _, ok := spec.bodylessActions[key]; !ok {
 			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", key))

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -101,10 +101,12 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 }
 
 // Validate validates the given data against the OpenAPI schema.
+// reqURL carries the Beckn endpoint action in its Path field, already stripped
+// of the module base path by the step layer (e.g. "catalog/subscription").
 // When the request body is empty (GET/DELETE) it performs an O(1) lookup in
-// the pre-built bodylessActions index to confirm the path is a known bodyless
-// endpoint, then returns without body schema validation. For body-bearing
-// requests it validates the JSON payload against the indexed action schema.
+// the pre-built bodylessActions index using reqURL.Path as the key.
+// For body-bearing requests the action is extracted from the JSON payload
+// and reqURL is not used.
 func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data []byte) error {
 	if len(data) == 0 {
 		if reqURL == nil {
@@ -119,20 +121,17 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 		}
 
-		// The step layer strips the module base path before calling Validate, so
-		// reqURL.Path is of the form "/catalog/subscription". Remove the leading
-		// slash to match the index keys built in buildActionIndex.
-		// strings.TrimPrefix is used (not path.Base) so multi-segment compound
-		// paths are preserved verbatim (e.g. "catalog/subscription").
-		// Note: the check is path-only — it does not distinguish HTTP methods. A
-		// POST with an empty body to a bodyless-indexed path would pass here.
+		// reqURL.Path is the clean endpoint action (e.g. "catalog/subscription"),
+		// matching the keys built in buildActionIndex. No further stripping needed.
+		// Note: the check is path-only — it does not distinguish HTTP methods. A POST
+		// with an empty body to a bodyless-indexed path would pass here.
 		// Method-aware validation is tracked in issue #740.
-		key := strings.TrimPrefix(reqURL.Path, "/")
-		if _, ok := spec.bodylessActions[key]; !ok {
-			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", key))
+		action := reqURL.Path
+		if _, ok := spec.bodylessActions[action]; !ok {
+			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", action))
 		}
 
-		log.Debugf(ctx, "bodyless request to %s: skipping body schema validation", reqURL.Path)
+		log.Debugf(ctx, "bodyless request to %s: skipping body schema validation", action)
 		return nil
 	}
 
@@ -410,7 +409,7 @@ func (v *schemav2Validator) buildActionIndex(ctx context.Context, doc *openapi3.
 		// A separate loop (rather than sharing pass 1) keeps the two indexing concerns
 		// independent and avoids complicating the guard logic for body-bearing ops.
 		// Key is the spec path without its leading slash so it matches
-		// strings.TrimPrefix(reqURL.Path, "/") in Validate's bodyless branch.
+		// the endpointAction passed to Validate's bodyless branch.
 		for _, op := range []*openapi3.Operation{item.Get, item.Delete} {
 			if op == nil || op.RequestBody != nil {
 				continue

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -211,6 +211,7 @@ func TestValidate_ActionExtraction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// endpointAction is not used for body-bearing requests; pass "" for clarity.
 			err := validator.Validate(context.Background(), nil, []byte(tt.payload))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
@@ -263,9 +264,9 @@ func TestValidate_NestedValidation(t *testing.T) {
 }
 
 // TestValidate_BodylessRequest covers GET/DELETE requests (Beckn 2.0
-// catalog/subscription verbs) that carry no body. Validate() detects
-// len(data)==0, looks up the path in the pre-built bodylessActions index,
-// and either passes (known bodyless endpoint) or rejects (unknown/body-only).
+// catalog/subscription verbs) that carry no body. The step layer has already
+// stripped the module base path and extracted the action string before calling
+// Validate, so endpointAction is a clean key like "catalog/subscription".
 func TestValidate_BodylessRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(testSpecBodyless))
@@ -277,73 +278,53 @@ func TestValidate_BodylessRequest(t *testing.T) {
 		t.Fatalf("Failed to create validator: %v", err)
 	}
 
-	mustURL := func(raw string) *url.URL {
-		u, err := url.Parse(raw)
-		if err != nil {
-			t.Fatalf("url.Parse(%q): %v", raw, err)
-		}
-		return u
-	}
-
-	// NOTE: bodylessActions is keyed by path only — it does not distinguish HTTP
-	// methods. GET, DELETE, and even an empty-body POST to the same path all resolve
-	// to the same map key. Method-aware validation requires the Option C StepContext
-	// refactor. The "known limitation" case below documents this current behaviour.
+	// NOTE: bodylessActions is keyed by endpoint action only — it does not
+	// distinguish HTTP methods. GET, DELETE, and even an empty-body POST with the
+	// same action all resolve to the same map key.
 	tests := []struct {
 		name    string
-		path    string
-		nilURL  bool // pass nil *url.URL instead of parsing path
+		urlPath string // set to "" to pass nil URL
 		wantErr bool
 		errMsg  string
 	}{
 		{
-			// Multi-segment path with GET — indexed in bodylessActions, must pass.
-			name:    "GET /catalog/subscription — empty body passes",
-			path:    "/catalog/subscription",
+			// Multi-segment action — indexed in bodylessActions, must pass.
+			name:    "GET catalog/subscription — empty body passes",
+			urlPath: "catalog/subscription",
 			wantErr: false,
 		},
 		{
-			// Same path, DELETE is also indexed as bodyless (path-only key, no
-			// method distinction at this layer).
-			name:    "DELETE /catalog/subscription — empty body passes",
-			path:    "/catalog/subscription",
+			// DELETE on the same action — same key, passes for the same reason.
+			name:    "DELETE catalog/subscription — empty body passes",
+			urlPath: "catalog/subscription",
 			wantErr: false,
 		},
 		{
-			// Known limitation (Option A): bodylessActions is path-only. An empty-body
-			// POST to a bodyless-indexed path passes through without body validation.
-			// This will become wantErr:true once the Option C StepContext refactor lands.
-			name:    "empty-body POST to bodyless-indexed path passes (known limitation)",
-			path:    "/catalog/subscription",
+			// Known limitation: bodylessActions is method-agnostic. An empty-body POST
+			// with a bodyless-indexed action passes without body validation.
+			name:    "empty-body POST to bodyless-indexed action passes (known limitation)",
+			urlPath: "catalog/subscription",
 			wantErr: false,
 		},
 		{
-			// Query string must not pollute the path key — reqURL.Path strips RawQuery,
-			// so /catalog/subscription?subscriptionId=abc resolves to the same map key
-			// as /catalog/subscription and must pass.
-			name:    "GET with query string — query params do not affect path match",
-			path:    "/catalog/subscription?subscriptionId=abc-123",
-			wantErr: false,
-		},
-		{
-			// nil reqURL with empty body must return an error, not panic.
-			// Guards the reqURL == nil check added in the self-review.
+			// Nil URL with empty body must return an error.
+			// The step layer passes nil when ctx.Request.URL is nil.
 			name:    "nil URL with empty body returns error",
-			nilURL:  true,
+			urlPath: "",
 			wantErr: true,
 			errMsg:  "request URL is required for bodyless validation",
 		},
 		{
 			// /search only has a POST with requestBody — not in bodylessActions.
-			name:    "POST-only endpoint /search with empty body is rejected",
-			path:    "/search",
+			name:    "POST-only endpoint search with empty body is rejected",
+			urlPath: "search",
 			wantErr: true,
 			errMsg:  "unsupported bodyless request for endpoint: search",
 		},
 		{
-			// Path absent from spec entirely.
-			name:    "unknown endpoint /nonsense with empty body is rejected",
-			path:    "/nonsense",
+			// Action absent from spec entirely.
+			name:    "unknown action nonsense with empty body is rejected",
+			urlPath: "nonsense",
 			wantErr: true,
 			errMsg:  "unsupported bodyless request for endpoint: nonsense",
 		},
@@ -352,8 +333,8 @@ func TestValidate_BodylessRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var reqURL *url.URL
-			if !tt.nilURL {
-				reqURL = mustURL(tt.path)
+			if tt.urlPath != "" {
+				reqURL = &url.URL{Path: tt.urlPath}
 			}
 			err := validator.Validate(context.Background(), reqURL, []byte{})
 			if (err != nil) != tt.wantErr {

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +53,9 @@ func New(ctx context.Context, config *Config) (*schemaValidator, func() error, e
 }
 
 // Validate validates the given data against the schema.
-func (v *schemaValidator) Validate(ctx context.Context, url *url.URL, data []byte) error {
+// reqURL.Path holds the Beckn endpoint action already stripped of the module
+// base path by the step layer (e.g. "search") — no leading slash.
+func (v *schemaValidator) Validate(ctx context.Context, reqURL *url.URL, data []byte) error {
 	var payloadData payload
 	err := json.Unmarshal(data, &payloadData)
 	if err != nil {
@@ -68,12 +69,12 @@ func (v *schemaValidator) Validate(ctx context.Context, url *url.URL, data []byt
 		return model.NewBadReqErr(fmt.Errorf("missing field Version in context"))
 	}
 
-	// Extract domain, version, and endpoint from the payload and uri.
+	// Extract domain and version from the payload; use reqURL.Path as the endpoint action.
 	cxtDomain := payloadData.Context.Domain
 	version := payloadData.Context.Version
 	version = fmt.Sprintf("v%s", version)
 
-	endpoint := path.Base(url.String())
+	endpoint := reqURL.Path
 	log.Debugf(ctx, "Handling request for endpoint: %s", endpoint)
 	domain := strings.ToLower(cxtDomain)
 	domain = strings.ReplaceAll(domain, ":", "_")

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
@@ -54,16 +54,16 @@ func setupTestSchema(t *testing.T) string {
 
 func TestValidator_Validate_Success(t *testing.T) {
 	tests := []struct {
-		name    string
-		url     string
-		payload string
-		wantErr bool
+		name           string
+		endpointAction string
+		payload        string
+		wantErr        bool
 	}{
 		{
-			name:    "Valid payload",
-			url:     "http://example.com/endpoint",
-			payload: `{"context": {"domain": "example", "version": "1.0", "action": "endpoint"}}`,
-			wantErr: false,
+			name:           "Valid payload",
+			endpointAction: "endpoint",
+			payload:        `{"context": {"domain": "example", "version": "1.0", "action": "endpoint"}}`,
+			wantErr:        false,
 		},
 	}
 
@@ -79,8 +79,7 @@ func TestValidator_Validate_Success(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u, _ := url.Parse(tt.url)
-			err := v.Validate(context.Background(), u, []byte(tt.payload))
+			err := v.Validate(context.Background(), &url.URL{Path: tt.endpointAction}, []byte(tt.payload))
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			} else {
@@ -92,28 +91,28 @@ func TestValidator_Validate_Success(t *testing.T) {
 
 func TestValidator_Validate_Failure(t *testing.T) {
 	tests := []struct {
-		name    string
-		url     string
-		payload string
-		wantErr string
+		name           string
+		endpointAction string
+		payload        string
+		wantErr        string
 	}{
 		{
-			name:    "Invalid JSON payload",
-			url:     "http://example.com/endpoint",
-			payload: `{"context": {"domain": "example", "version": "1.0"`,
-			wantErr: "failed to parse JSON payload",
+			name:           "Invalid JSON payload",
+			endpointAction: "endpoint",
+			payload:        `{"context": {"domain": "example", "version": "1.0"`,
+			wantErr:        "failed to parse JSON payload",
 		},
 		{
-			name:    "Schema validation failure",
-			url:     "http://example.com/endpoint",
-			payload: `{"context": {"domain": "example", "version": "1.0"}}`,
-			wantErr: "context: at '/context': missing property 'action'",
+			name:           "Schema validation failure",
+			endpointAction: "endpoint",
+			payload:        `{"context": {"domain": "example", "version": "1.0"}}`,
+			wantErr:        "context: at '/context': missing property 'action'",
 		},
 		{
-			name:    "Schema not found",
-			url:     "http://example.com/unknown_endpoint",
-			payload: `{"context": {"domain": "example", "version": "1.0"}}`,
-			wantErr: "schema not found for domain",
+			name:           "Schema not found",
+			endpointAction: "unknown_endpoint",
+			payload:        `{"context": {"domain": "example", "version": "1.0"}}`,
+			wantErr:        "schema not found for domain",
 		},
 	}
 
@@ -129,8 +128,7 @@ func TestValidator_Validate_Failure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u, _ := url.Parse(tt.url)
-			err := v.Validate(context.Background(), u, []byte(tt.payload))
+			err := v.Validate(context.Background(), &url.URL{Path: tt.endpointAction}, []byte(tt.payload))
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Errorf("Expected error containing '%s', but got nil", tt.wantErr)


### PR DESCRIPTION
## Summary

- **Root cause:** The module mount prefix (e.g. \`/bap/receiver/\`) was never stripped from the incoming URL before plugins saw it. Both \`schemav2validator\` and \`router\` extracted actions from the raw path, so compound paths like \`catalog/subscription\` never matched their internal indexes.
- **Fix:** Move base-path stripping into the step layer (\`validateSchemaStep\` and \`addRouteStep\`). \`stripBasePath()\` returns a shallow \`*url.URL\` copy whose \`.Path\` is the clean endpoint action (e.g. \`catalog/subscription\`) with no leading slash — plugins use \`.Path\` directly, no further \`TrimPrefix\` needed.
- **Router cleanup:** Removes the \`Config.BasePath\` / \`Router.basePath\` workaround added in #743 that was never wired through \`cmd/plugin.go\` and was dead in production.

## Changes

| File | Change |
|---|---|
| \`core/module/handler/config.go\` | Add \`BasePath string\` (set from module path) |
| \`core/module/module.go\` | Thread \`module.Config.Path\` → \`handler.Config.BasePath\` |
| \`core/module/handler/stdHandler.go\` | Store \`basePath\`, pass to step constructors |
| \`core/module/handler/step.go\` | \`stripBasePath()\` returns \`*url.URL\` with clean \`.Path\`; both steps pass it to plugins |
| \`pkg/plugin/implementation/router/router.go\` | Remove \`Config.BasePath\`; \`Route\` uses \`reqURL.Path\` directly |
| \`pkg/plugin/implementation/schemav2validator/schemav2validator.go\` | \`Validate\` uses \`reqURL.Path\` for bodyless lookup; nil URL guard |
| \`pkg/plugin/implementation/schemavalidator/schemavalidator.go\` | \`Validate\` uses \`reqURL.Path\` directly |
| \`core/module/handler/step_test.go\` | \`TestStripBasePath_*\` unit tests; wiring tests assert \`.Path\` on recorded \`*url.URL\` |
| \`pkg/plugin/implementation/router/router_test.go\` | \`Route\` calls pass \`&url.URL{Path: action}\` |
| \`pkg/plugin/implementation/schemav2validator/schemav2validator_test.go\` | Bodyless tests pass \`&url.URL{Path: action}\` or \`nil\` |
| \`pkg/plugin/implementation/schemavalidator/schemavalidator_test.go\` | \`Validate\` calls pass \`&url.URL{Path: action}\` |

## Test plan

- [x] \`go test ./core/...\` — all pass
- [x] \`go test ./pkg/plugin/implementation/router/...\` — all pass including \`TestRouteCompoundEndpointSuccess\` and \`TestRouteBodyless\`
- [x] \`go test ./pkg/plugin/implementation/schemav2validator/...\` — all pass
- [x] \`go test ./pkg/plugin/implementation/schemavalidator/...\` — all pass
- [x] Full suite \`go test ./...\` (excl. plugin cmd) — all pass

## Notes

- **Plugin interfaces unchanged:** \`SchemaValidator.Validate\` and \`Router.Route\` signatures remain \`(ctx, reqURL *url.URL, ...)\`. The contract clarification is that \`reqURL.Path\` now carries the clean endpoint action rather than the raw mount-prefixed path.
- OPA \`extractActionFromPath\` has a related compound-path bug — not in scope here, tracked separately.

Fixes #742, fixes #741