### PR TITLE
fix(schemav2validator): reject empty-body POST before schema validation

### DIFF
--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -397,9 +398,14 @@ func newValidateSchemaStep(schemaValidator definition.SchemaValidator, basePath 
 
 // Run executes the schema validation step.
 func (s *validateSchemaStep) Run(ctx *model.StepContext) error {
-	err := s.validator.Validate(ctx, stripBasePath(ctx.Request.URL, s.basePath), ctx.Body)
-	if err != nil {
-		err = fmt.Errorf("schema validation failed: %w", err)
+	var err error
+	if len(ctx.Body) == 0 && ctx.Request.Method == http.MethodPost {
+		err = fmt.Errorf("schema validation failed: %w", model.NewBadReqErr(fmt.Errorf("POST request requires a body")))
+	} else {
+		err = s.validator.Validate(ctx, stripBasePath(ctx.Request.URL, s.basePath), ctx.Body)
+		if err != nil {
+			err = fmt.Errorf("schema validation failed: %w", err)
+		}
 	}
 	s.recordMetrics(ctx, err)
 	return err

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -595,6 +595,24 @@ func TestValidateSchemaStep_Run_NoBasePath_UsesRawAction(t *testing.T) {
 	}
 }
 
+func TestValidateSchemaStep_Run_EmptyBodyPost_ReturnsError(t *testing.T) {
+	mv := &mockRecordingValidator{}
+	step, _ := newValidateSchemaStep(mv, "")
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost/catalog/subscription", nil)
+	ctx := &model.StepContext{
+		Context:    context.Background(),
+		Request:    req,
+		Body:       []byte{},
+		RespHeader: http.Header{},
+	}
+	if err := step.Run(ctx); err == nil {
+		t.Fatal("expected error for empty-body POST, got nil")
+	}
+	if mv.gotURL != nil {
+		t.Error("Validate should not have been called for empty-body POST")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // addRouteStep constructor + stripBasePath wiring tests
 // ---------------------------------------------------------------------------

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -605,8 +605,13 @@ func TestValidateSchemaStep_Run_EmptyBodyPost_ReturnsError(t *testing.T) {
 		Body:       []byte{},
 		RespHeader: http.Header{},
 	}
-	if err := step.Run(ctx); err == nil {
+	err := step.Run(ctx)
+	if err == nil {
 		t.Fatal("expected error for empty-body POST, got nil")
+	}
+	var badReq *model.BadReqErr
+	if !errors.As(err, &badReq) {
+		t.Errorf("expected BadReqErr, got %T: %v", err, err)
 	}
 	if mv.gotURL != nil {
 		t.Error("Validate should not have been called for empty-body POST")

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -123,9 +123,8 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 
 		// reqURL.Path is the clean endpoint action (e.g. "catalog/subscription"),
 		// matching the keys built in buildActionIndex. No further stripping needed.
-		// Note: the check is path-only — it does not distinguish HTTP methods. A POST
-		// with an empty body to a bodyless-indexed path would pass here.
-		// Method-aware validation is tracked in issue #740.
+		// Empty-body POST requests are rejected upstream by validateSchemaStep before
+		// reaching here, so only GET/DELETE arrive at this branch.
 		action := reqURL.Path
 		if _, ok := spec.bodylessActions[action]; !ok {
 			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", action))

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -278,9 +278,6 @@ func TestValidate_BodylessRequest(t *testing.T) {
 		t.Fatalf("Failed to create validator: %v", err)
 	}
 
-	// NOTE: bodylessActions is keyed by endpoint action only — it does not
-	// distinguish HTTP methods. GET, DELETE, and even an empty-body POST with the
-	// same action all resolve to the same map key.
 	tests := []struct {
 		name    string
 		urlPath string // set to "" to pass nil URL
@@ -300,9 +297,9 @@ func TestValidate_BodylessRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Known limitation: bodylessActions is method-agnostic. An empty-body POST
-			// with a bodyless-indexed action passes without body validation.
-			name:    "empty-body POST to bodyless-indexed action passes (known limitation)",
+			// The plugin itself is method-agnostic; empty-body POST rejection is
+			// enforced upstream by validateSchemaStep before Validate is called.
+			name:    "empty-body POST to bodyless-indexed action passes — method enforcement is upstream",
 			urlPath: "catalog/subscription",
 			wantErr: false,
 		},


### PR DESCRIPTION
## Summary

- Adds a method guard in `validateSchemaStep.Run`: a POST request with no body is rejected with a 400 `BadReqErr` before `Validate` is ever called
- Closes the known limitation in `schemav2validator` where an empty-body POST to a bodyless-indexed path (e.g. `/catalog/subscription`) bypassed body schema validation
- All `SchemaValidator` plugin implementations benefit automatically — no interface change, no context injection, no model change

## Approach

The HTTP method is available on `ctx.Request` in the step layer. Rather than threading it into the plugin via interface changes or `context.WithValue`, the step enforces the HTTP invariant ("POST requires a body") upstream. The plugin remains method-agnostic by design.

Checked against the Beckn 2.0.0 spec (`api/v2.0.0/beckn.yaml`): `/catalog/subscription` is the only path with both a bodyless GET/DELETE and a body-bearing POST — confirming the fix targets a real spec case.

## Test plan

- [ ] `TestValidateSchemaStep_Run_EmptyBodyPost_ReturnsError` — empty-body POST returns error; validator mock not called
- [ ] Existing `TestValidateSchemaStep_Run_ExtractsAction` and `TestValidateSchemaStep_Run_NoBasePath_UsesRawAction` still pass
- [ ] `TestValidate_BodylessRequest` in `schemav2validator` — all cases pass; known-limitation label removed

Closes #740