### PR TITLE
fix(handler): use 4-line signing string for solicited callbacks (#752)

### DIFF
--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -441,13 +441,16 @@ func TestNack_1(t *testing.T) {
 
 // mockSigner satisfies definition.Signer for testing.
 type mockSigner struct {
+	signCalled    bool
 	signAckCalled bool
 	signAckErr    error
-	returnSig     string
+	returnSig     string // returned by SignAck
+	returnSignSig string // returned by Sign (default "")
 }
 
 func (m *mockSigner) Sign(_ context.Context, _ []byte, _ string, _, _ int64) (string, error) {
-	return "", nil
+	m.signCalled = true
+	return m.returnSignSig, nil
 }
 
 func (m *mockSigner) SignAck(_ context.Context, _ []byte, _ string, _ string, _, _ int64) (string, error) {

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -27,10 +27,10 @@ type signStep struct {
 }
 
 // newSignStep initializes and returns a new signing step.
-// payloadStore may be nil; when non-nil and the outgoing action is a callback
-// (prefixed with "on_"), signStep looks up the originating request's signature
-// in the store and includes it as request-signature="..." in the Authorization
-// header, enabling the peer to verify the solicited-callback chain (NFH-004 §6).
+// payloadStore may be nil; when non-nil and the outgoing action is a solicited
+// callback (prefixed with "on_"), signStep looks up the originating request's
+// signature and signs with SignAck (4-line signing string, NFH-004 §3.3),
+// cryptographically binding the callback to the CN's original request.
 func newSignStep(signer definition.Signer, km definition.KeyManager, payloadStore definition.PayloadStore) (definition.Step, error) {
 	if signer == nil {
 		return nil, fmt.Errorf("invalid config: Signer plugin not configured")
@@ -62,22 +62,28 @@ func (s *signStep) Run(ctx *model.StepContext) error {
 	}
 
 	{
+		// Look up the CN's original signature before signing so we can choose
+		// Sign (3-line) vs SignAck (4-line) based on whether this is a solicited
+		// callback (NFH-004 §3.3).
+		requestSig := s.lookupRequestSignature(ctx)
+
 		signerCtx, signerSpan := tracer.Start(ctx.Context, "sign")
 		createdAt := time.Now().Unix()
 		validTill := time.Now().Add(5 * time.Minute).Unix()
-		sign, err := s.signer.Sign(signerCtx, ctx.Body, keySet.SigningPrivate, createdAt, validTill)
+		var sign string
+		var err error
+		if requestSig != "" {
+			sign, err = s.signer.SignAck(signerCtx, ctx.Body, requestSig, keySet.SigningPrivate, createdAt, validTill)
+		} else {
+			sign, err = s.signer.Sign(signerCtx, ctx.Body, keySet.SigningPrivate, createdAt, validTill)
+		}
 		signerSpan.End()
 		if err != nil {
 			return fmt.Errorf("failed to sign request: %w", err)
 		}
 
-		// For solicited callbacks (action starts with "on_") look up the original
-		// request's signature in the store and include it as request-signature="..."
-		// so the receiving peer can verify the chain (NFH-004 §6).
-		requestSig := s.lookupRequestSignature(ctx)
-
 		authHeader := s.generateAuthHeader(ctx.SubID, keySet.UniqueKeyID, createdAt, validTill, sign, requestSig)
-		log.Debugf(ctx, "Signature generated: %v (request-signature included: %v)", sign, requestSig != "")
+		log.Debugf(ctx, "Signature generated: %v (4-line signing string: %v)", sign, requestSig != "")
 		header := model.AuthHeaderSubscriber
 		if ctx.Role == model.RoleGateway {
 			header = model.AuthHeaderGateway
@@ -114,9 +120,10 @@ func (s *signStep) lookupRequestSignature(ctx *model.StepContext) string {
 	return entry.Signature
 }
 
-// generateAuthHeader constructs the authorization header for the signed request.
-// When requestSig is non-empty (solicited callback path) it appends the
-// request-signature field and extends the headers coverage string accordingly.
+// generateAuthHeader constructs the Authorization header for the signed request.
+// When requestSig is non-empty (solicited callback path) it declares
+// "request-signature" in the headers list (NFH-004 §4); the value itself is
+// in the signing string, not as a separate header attribute.
 func (s *signStep) generateAuthHeader(subID, keyID string, createdAt, validTill int64, signature, requestSig string) string {
 	base := fmt.Sprintf(
 		"Signature keyId=\"%s|%s|ed25519\",algorithm=\"ed25519\",created=\"%d\",expires=\"%d\"",
@@ -124,8 +131,8 @@ func (s *signStep) generateAuthHeader(subID, keyID string, createdAt, validTill 
 	)
 	if requestSig != "" {
 		return base + fmt.Sprintf(
-			",headers=\"(created) (expires) digest request-signature\",signature=\"%s\",request-signature=\"%s\"",
-			signature, requestSig,
+			",headers=\"(created) (expires) digest request-signature\",signature=\"%s\"",
+			signature,
 		)
 	}
 	return base + fmt.Sprintf(",headers=\"(created) (expires) digest\",signature=\"%s\"", signature)
@@ -140,8 +147,9 @@ type validateSignStep struct {
 }
 
 // newValidateSignStep initializes and returns a new validate sign step.
-// payloadStore may be nil; when non-nil it enables solicited-callback
-// request-signature chain verification (NFH-004 §6, issue #679).
+// payloadStore may be nil; when non-nil and the incoming request is a solicited
+// callback (v2, headers declares "request-signature"), ValidateAck is used with
+// the stored outbound signature to verify the 4-line signing string (NFH-004 §3.3).
 func newValidateSignStep(signValidator definition.SignValidator, km definition.KeyManager, payloadStore definition.PayloadStore) (definition.Step, error) {
 	if signValidator == nil {
 		return nil, fmt.Errorf("invalid config: SignValidator plugin not configured")
@@ -175,11 +183,6 @@ func (s *validateSignStep) Run(ctx *model.StepContext) error {
 		MessageID:       ctx.MessageID,
 	}
 	err := s.validateHeaders(stepCtx)
-	if err == nil {
-		// For solicited callbacks (v2, headers includes "request-signature"),
-		// additionally verify the request-signature chain (NFH-004 §6).
-		err = s.validateRequestSignatureChain(stepCtx)
-	}
 	s.recordMetrics(stepCtx, err)
 	return err
 }
@@ -189,7 +192,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue := ctx.Request.Header.Get(model.AuthHeaderGateway)
 	if len(headerValue) != 0 {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
-		if err := s.validate(ctx, headerValue); err != nil {
+		if err := s.validate(ctx, headerValue, ""); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
 			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
 		}
@@ -201,15 +204,49 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("%s missing", model.UnaAuthorizedHeaderSubscriber))
 	}
-	if err := s.validate(ctx, headerValue); err != nil {
+	reqSig, err := s.lookupCallbackRequestSig(ctx, headerValue)
+	if err != nil {
+		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
+		return model.NewSignValidationErr(err)
+	}
+	if err := s.validate(ctx, headerValue, reqSig); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
 	}
 	return nil
 }
 
+// lookupCallbackRequestSig returns the stored CN outbound signature for solicited
+// callbacks so that validateHeaders can pass it to ValidateAck (4-line signing
+// string, NFH-004 §3.3). Returns "" when any of the following apply, degrading
+// to the standard 3-line Validate path:
+//   - payloadStore is nil (not configured)
+//   - protocol version < 2.0.0
+//   - "request-signature" absent from the Authorization headers attribute (provider-initiated)
+//   - action cannot be extracted from the body
+func (s *validateSignStep) lookupCallbackRequestSig(ctx *model.StepContext, authHeader string) (string, error) {
+	if s.payloadStore == nil || !model.IsAtLeastV2(ctx.ProtocolVersion) || !authHeaderIncludesRequestSig(authHeader) {
+		return "", nil
+	}
+	action := strings.TrimPrefix(extractBecknAction(ctx.Body), "on_")
+	if action == "" {
+		return "", nil
+	}
+	entry, err := s.payloadStore.GetByMessageID(ctx, ctx.MessageID, action)
+	if err != nil {
+		return "", fmt.Errorf("validateSign: outbound signature lookup failed for message_id=%s action=%s: %w", ctx.MessageID, action, err)
+	}
+	if entry == nil {
+		return "", fmt.Errorf("validateSign: no outbound signature on record for message_id=%s action=%s — callback may be unsolicited or entry expired", ctx.MessageID, action)
+	}
+	return entry.Signature, nil
+}
+
 // validate checks the validity of the provided signature header.
-func (s *validateSignStep) validate(ctx *model.StepContext, value string) error {
+// When requestSig is non-empty (solicited callback path) it calls ValidateAck
+// to verify against the 4-line signing string (NFH-004 §3.3); otherwise it
+// calls Validate for the standard 3-line signing string.
+func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) error {
 	headerVals, err := parseHeader(value)
 	if err != nil {
 		return fmt.Errorf("failed to parse header")
@@ -218,6 +255,12 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value string) error 
 	signingPublicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
 	if err != nil {
 		return fmt.Errorf("failed to get validation key: %w", err)
+	}
+	if requestSig != "" {
+		if err := s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey); err != nil {
+			return fmt.Errorf("sign validation failed: %w", err)
+		}
+		return nil
 	}
 	if err := s.validator.Validate(ctx, ctx.Body, value, signingPublicKey); err != nil {
 		return fmt.Errorf("sign validation failed: %w", err)
@@ -237,56 +280,6 @@ func (s *validateSignStep) recordMetrics(ctx *model.StepContext, err error) {
 		metric.WithAttributes(telemetry.AttrStatus.String(status)))
 }
 
-// validateRequestSignatureChain verifies the request-signature field for
-// solicited callbacks (NFH-004 §6).
-//
-// A solicited callback is identified by the presence of "request-signature" in
-// the Authorization header's headers="..." attribute. In that case, the BPP
-// must include the BAP's original signature as request-signature="<sig>" in
-// its Authorization header, and ONIX verifies it matches what was sent.
-//
-// Provider-initiated pushes (headers without "request-signature") are passed
-// through without the chain check.
-//
-// No-ops:
-//   - payloadStore is nil (not configured)
-//   - protocol version < 2.0.0
-//   - "request-signature" absent from headers attribute (provider-initiated)
-func (s *validateSignStep) validateRequestSignatureChain(ctx *model.StepContext) error {
-	if s.payloadStore == nil {
-		return nil
-	}
-	if !model.IsAtLeastV2(ctx.ProtocolVersion) {
-		return nil
-	}
-	authHeader := ctx.Request.Header.Get(model.AuthHeaderSubscriber)
-	if !authHeaderIncludesRequestSig(authHeader) {
-		// Provider-initiated callback — no chain to verify.
-		return nil
-	}
-
-	// Strip "on_" prefix: callback action "on_search" → lookup key "search".
-	action := strings.TrimPrefix(extractBecknAction(ctx.Body), "on_")
-	if action == "" {
-		log.Debugf(ctx, "validateRequestSignatureChain: empty action; skipping chain check")
-		return nil
-	}
-
-	storedEntry, err := s.payloadStore.GetByMessageID(ctx, ctx.MessageID, action)
-	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("validateSign: outbound signature lookup failed for message_id=%s action=%s: %w", ctx.MessageID, action, err))
-	}
-	if storedEntry == nil {
-		return model.NewSignValidationErr(fmt.Errorf("validateSign: no outbound signature on record for message_id=%s action=%s — callback may be unsolicited or entry expired", ctx.MessageID, action))
-	}
-
-	reqSig := extractRequestSignatureValue(authHeader)
-	if reqSig != storedEntry.Signature {
-		return model.NewSignValidationErr(fmt.Errorf("validateSign: request-signature mismatch for message_id=%s action=%s", ctx.MessageID, action))
-	}
-	return nil
-}
-
 // authHeaderIncludesRequestSig returns true when the Authorization header's
 // headers="..." attribute lists "request-signature" as one of the covered fields.
 // This distinguishes solicited callbacks (4-line signing string) from
@@ -303,23 +296,6 @@ func authHeaderIncludesRequestSig(header string) bool {
 		return false
 	}
 	return strings.Contains(header[idx:idx+end], "request-signature")
-}
-
-// extractRequestSignatureValue extracts the raw Base64 value of the
-// request-signature="..." field from a Beckn Authorization header.
-// Returns empty string if the field is absent or malformed.
-func extractRequestSignatureValue(authHeader string) string {
-	const marker = `request-signature="`
-	idx := strings.Index(authHeader, marker)
-	if idx < 0 {
-		return ""
-	}
-	rest := authHeader[idx+len(marker):]
-	end := strings.IndexByte(rest, '"')
-	if end < 0 {
-		return ""
-	}
-	return rest[:end]
 }
 
 // ParsedKeyID holds the components from the parsed Authorization header's keyId.
@@ -490,9 +466,9 @@ func extractProtocolVersion(body []byte) string {
 // empty string if the attribute is absent or malformed.
 //
 // NOTE: The search uses ",signature=\"" (comma-prefixed) rather than the bare
-// "signature=\"" substring to avoid accidentally matching the request-signature
-// field (which also contains the substring "signature=") when it appears before
-// the standalone signature field in the header.
+// "signature=\"" substring so that a non-spec-compliant peer that emits
+// "request-signature=..." before "signature=..." in its header does not cause
+// the wrong value to be extracted.
 func extractAuthSignature(authHeader string) string {
 	const marker = `,signature="`
 	idx := strings.Index(authHeader, marker)

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -230,6 +230,7 @@ func (s *validateSignStep) lookupCallbackRequestSig(ctx *model.StepContext, auth
 	}
 	action := strings.TrimPrefix(extractBecknAction(ctx.Body), "on_")
 	if action == "" {
+		log.Debugf(ctx, "lookupCallbackRequestSig: no on_ action in body; skipping 4-line path")
 		return "", nil
 	}
 	entry, err := s.payloadStore.GetByMessageID(ctx, ctx.MessageID, action)
@@ -256,14 +257,14 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 	if err != nil {
 		return fmt.Errorf("failed to get validation key: %w", err)
 	}
+	var validErr error
 	if requestSig != "" {
-		if err := s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey); err != nil {
-			return fmt.Errorf("sign validation failed: %w", err)
-		}
-		return nil
+		validErr = s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey)
+	} else {
+		validErr = s.validator.Validate(ctx, ctx.Body, value, signingPublicKey)
 	}
-	if err := s.validator.Validate(ctx, ctx.Body, value, signingPublicKey); err != nil {
-		return fmt.Errorf("sign validation failed: %w", err)
+	if validErr != nil {
+		return fmt.Errorf("sign validation failed: %w", validErr)
 	}
 	return nil
 }

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -284,6 +284,41 @@ func TestSignStep_Run_NonCallback_UsesSign(t *testing.T) {
 	}
 }
 
+func TestSignStep_Run_SolicitedCallback_NoStoredEntry_FallsBackToSign(t *testing.T) {
+	// PayloadStore configured but no entry for this messageID — lookupRequestSignature
+	// returns "" so Sign (3-line) is used rather than failing the sign step.
+	store := newMockPayloadStore() // empty
+
+	signer := &mockSigner{returnSignSig: "fallbackSig=="}
+	km := &mockKMBasic{keyset: testKeyset()}
+	step, _ := newSignStep(signer, km, store)
+
+	ctx := makeSignStepCtx("on_search", "msg-sign-run-003", "bpp.example.com")
+	if err := step.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if signer.signAckCalled {
+		t.Error("expected SignAck NOT to be called when no stored entry exists")
+	}
+	if !signer.signCalled {
+		t.Error("expected Sign to be called when no stored entry exists")
+	}
+}
+
+func TestSignStep_Run_SignAckError_ReturnsError(t *testing.T) {
+	store := newMockPayloadStore()
+	store.storeEntry("msg-sign-run-004", "search", "callerSig==")
+
+	signer := &mockSigner{signAckErr: errors.New("key unavailable")}
+	km := &mockKMBasic{keyset: testKeyset()}
+	step, _ := newSignStep(signer, km, store)
+
+	ctx := makeSignStepCtx("on_search", "msg-sign-run-004", "bpp.example.com")
+	if err := step.Run(ctx); err == nil {
+		t.Fatal("expected error when SignAck fails")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // validateHeaders — 3-line vs 4-line dispatch
 // ---------------------------------------------------------------------------

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -16,28 +16,37 @@ import (
 // Mocks
 // ---------------------------------------------------------------------------
 
-// mockSignValidatorBasic is a simple SignValidator that always returns nil or a preset error.
+// mockSignValidatorBasic is a simple SignValidator that tracks which method was
+// called and returns configurable errors.
 type mockSignValidatorBasic struct {
-	validateErr error
+	validateErr       error
+	validateAckErr    error
+	validateCalled    bool
+	validateAckCalled bool
 }
 
 func (m *mockSignValidatorBasic) Validate(_ context.Context, _ []byte, _ string, _ string) error {
+	m.validateCalled = true
 	return m.validateErr
 }
 func (m *mockSignValidatorBasic) ValidateAck(_ context.Context, _ []byte, _, _, _ string) error {
-	return nil
+	m.validateAckCalled = true
+	return m.validateAckErr
 }
 
 // mockKMBasic is a simple KeyManager that returns a preset public key or error.
 type mockKMBasic struct {
 	publicKey string
 	lookupErr error
+	keyset    *model.Keyset // returned by Keyset(); nil when not set
 }
 
 func (m *mockKMBasic) GenerateKeyset() (*model.Keyset, error)                          { return nil, nil }
 func (m *mockKMBasic) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error { return nil }
 func (m *mockKMBasic) DeleteKeyset(_ context.Context, _ string) error                  { return nil }
-func (m *mockKMBasic) Keyset(_ context.Context, _ string) (*model.Keyset, error)       { return nil, nil }
+func (m *mockKMBasic) Keyset(_ context.Context, _ string) (*model.Keyset, error) {
+	return m.keyset, nil
+}
 func (m *mockKMBasic) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) {
 	return m.publicKey, "", m.lookupErr
 }
@@ -84,14 +93,15 @@ func (m *mockPayloadStore) GetByMessageID(_ context.Context, messageID, action s
 // Helpers
 // ---------------------------------------------------------------------------
 
-// solicitedCallbackAuthHeader builds a Signature header that declares
-// "request-signature" in the headers attribute — identifying a solicited callback.
-func solicitedCallbackAuthHeader(subscriberID, requestSigValue string) string {
+// solicitedCallbackAuthHeader builds a spec-compliant 6-attribute Signature header
+// that declares "request-signature" in the headers list — identifying a solicited
+// callback. The CN's original signature is in the signing string, not as a header
+// attribute (NFH-004 §4).
+func solicitedCallbackAuthHeader(subscriberID string) string {
 	return `Signature keyId="` + subscriberID + `|key-1|ed25519",algorithm="ed25519",` +
 		`created="1700000000",expires="1700003600",` +
 		`headers="(created) (expires) digest request-signature",` +
-		`signature="callbackSig==",` +
-		`request-signature="` + requestSigValue + `"`
+		`signature="callbackSig=="`
 }
 
 // providerInitiatedAuthHeader builds a Signature header without request-signature.
@@ -173,145 +183,7 @@ func TestAuthHeaderIncludesRequestSig_False_MissingHeadersField(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// extractRequestSignatureValue unit tests
-// ---------------------------------------------------------------------------
-
-func TestExtractRequestSignatureValue_Present(t *testing.T) {
-	header := solicitedCallbackAuthHeader("bpp.example.com", "outboundSig==")
-	got := extractRequestSignatureValue(header)
-	if got != "outboundSig==" {
-		t.Errorf("extractRequestSignatureValue() = %q, want %q", got, "outboundSig==")
-	}
-}
-
-func TestExtractRequestSignatureValue_Absent(t *testing.T) {
-	header := providerInitiatedAuthHeader("bpp.example.com")
-	got := extractRequestSignatureValue(header)
-	if got != "" {
-		t.Errorf("extractRequestSignatureValue() = %q, want empty", got)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// validateRequestSignatureChain tests
-// ---------------------------------------------------------------------------
-
 const onSearchBody = `{"context":{"action":"on_search","messageId":"msg-chain-001","version":"2.0.0"}}`
-
-func TestValidateRequestSignatureChain_NilStore_Skips(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-
-	vStep := step.(*validateSignStep)
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-001", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "storedSig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err != nil {
-		t.Fatalf("expected nil when payloadStore is nil, got: %v", err)
-	}
-}
-
-func TestValidateRequestSignatureChain_PreV2Version_Skips(t *testing.T) {
-	store := newMockPayloadStore()
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	ctx := makeReceiverStepCtx("1.1.0", "msg-chain-002", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "storedSig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err != nil {
-		t.Fatalf("expected nil for pre-v2 version, got: %v", err)
-	}
-}
-
-func TestValidateRequestSignatureChain_ProviderInitiated_Skips(t *testing.T) {
-	store := newMockPayloadStore()
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	// headers= without request-signature → provider-initiated
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-003", "bap.example.com",
-		providerInitiatedAuthHeader("bpp.example.com"), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err != nil {
-		t.Fatalf("expected nil for provider-initiated callback, got: %v", err)
-	}
-}
-
-func TestValidateRequestSignatureChain_ValidChain(t *testing.T) {
-	store := newMockPayloadStore()
-	store.storeEntry("msg-chain-004", "search", "originalCallerSig==")
-
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	// BPP callback Authorization includes request-signature matching what BAP sent.
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-004", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "originalCallerSig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err != nil {
-		t.Fatalf("expected nil for valid chain, got: %v", err)
-	}
-}
-
-func TestValidateRequestSignatureChain_Mismatch_ReturnsError(t *testing.T) {
-	store := newMockPayloadStore()
-	store.storeEntry("msg-chain-005", "search", "originalCallerSig==")
-
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	// BPP sends a different request-signature value — tampered.
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-005", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "tamperedSig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err == nil {
-		t.Fatal("expected error for request-signature mismatch")
-	}
-}
-
-func TestValidateRequestSignatureChain_NoEntry_ReturnsError(t *testing.T) {
-	store := newMockPayloadStore() // empty — no stored entry
-
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-006", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "anySig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err == nil {
-		t.Fatal("expected error when no outbound entry found for message ID")
-	}
-}
-
-func TestValidateRequestSignatureChain_StoreGetError_ReturnsError(t *testing.T) {
-	store := newMockPayloadStore()
-	store.getErr = errors.New("redis connection error")
-
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, store)
-
-	vStep := step.(*validateSignStep)
-	ctx := makeReceiverStepCtx("2.0.0", "msg-chain-007", "bap.example.com",
-		solicitedCallbackAuthHeader("bpp.example.com", "anySig=="), onSearchBody)
-
-	if err := vStep.validateRequestSignatureChain(ctx); err == nil {
-		t.Fatal("expected error when payloadStore.GetByMessageID returns error")
-	}
-}
 
 // ---------------------------------------------------------------------------
 // PayloadStore wiring tests via initSteps
@@ -338,6 +210,219 @@ func TestValidateSignStep_InitSteps_WithPayloadStore(t *testing.T) {
 	}
 	if len(h.steps) != 1 {
 		t.Errorf("expected 1 step, got %d", len(h.steps))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// signStep.Run — Sign vs SignAck dispatch
+// ---------------------------------------------------------------------------
+
+// testKeyset returns a minimal Keyset with a dummy private key seed (32 zero
+// bytes, base64-encoded) sufficient to construct but not cryptographically
+// verify real signatures in unit tests.
+func testKeyset() *model.Keyset {
+	return &model.Keyset{
+		UniqueKeyID:   "key-1",
+		SigningPrivate: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+	}
+}
+
+func makeSignStepCtx(action, messageID, subID string) *model.StepContext {
+	body := []byte(`{"context":{"action":"` + action + `","messageId":"` + messageID + `","version":"2.0.0"}}`)
+	req, _ := http.NewRequest(http.MethodPost, "/bpp/caller/"+action, nil)
+	return &model.StepContext{
+		Context:    context.Background(),
+		Request:    req,
+		Body:       body,
+		MessageID:  messageID,
+		SubID:      subID,
+		RespHeader: http.Header{},
+	}
+}
+
+func TestSignStep_Run_SolicitedCallback_UsesSignAck(t *testing.T) {
+	store := newMockPayloadStore()
+	store.storeEntry("msg-sign-run-001", "search", "callerSig==")
+
+	signer := &mockSigner{returnSig: "callbackSig=="}
+	km := &mockKMBasic{keyset: testKeyset()}
+	step, _ := newSignStep(signer, km, store)
+
+	ctx := makeSignStepCtx("on_search", "msg-sign-run-001", "bpp.example.com")
+	if err := step.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if !signer.signAckCalled {
+		t.Error("expected SignAck to be called for a solicited callback")
+	}
+	if signer.signCalled {
+		t.Error("expected Sign NOT to be called for a solicited callback")
+	}
+	authVal := ctx.Request.Header.Get(model.AuthHeaderSubscriber)
+	if strings.Contains(authVal, `request-signature="`) {
+		t.Errorf("Authorization header must not contain request-signature attribute, got: %s", authVal)
+	}
+	if !strings.Contains(authVal, `headers="(created) (expires) digest request-signature"`) {
+		t.Errorf("Authorization header must declare request-signature in headers list, got: %s", authVal)
+	}
+}
+
+func TestSignStep_Run_NonCallback_UsesSign(t *testing.T) {
+	signer := &mockSigner{returnSig: "requestSig=="}
+	km := &mockKMBasic{keyset: testKeyset()}
+	step, _ := newSignStep(signer, km, nil)
+
+	ctx := makeSignStepCtx("search", "msg-sign-run-002", "bap.example.com")
+	if err := step.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if signer.signAckCalled {
+		t.Error("expected SignAck NOT to be called for a regular request")
+	}
+	if !signer.signCalled {
+		t.Error("expected Sign to be called for a regular request")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateHeaders — 3-line vs 4-line dispatch
+// ---------------------------------------------------------------------------
+
+func makeValidateStepCtx(protocolVersion, messageID, subID, authHeader, bodyJSON string) *model.StepContext {
+	req, _ := http.NewRequest(http.MethodPost, "/bap/receiver/on_search", strings.NewReader(bodyJSON))
+	req.Header.Set(model.AuthHeaderSubscriber, authHeader)
+	return &model.StepContext{
+		Context:         context.Background(),
+		Request:         req,
+		Body:            []byte(bodyJSON),
+		ProtocolVersion: protocolVersion,
+		MessageID:       messageID,
+		SubID:           subID,
+		RespHeader:      http.Header{},
+	}
+}
+
+func TestValidateHeaders_SolicitedCallback_UsesValidateAck(t *testing.T) {
+	store := newMockPayloadStore()
+	store.storeEntry("msg-vh-001", "search", "storedSig==")
+
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, store)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-vh-001", "bap.example.com",
+		solicitedCallbackAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-001","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+	if !sv.validateAckCalled {
+		t.Error("expected ValidateAck to be called for a solicited callback")
+	}
+	if sv.validateCalled {
+		t.Error("expected Validate NOT to be called for a solicited callback")
+	}
+}
+
+func TestValidateHeaders_ProviderInitiated_UsesValidate(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-vh-002", "bap.example.com",
+		providerInitiatedAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-002","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+	if sv.validateAckCalled {
+		t.Error("expected ValidateAck NOT to be called for a provider-initiated callback")
+	}
+	if !sv.validateCalled {
+		t.Error("expected Validate to be called for a provider-initiated callback")
+	}
+}
+
+func TestValidateHeaders_SolicitedCallback_NilStore_FallsBackToValidate(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	// nil payloadStore — degrade to 3-line verification
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-vh-003", "bap.example.com",
+		solicitedCallbackAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-003","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+	if sv.validateAckCalled {
+		t.Error("expected ValidateAck NOT to be called when payloadStore is nil")
+	}
+	if !sv.validateCalled {
+		t.Error("expected Validate to be called when payloadStore is nil")
+	}
+}
+
+func TestValidateHeaders_SolicitedCallback_PreV2_FallsBackToValidate(t *testing.T) {
+	store := newMockPayloadStore()
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, store)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("1.1.0", "msg-vh-004", "bap.example.com",
+		solicitedCallbackAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-004","version":"1.1.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+	if sv.validateAckCalled {
+		t.Error("expected ValidateAck NOT to be called for pre-v2 version")
+	}
+	if !sv.validateCalled {
+		t.Error("expected Validate to be called for pre-v2 version")
+	}
+}
+
+func TestValidateHeaders_SolicitedCallback_NoEntry_ReturnsError(t *testing.T) {
+	store := newMockPayloadStore() // empty
+
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, store)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-vh-005", "bap.example.com",
+		solicitedCallbackAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-005","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err == nil {
+		t.Fatal("expected error when no stored entry found for message ID")
+	}
+}
+
+func TestValidateHeaders_SolicitedCallback_StoreError_ReturnsError(t *testing.T) {
+	store := newMockPayloadStore()
+	store.getErr = errors.New("redis down")
+
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, store)
+	vStep := step.(*validateSignStep)
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-vh-006", "bap.example.com",
+		solicitedCallbackAuthHeader("bpp.example.com"),
+		`{"context":{"action":"on_search","messageId":"msg-vh-006","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err == nil {
+		t.Fatal("expected error when payloadStore.GetByMessageID returns error")
 	}
 }
 
@@ -388,8 +473,10 @@ func TestGenerateAuthHeader_WithRequestSig(t *testing.T) {
 	if !strings.Contains(h, `headers="(created) (expires) digest request-signature"`) {
 		t.Errorf("expected extended headers field, got: %s", h)
 	}
-	if !strings.Contains(h, `request-signature="originalSig=="`) {
-		t.Errorf("missing request-signature value, got: %s", h)
+	// request-signature must be in the headers list (signing string declaration)
+	// but must NOT appear as a separate header attribute (NFH-004 §4).
+	if strings.Contains(h, `request-signature="`) {
+		t.Errorf("request-signature must not appear as a header attribute, got: %s", h)
 	}
 	if !strings.Contains(h, `signature="mySig=="`) {
 		t.Errorf("missing signature value, got: %s", h)


### PR DESCRIPTION
## Summary

Fixes #752.

Solicited callbacks (`on_*` actions) were signed with the standard 3-line signing string and carried the CN's original signature only as a non-spec 7th `Authorization` header attribute. Both sides were internally consistent, but the implementation deviated from NFH-004 §3.3 and would fail to interoperate with any spec-compliant peer in either direction.

### Root cause
`signStep.Run` called `signer.Sign` for all outgoing messages, producing a 3-line signing string. The CN's original signature was looked up from the PayloadStore but only appended as `request-signature="..."` in the header — it was never included in the data that was actually signed. On the receive side, `validateHeaders` always called `validator.Validate` (3-line reconstruction), and a separate `validateRequestSignatureChain` did a plain string comparison against the non-spec header attribute rather than cryptographic verification.

### Fix

**Send side (`signStep.Run`):**
- Looks up the CN's stored outbound signature _before_ the signer span.
- Calls `signer.SignAck` (4-line signing string, NFH-004 §3.3) for solicited callbacks; `signer.Sign` (3-line) for all other messages.
- Degrades gracefully to `Sign` when PayloadStore has no entry for the message ID (non-fatal, same as existing `lookupRequestSignature` behaviour).
- `generateAuthHeader` no longer emits the non-spec `request-signature="..."` attribute — Authorization header is now spec-compliant 6 attributes.

**Receive side (`validateHeaders`):**
- New `lookupCallbackRequestSig` helper: for v2 solicited callbacks (v2 protocol, `headers` attribute declares `request-signature`, PayloadStore configured), fetches the stored CN outbound signature. Degrades to empty string (3-line path) when store is nil or protocol is pre-v2.
- `validate` now takes a `requestSig` parameter; dispatches to `validator.ValidateAck` (4-line) when non-empty, `validator.Validate` (3-line) otherwise. Both branches share a single error format.
- `validateRequestSignatureChain` removed — chain integrity is now proven by the Ed25519 signature itself.
- `extractRequestSignatureValue` removed — its only caller was the removed chain check.

### Behaviour table after this fix

| Case | Signing string | Spec | Before | After |
|---|---|---|---|---|
| CN request / PN-initiated | 3-line | `(created) (expires) digest` | ✓ | ✓ |
| **Solicited callback** | **4-line** | `(created) (expires) digest request-signature` | ✗ 3-line signed, non-spec 7th attr | ✓ |
| Synchronous ACK response | 4-line | `(created) (expires) digest request-signature` | ✓ | ✓ |

### Out of scope
- `BLAKE-512=` digest prefix (spec says `BLAKE2b-512=`) — tracked in #749.
- `SignAck`/`ValidateAck` naming refactor mentioned in #752 — no functional impact, separate PR.

## Test plan

- [x] `TestSignStep_Run_SolicitedCallback_UsesSignAck` — `SignAck` called, not `Sign`, for `on_*` actions; no `request-signature` attribute in emitted header
- [x] `TestSignStep_Run_NonCallback_UsesSign` — `Sign` called for regular actions
- [x] `TestSignStep_Run_SolicitedCallback_NoStoredEntry_FallsBackToSign` — missing store entry degrades to `Sign` without error
- [x] `TestSignStep_Run_SignAckError_ReturnsError` — `SignAck` failure propagated correctly
- [x] `TestValidateHeaders_SolicitedCallback_UsesValidateAck` — `ValidateAck` dispatched for v2 solicited callbacks with stored entry
- [x] `TestValidateHeaders_ProviderInitiated_UsesValidate` — `Validate` dispatched for provider-initiated callbacks
- [x] `TestValidateHeaders_SolicitedCallback_NilStore_FallsBackToValidate` — degrades gracefully when PayloadStore not configured
- [x] `TestValidateHeaders_SolicitedCallback_PreV2_FallsBackToValidate` — no 4-line path for pre-v2 protocol
- [x] `TestValidateHeaders_SolicitedCallback_NoEntry_ReturnsError` — unsolicited callback rejected
- [x] `TestValidateHeaders_SolicitedCallback_StoreError_ReturnsError` — store error propagated
- [x] Full suite: `go test ./...` — all green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)