### PR TITLE
fix(signvalidator): enforce ed25519 algorithm in signature validation

### DIFF
--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -252,6 +252,8 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 	if err != nil {
 		return fmt.Errorf("failed to parse header")
 	}
+	// Guards the keyId component (sub|key|alg); parseAuthHeader in signvalidator
+	// guards the outer algorithm= attribute — the two cover different header fields.
 	if headerVals.Algorithm != "ed25519" {
 		return fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
 	}

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -252,6 +252,9 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 	if err != nil {
 		return fmt.Errorf("failed to parse header")
 	}
+	if headerVals.Algorithm != "ed25519" {
+		return fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
+	}
 	log.Debugf(ctx, "Validating Signature for subscriberID: %v", headerVals.SubscriberID)
 	signingPublicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
 	if err != nil {

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -461,6 +461,27 @@ func TestValidateHeaders_SolicitedCallback_StoreError_ReturnsError(t *testing.T)
 	}
 }
 
+func TestValidate_NonEd25519Algorithm_ReturnsError(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	badAlgHeader := `Signature keyId="bpp.example.com|key-1|rsa",algorithm="rsa",` +
+		`created="1700000000",expires="1700003600",signature="sig=="`
+
+	ctx := makeValidateStepCtx("2.0.0", "msg-alg-001", "bap.example.com",
+		badAlgHeader,
+		`{"context":{"action":"on_search","messageId":"msg-alg-001","version":"2.0.0"}}`)
+
+	if err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
+		t.Fatal("expected error for non-ed25519 algorithm")
+	}
+	if sv.validateCalled || sv.validateAckCalled {
+		t.Error("signature validator must not be called when algorithm is rejected")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // signStep — constructor and generateAuthHeader tests
 // ---------------------------------------------------------------------------

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -79,6 +79,10 @@ func parseAuthHeader(header string) (int64, int64, string, error) {
 		}
 	}
 
+	if signatureMap["algorithm"] != "ed25519" {
+		return 0, 0, "", model.NewSignValidationErr(fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
+	}
+
 	createdTimestamp, err := strconv.ParseInt(signatureMap["created"], 10, 64)
 	if err != nil {
 		// TODO: Return appropriate error code when Error Code Handling Module is ready

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -98,6 +98,14 @@ func TestVerifyFailure(t *testing.T) {
 			pubKey: publicKeyBase64,
 		},
 		{
+			name: "Missing Algorithm",
+			body: []byte("Test Payload"),
+			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
+				`", signature="somesig=="`,
+			pubKey: publicKeyBase64,
+		},
+		{
 			name: "Invalid Base64 Signature",
 			body: []byte("Test Payload"),
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -47,7 +47,7 @@ func TestVerifySuccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			signature := signTestData(privateKeyBase64, tt.body, tt.createdAt, tt.expiresAt)
-			header := `Signature created="` + strconv.FormatInt(tt.createdAt, 10) +
+			header := `Signature algorithm="ed25519", created="` + strconv.FormatInt(tt.createdAt, 10) +
 				`", expires="` + strconv.FormatInt(tt.expiresAt, 10) +
 				`", signature="` + signature + `"`
 
@@ -90,9 +90,17 @@ func TestVerifyFailure(t *testing.T) {
 			pubKey: publicKeyBase64,
 		},
 		{
+			name: "Unsupported Algorithm",
+			body: []byte("Test Payload"),
+			header: `Signature algorithm="rsa", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
+				`", signature="somesig=="`,
+			pubKey: publicKeyBase64,
+		},
+		{
 			name: "Invalid Base64 Signature",
 			body: []byte("Test Payload"),
-			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="!!INVALIDBASE64!!"`,
 			pubKey: publicKeyBase64,
@@ -100,7 +108,7 @@ func TestVerifyFailure(t *testing.T) {
 		{
 			name: "Expired Signature",
 			body: []byte("Test Payload"),
-			header: `Signature created="` + strconv.FormatInt(time.Now().Unix()-7200, 10) +
+			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix()-7200, 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()-3600, 10) +
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix()-7200, time.Now().Unix()-3600) + `"`,
 			pubKey: publicKeyBase64,
@@ -108,7 +116,7 @@ func TestVerifyFailure(t *testing.T) {
 		{
 			name: "Invalid Public Key",
 			body: []byte("Test Payload"),
-			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix(), time.Now().Unix()+3600) + `"`,
 			pubKey: wrongPublicKeyBase64,
@@ -116,14 +124,14 @@ func TestVerifyFailure(t *testing.T) {
 		{
 			name: "Invalid Expires Timestamp",
 			body: []byte("Test Payload"),
-			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="invalid_timestamp"`,
 			pubKey: publicKeyBase64,
 		},
 		{
 			name: "Signature Missing in Headers",
 			body: []byte("Test Payload"),
-			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
+			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) + `"`,
 			pubKey: publicKeyBase64,
 		},


### PR DESCRIPTION
**Closes #753**

### Summary

- Rejects any `Authorization` header whose `keyId` algorithm component (3rd pipe-delimited segment) is not `ed25519` in `validate()` — returns an error before key lookup or signature verification is attempted (NFH-007 §1, §7 Step 3, §8 Step 3, CON-004-03)
- Rejects any `Authorization` header whose outer `algorithm=` attribute is not `ed25519` inside `signvalidator.parseAuthHeader()`, making the validator plugin self-contained regardless of caller
- Adds `TestValidate_NonEd25519Algorithm_ReturnsError` confirming the signature validator is never invoked when the algorithm is rejected
- Adds `"Unsupported Algorithm"` failure case to `TestVerifyFailure`; updates existing signvalidator test headers to include `algorithm="ed25519"` so each case exercises its intended failure mode

### What changed

| File | Change |
|------|--------|
| `core/module/handler/step.go` | Guard in `validate()` — checks `headerVals.Algorithm != "ed25519"` before key lookup |
| `pkg/plugin/implementation/signvalidator/signvalidator.go` | Guard in `parseAuthHeader()` — checks `signatureMap["algorithm"] != "ed25519"` before timestamp parsing |
| `core/module/handler/step_test.go` | New test `TestValidate_NonEd25519Algorithm_ReturnsError` |
| `pkg/plugin/implementation/signvalidator/signvalidator_test.go` | New `"Unsupported Algorithm"` case; existing headers updated with `algorithm="ed25519"` |

### Why two validation points

The two checks cover **different fields** in the header:

```
Signature keyId="sub|key|ed25519", algorithm="ed25519", ...
                          ↑                   ↑
                   step.go checks      signvalidator checks
                   (keyId component)   (outer attribute)
```

A header where only one field is wrong would bypass a single-point check.

### Test plan

- [x] `go test ./core/module/handler/...` — all pass including `TestValidate_NonEd25519Algorithm_ReturnsError`
- [x] `go test ./pkg/plugin/implementation/signvalidator/...` — all pass including `TestVerifyFailure/Unsupported_Algorithm`
- [x] Manually send a request with `algorithm="rsa"` in the `Authorization` header → confirm `401` response
