### PR TITLE
fix(opapolicychecker): remove actions allowlist and extractActionFromPath

### DIFF
--- a/pkg/plugin/implementation/opapolicychecker/README.md
+++ b/pkg/plugin/implementation/opapolicychecker/README.md
@@ -59,14 +59,11 @@ Both teams share a single configuration contract: the **network policy config fi
          │     │    → skip evaluation (allow)          │    │
          │     └──────────────────────────────────────┘    │
          │           │                                      │
-         │  ③ Check action filter (if actions: set)        │
-         │     not in list? → skip evaluation (allow)      │
-         │           │                                      │
-         │  ④ Evaluate OPA query                           │
+         │  ③ Evaluate OPA query                           │
          │     input        = full Beckn message body       │
          │     data.config  = adapter plugin config keys    │
          │           │                                      │
-         │  ⑤ Interpret result                             │
+         │  ④ Interpret result                             │
          │     {"valid": true,  "violations": []}  → allow │
          │     {"valid": false, "violations": […]} → 400   │
          │     empty / undefined result            → 400   │
@@ -97,7 +94,7 @@ If the OPA query returns an undefined or empty result, the plugin treats it as a
 
 `opapolicychecker` is a module-level plugin compiled as a `.so` and loaded by the plugin manager. It runs as one step in a module's `steps` list alongside the schema validator, signer, and router. The plugin ID (`opapolicychecker`, used in `id:`) and the step name (`checkPolicy`, used in `steps:` and as the YAML config key) are distinct — both must appear in the module config.
 
-> **Migrating from an older config format.** Previous versions accepted top-level keys such as `type`, `location`, `query`, `actions`, and `refreshIntervalSeconds` directly in the plugin config. These keys are no longer used as plugin parameters — unrecognised keys are forwarded to Rego as `data.config.<key>` rather than silently dropped, so leftover keys from the old format will appear as Rego data values instead of configuring the plugin.
+> **Migrating from an older config format.** Previous versions accepted top-level keys such as `type`, `location`, `query`, and `refreshIntervalSeconds` directly in the plugin config. These keys are no longer used as plugin parameters — unrecognised keys are forwarded to Rego as `data.config.<key>` rather than silently dropped, so leftover keys from the old format will appear as Rego data values instead of configuring the plugin.
 
 ```yaml
 manifestLoader:
@@ -176,7 +173,6 @@ networkPolicies:
 | `type` | string | Yes | — | `file`, `bundle`, `dir`, or `manifest` |
 | `location` | string | Yes (except `manifest`) | — | Local path or remote URL for the policy source |
 | `query` | string | Yes (except `manifest`) | — | OPA query path that returns the policy result |
-| `actions` | string | No | — | Comma-separated list of actions; if set, skip evaluation for actions not in this list |
 | `enabled` | bool | No | `true` | Set to `false` to skip this network while keeping it in config |
 | `fetchTimeoutSeconds` | string | No | `"30"` | Timeout for fetching remote policy sources |
 | `verification.enabled` | bool | No | `false` | Enable signature verification for `file` or `bundle` |
@@ -324,18 +320,6 @@ allowed_domains := {"ONDC:RET10", "ONDC:RET11", "ONDC:RET12"}
 violations contains "domain not allowed" if {
     not allowed_domains[input.context.domain]
 }
-```
-
-### Limit evaluation to specific actions (config-level)
-
-If your policy only makes sense for `confirm` and `init`, set `actions` in the network policy config rather than adding action guards to every rule:
-
-```yaml
-my.network/production:
-  type: file
-  location: ./policies/confirm-init.rego
-  query: "data.policy.result"
-  actions: confirm,init
 ```
 
 ### Skip a specific network without removing it from config
@@ -930,9 +914,9 @@ query: "data.policy.result"     # ✗ wrong if package is mypolicy
 
 **Symptom:** The policy rejects `search` requests that should not be affected.
 
-**Cause:** The `actions:` filter is not set, so the policy evaluates for every action.
+**Cause:** The policy evaluates for every action. Use explicit action guards in the Rego rules to limit which actions a rule fires on.
 
-**Fix:** Either set `actions:` in the network policy config to limit evaluation, or add explicit action guards in the Rego rules:
+**Fix:** Add action guards directly in the Rego rules:
 
 ```rego
 violations contains "confirm: missing provider" if {

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -30,7 +30,6 @@ type PolicyConfig struct {
 	Location      string
 	PolicyPaths   []string
 	Query         string
-	Actions       []string
 	Enabled       bool
 	FetchTimeout  time.Duration
 	IsBundle      bool
@@ -59,7 +58,6 @@ var policyEntryKnownKeys = map[string]bool{
 	"type":                            true,
 	"location":                        true,
 	"query":                           true,
-	"actions":                         true,
 	"enabled":                         true,
 	"fetchTimeoutSeconds":             true,
 	"verification.enabled":            true,
@@ -168,16 +166,6 @@ func parsePolicyConfig(cfg map[string]string) (*PolicyConfig, error) {
 		return nil, fmt.Errorf("'query' must not be set for type=%s", policyTypeManifest)
 	}
 
-	if actions, ok := cfg["actions"]; ok && actions != "" {
-		actionList := strings.Split(actions, ",")
-		config.Actions = make([]string, 0, len(actionList))
-		for _, action := range actionList {
-			action = strings.TrimSpace(action)
-			if action != "" {
-				config.Actions = append(config.Actions, action)
-			}
-		}
-	}
 
 	if enabled, ok := cfg["enabled"]; ok {
 		config.Enabled = enabled == "true" || enabled == "1"
@@ -238,17 +226,6 @@ func parsePolicyConfig(cfg map[string]string) (*PolicyConfig, error) {
 	return config, nil
 }
 
-func (c *PolicyConfig) IsActionEnabled(action string) bool {
-	if len(c.Actions) == 0 {
-		return true
-	}
-	for _, a := range c.Actions {
-		if a == action {
-			return true
-		}
-	}
-	return false
-}
 
 type loadedPolicy struct {
 	name                   string
@@ -532,36 +509,33 @@ func logLoadedPolicy(ctx context.Context, networkScoped bool, policy *loadedPoli
 			if policy.manifestDeclaredSigned != nil {
 				manifestSigned = strconv.FormatBool(*policy.manifestDeclaredSigned)
 			}
-			log.Infof(ctx, "OPAPolicyChecker: loaded network policy networkID=%q sourceType=manifest resolvedType=%s manifestSigned=%s manifestVerified=%t location=%s query=%s actions=%v enabled=%t modules=%v",
+			log.Infof(ctx, "OPAPolicyChecker: loaded network policy networkID=%q sourceType=manifest resolvedType=%s manifestSigned=%s manifestVerified=%t location=%s query=%s enabled=%t modules=%v",
 				policy.name,
 				policy.config.Type,
 				manifestSigned,
 				policy.manifestVerified,
 				policy.config.Location,
 				policy.config.Query,
-				policy.config.Actions,
 				policy.config.Enabled,
 				moduleNames,
 			)
 			return
 		}
-		log.Infof(ctx, "OPAPolicyChecker: loaded network policy networkID=%q type=%s location=%s query=%s actions=%v enabled=%t modules=%v",
+		log.Infof(ctx, "OPAPolicyChecker: loaded network policy networkID=%q type=%s location=%s query=%s enabled=%t modules=%v",
 			policy.name,
 			policy.config.Type,
 			policy.config.Location,
 			policy.config.Query,
-			policy.config.Actions,
 			policy.config.Enabled,
 			moduleNames,
 		)
 		return
 	}
 
-	log.Infof(ctx, "OPAPolicyChecker: loaded default policy type=%s location=%s query=%s actions=%v enabled=%t modules=%v",
+	log.Infof(ctx, "OPAPolicyChecker: loaded default policy type=%s location=%s query=%s enabled=%t modules=%v",
 		policy.config.Type,
 		policy.config.Location,
 		policy.config.Query,
-		policy.config.Actions,
 		policy.config.Enabled,
 		moduleNames,
 	)
@@ -684,18 +658,6 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	}
 	policyConfig := policy.config
 
-	action := extractActionFromPath(ctx.Request.URL.Path)
-	if action == "" {
-		action = reqCtx.Action
-	}
-
-	if !policyConfig.IsActionEnabled(action) {
-		if e.config.DebugLogging {
-			log.Debugf(ctx, "OPAPolicyChecker: action %q not in configured actions %v, skipping", action, policyConfig.Actions)
-		}
-		return nil
-	}
-
 	if !policyConfig.Enabled {
 		log.Debug(ctx, "OPAPolicyChecker: selected policy is disabled, skipping")
 		return nil
@@ -708,7 +670,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	}
 
 	if e.config.DebugLogging {
-		log.Debugf(ctx, "OPAPolicyChecker: evaluating policy for networkID=%q action=%q (modules=%v)", reqCtx.NetworkID, action, ev.ModuleNames())
+		log.Debugf(ctx, "OPAPolicyChecker: evaluating policy for networkID=%q action=%q (modules=%v)", reqCtx.NetworkID, reqCtx.Action, ev.ModuleNames())
 	}
 
 	requestLogCtx := formatRequestLogContext(reqCtx)
@@ -721,7 +683,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 
 	if len(violations) == 0 {
 		if e.config.DebugLogging {
-			log.Debugf(ctx, "OPAPolicyChecker: message compliant for action %q", action)
+			log.Debugf(ctx, "OPAPolicyChecker: message compliant for action %q", reqCtx.Action)
 		}
 		return nil
 	}
@@ -776,15 +738,6 @@ func parseRequestContext(body []byte) parsedRequestContext {
 	}
 }
 
-func extractActionFromPath(urlPath string) string {
-	// /bpp/caller/confirm/extra as action "extra".
-	parts := strings.FieldsFunc(strings.Trim(urlPath, "/"), func(r rune) bool { return r == '/' })
-	if len(parts) == 3 && isBecknDirection(parts[1]) && parts[2] != "" {
-		return parts[2]
-	}
-	return ""
-}
-
 func formatRequestLogContext(ctx parsedRequestContext) string {
 	parts := make([]string, 0, 6)
 	if ctx.BAPID != "" {
@@ -811,11 +764,3 @@ func formatRequestLogContext(ctx parsedRequestContext) string {
 	return " " + strings.Join(parts, " ")
 }
 
-func isBecknDirection(part string) bool {
-	switch part {
-	case "caller", "receiver", "reciever":
-		return true
-	default:
-		return false
-	}
-}

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -167,26 +167,6 @@ func TestParsePolicyConfig_RuntimeConfigForwarding(t *testing.T) {
 	}
 }
 
-func TestParsePolicyConfig_CustomActions(t *testing.T) {
-	cfg, err := parsePolicyConfig(map[string]string{
-		"type":     "dir",
-		"location": "/tmp",
-		"query":    "data.policy.violations",
-		"actions":  "confirm, select, init",
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(cfg.Actions) != 3 {
-		t.Fatalf("expected 3 actions, got %d: %v", len(cfg.Actions), cfg.Actions)
-	}
-	expected := []string{"confirm", "select", "init"}
-	for i, want := range expected {
-		if cfg.Actions[i] != want {
-			t.Errorf("action[%d] = %q, want %q", i, cfg.Actions[i], want)
-		}
-	}
-}
 
 func TestParsePolicyConfig_PolicyPaths(t *testing.T) {
 	cfg, err := parsePolicyConfig(map[string]string{
@@ -207,8 +187,7 @@ func TestParsePolicyConfig_PolicyPaths(t *testing.T) {
 
 func TestParsePolicyConfig_ManifestType(t *testing.T) {
 	cfg, err := parsePolicyConfig(map[string]string{
-		"type":    "manifest",
-		"actions": "confirm",
+		"type": "manifest",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -651,7 +630,7 @@ violations contains "blocked" if { input.context.action == "confirm"; input.bloc
 `
 	dir := writePolicyDir(t, "test.rego", policy)
 
-	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\nactions: confirm\n")
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
 	enforcer, err := New(context.Background(), map[string]string{
 		"networkPolicyConfig": configPath,
 	})
@@ -674,7 +653,7 @@ violations contains "blocked" if { input.context.action == "confirm" }
 `
 	dir := writePolicyDir(t, "test.rego", policy)
 
-	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\nactions: confirm\n")
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
 	enforcer, err := New(context.Background(), map[string]string{
 		"networkPolicyConfig": configPath,
 	})
@@ -691,30 +670,6 @@ violations contains "blocked" if { input.context.action == "confirm" }
 	// Should be a BadReqErr
 	if _, ok := err.(*model.BadReqErr); !ok {
 		t.Errorf("expected *model.BadReqErr, got %T: %v", err, err)
-	}
-}
-
-func TestEnforcer_SkipsNonMatchingAction(t *testing.T) {
-	policy := `
-package policy
-import rego.v1
-violations contains "blocked" if { true }
-`
-	dir := writePolicyDir(t, "test.rego", policy)
-
-	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\nactions: confirm\n")
-	enforcer, err := New(context.Background(), map[string]string{
-		"networkPolicyConfig": configPath,
-	})
-	if err != nil {
-		t.Fatalf("New failed: %v", err)
-	}
-
-	// Non-compliant body, but action is "search" — not in configured actions
-	ctx := makeStepCtx("search", `{"context": {"action": "search"}}`)
-	err = enforcer.CheckPolicy(ctx)
-	if err != nil {
-		t.Errorf("expected nil for non-matching action, got: %v", err)
 	}
 }
 
@@ -741,6 +696,29 @@ violations contains "blocked" if { true }
 	}
 }
 
+func TestEnforcer_CompoundActionNotFiltered(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains "blocked" if { input.context.action == "catalog/subscription" }
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("catalog/subscription", `{"context": {"action": "catalog/subscription"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if _, ok := err.(*model.BadReqErr); !ok {
+		t.Fatalf("expected BadReqErr for compound action violation, got %T: %v", err, err)
+	}
+}
+
 // --- Enforcer with URL-sourced policy ---
 
 func TestEnforcer_PolicyFromURL(t *testing.T) {
@@ -754,7 +732,7 @@ violations contains "blocked" if { input.context.action == "confirm" }
 	}))
 	defer srv.Close()
 
-	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: file\nlocation: "+srv.URL+"/block_confirm.rego\nquery: data.policy.violations\nactions: confirm\n")
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: file\nlocation: "+srv.URL+"/block_confirm.rego\nquery: data.policy.violations\n")
 	enforcer, err := New(context.Background(), map[string]string{
 		"networkPolicyConfig": configPath,
 	})
@@ -773,13 +751,6 @@ violations contains "blocked" if { input.context.action == "confirm" }
 }
 
 // --- Request Context Parsing Tests ---
-
-func TestExtractActionFromPath_FromURL(t *testing.T) {
-	action := extractActionFromPath("/bpp/caller/confirm")
-	if action != "confirm" {
-		t.Errorf("expected 'confirm', got %q", action)
-	}
-}
 
 func TestParseRequestContext(t *testing.T) {
 	reqCtx := parseRequestContext([]byte(`{"context":{"action":"select","networkId":"retail.network/production","bap_id":"bap.example.com","bppId":"bpp.example.com","message_id":"msg-1","transactionId":"txn-1","timestamp":"2026-04-21T10:00:00Z"}}`))
@@ -1478,7 +1449,7 @@ violations contains "blocked" if {
 	}))
 	defer srv.Close()
 
-	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: bundle\nlocation: "+srv.URL+"/policy-bundle.tar.gz\nquery: data.retail.policy.result\nactions: confirm\n")
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: bundle\nlocation: "+srv.URL+"/policy-bundle.tar.gz\nquery: data.retail.policy.result\n")
 	enforcer, err := New(context.Background(), map[string]string{
 		"networkPolicyConfig": configPath,
 	})
@@ -1616,12 +1587,10 @@ networkPolicies:
     type: dir
     location: `+retailDir+`
     query: data.retail.result
-    actions: confirm
   retail.network/logistics:
     type: dir
     location: `+logisticsDir+`
     query: data.logistics.result
-    actions: confirm
 `)
 
 	enforcer, err := New(context.Background(), map[string]string{
@@ -1661,7 +1630,6 @@ networkPolicies:
     type: dir
     location: `+defaultDir+`
     query: data.policy.result
-    actions: confirm
 `)
 
 	enforcer, err := New(context.Background(), map[string]string{
@@ -1692,12 +1660,10 @@ networkPolicies:
     type: dir
     location: `+defaultDir+`
     query: data.policy.result
-    actions: confirm
   default:
     type: dir
     location: `+defaultDir+`
     query: data.policy.result
-    actions: confirm
 `)
 
 	enforcer, err := New(context.Background(), map[string]string{
@@ -1727,7 +1693,6 @@ networkPolicies:
     type: dir
     location: `+retailDir+`
     query: data.retail.result
-    actions: confirm
 `)
 
 	enforcer, err := New(context.Background(), map[string]string{
@@ -1798,17 +1763,6 @@ violations := []`))
 	}
 }
 
-func TestExtractAction_NonStandardURLFallsBackToBody(t *testing.T) {
-	reqCtx := parseRequestContext([]byte(`{"context": {"action": "confirm"}}`))
-	action := extractActionFromPath("/bpp/caller/confirm/extra")
-	if action == "" {
-		action = reqCtx.Action
-	}
-	if action != "confirm" {
-		t.Fatalf("expected body fallback action 'confirm', got %q", action)
-	}
-}
-
 func TestEnforcer_ManifestBackedFilePolicy(t *testing.T) {
 	policy := []byte(`
 package policy
@@ -1861,7 +1815,6 @@ result := {"valid": false, "violations": ["missing provider"]} if {
 networkPolicies:
   retail.network/production:
     type: manifest
-    actions: confirm
 `)
 	enforcer, err := NewWithManifestLoader(context.Background(), stubManifestLoader{
 		docs: map[string]*model.ManifestDocument{
@@ -1929,7 +1882,6 @@ result := {"valid": false, "violations": ["bundle blocked"]} if {
 networkPolicies:
   retail.network/production:
     type: manifest
-    actions: confirm
 `)
 	enforcer, err := NewWithManifestLoader(context.Background(), stubManifestLoader{
 		docs: map[string]*model.ManifestDocument{


### PR DESCRIPTION
Closes #748

### Problem

`extractActionFromPath` only handled 3-segment URL paths (`/<role>/<direction>/<action>`), returning `""` for compound actions like `catalog/subscription`. This caused the `IsActionEnabled` check to fall back to the body action — but more fundamentally, the `actions` allowlist itself is a security hole: an NP can omit any action from their local config to bypass NFO-mandated policy enforcement for that action entirely.

### Fix

Remove the `actions` config and the code that depends on it. OPA policy evaluation now runs for every action. Action-specific filtering belongs in Rego rules via `input.context.action` guards, not in the plugin config.

- Removed `Actions` field from `PolicyConfig` and its config parsing
- Removed `IsActionEnabled` method
- Removed `extractActionFromPath` and `isBecknDirection` (only existed to serve the allowlist)
- `CheckPolicy` no longer reads the URL path; action for debug logging comes from `reqCtx.Action` (request body)
- Updated log messages to drop `actions=` field
- Removed `actions:` from all test configs; removed tests for deleted behaviour
- Added `TestEnforcer_CompoundActionNotFiltered` to verify compound actions reach OPA evaluation
- Updated README: removed `actions` from config table, flowchart, recipe section, and troubleshooting entry
