### PR TITLE
feat: support senderId/receiverId and senderUri/receiverUri as Beckn spec v2 context field aliases

### DIFF
--- a/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
@@ -67,6 +67,10 @@ var sampleBecknInput = []byte(`{
 		"bap_uri": "https://buyer-bap.example.com",
 		"bpp_id": "seller-bpp.example.com",
 		"bpp_uri": "https://seller-bpp.example.com",
+		"senderId": "buyer-bap.example.com",
+		"senderUri": "https://buyer-bap.example.com",
+		"receiverId": "seller-bpp.example.com",
+		"receiverUri": "https://seller-bpp.example.com",
 		"transaction_id": "txn-12345",
 		"message_id": "msg-67890",
 		"timestamp": "2026-03-04T10:00:00Z"

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -740,10 +740,10 @@ func parseRequestContext(body []byte) parsedRequestContext {
 func formatRequestLogContext(ctx parsedRequestContext) string {
 	parts := make([]string, 0, 6)
 	if ctx.BAPID != "" {
-		parts = append(parts, fmt.Sprintf("bap_id=%q", ctx.BAPID))
+		parts = append(parts, fmt.Sprintf("sender_id=%q", ctx.BAPID))
 	}
 	if ctx.BPPID != "" {
-		parts = append(parts, fmt.Sprintf("bpp_id=%q", ctx.BPPID))
+		parts = append(parts, fmt.Sprintf("receiver_id=%q", ctx.BPPID))
 	}
 	if ctx.MessageID != "" {
 		parts = append(parts, fmt.Sprintf("message_id=%q", ctx.MessageID))

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -717,20 +717,19 @@ func parseRequestContext(body []byte) parsedRequestContext {
 		return parsedRequestContext{}
 	}
 
-	get := func(snakeKey, camelKey string) string {
-		if v, ok := payload.Context[snakeKey].(string); ok && v != "" {
-			return v
-		}
-		if v, ok := payload.Context[camelKey].(string); ok && v != "" {
-			return v
+	get := func(keys ...string) string {
+		for _, key := range keys {
+			if v, ok := payload.Context[key].(string); ok && v != "" {
+				return v
+			}
 		}
 		return ""
 	}
 
 	return parsedRequestContext{
 		NetworkID:     get("network_id", "networkId"),
-		BAPID:         get("bap_id", "bapId"),
-		BPPID:         get("bpp_id", "bppId"),
+		BAPID:         get("bap_id", "bapId", "senderId"),
+		BPPID:         get("bpp_id", "bppId", "receiverId"),
 		MessageID:     get("message_id", "messageId"),
 		TransactionID: get("transaction_id", "transactionId"),
 		Action:        get("action", "action"), // "action" has no camelCase variant

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -786,6 +786,26 @@ func TestParseRequestContext_NetworkIDVariants(t *testing.T) {
 	}
 }
 
+func TestParseRequestContext_SenderReceiverIDs(t *testing.T) {
+	// Spec v2: senderId maps to BAPID, receiverId maps to BPPID
+	reqCtx := parseRequestContext([]byte(`{"context":{"action":"select","senderId":"sender.example.com","receiverId":"receiver.example.com","message_id":"msg-2","transactionId":"txn-2","timestamp":"2026-06-01T10:00:00Z"}}`))
+	if reqCtx.BAPID != "sender.example.com" {
+		t.Fatalf("expected BAPID sender.example.com from senderId, got %q", reqCtx.BAPID)
+	}
+	if reqCtx.BPPID != "receiver.example.com" {
+		t.Fatalf("expected BPPID receiver.example.com from receiverId, got %q", reqCtx.BPPID)
+	}
+
+	// Legacy bap_id takes precedence over senderId when both present
+	reqCtxPrecedence := parseRequestContext([]byte(`{"context":{"bap_id":"legacy-bap.example.com","senderId":"sender.example.com","bpp_id":"legacy-bpp.example.com","receiverId":"receiver.example.com"}}`))
+	if reqCtxPrecedence.BAPID != "legacy-bap.example.com" {
+		t.Fatalf("expected bap_id to take precedence over senderId, got %q", reqCtxPrecedence.BAPID)
+	}
+	if reqCtxPrecedence.BPPID != "legacy-bpp.example.com" {
+		t.Fatalf("expected bpp_id to take precedence over receiverId, got %q", reqCtxPrecedence.BPPID)
+	}
+}
+
 // --- Config Tests: Bundle Type ---
 
 func TestParsePolicyConfig_BundleType(t *testing.T) {

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -25,7 +25,7 @@ const contextKey = "context"
 
 // firstNonNil returns the first non-nil value from the provided list.
 // Used to resolve context fields that may appear under different key names
-// (e.g. bap_id or bapId) depending on the beckn spec version in use.
+// (e.g. bap_id, bapId, or senderId) depending on the beckn spec version in use.
 func firstNonNil(values ...any) any {
 	for _, v := range values {
 		if v != nil {
@@ -95,22 +95,23 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				return
 			}
 
-			// Resolve subscriber ID — checks snake_case key first, falls back to camelCase.
+			// Resolve subscriber ID — tries legacy snake_case, then camelCase, then
+			// the new Beckn spec v2 names (senderId / receiverId).
 			var subID any
 			switch cfg.Role {
 			case "bap":
-				subID = firstNonNil(reqContext["bap_id"], reqContext["bapId"])
+				subID = firstNonNil(reqContext["bap_id"], reqContext["bapId"], reqContext["senderId"])
 			case "bpp":
-				subID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"])
+				subID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"], reqContext["receiverId"])
 			}
 
-			// Resolve caller ID — same dual-key pattern, opposite role.
+			// Resolve caller ID — same triple-key pattern, opposite role.
 			var callerID any
 			switch cfg.Role {
 			case "bap":
-				callerID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"])
+				callerID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"], reqContext["receiverId"])
 			case "bpp":
-				callerID = firstNonNil(reqContext["bap_id"], reqContext["bapId"])
+				callerID = firstNonNil(reqContext["bap_id"], reqContext["bapId"], reqContext["senderId"])
 			}
 
 			if subID != nil {

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -260,8 +260,8 @@ func TestSnakeToCamel(t *testing.T) {
 	}
 }
 
-// TestCamelCaseSubscriberID tests that bapId / bppId are resolved when the payload
-// uses camelCase context attribute names (new beckn spec).
+// TestCamelCaseSubscriberID tests that bapId / bppId / senderId / receiverId are
+// resolved when the payload uses camelCase context attribute names.
 func TestCamelCaseSubscriberID(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -301,6 +301,38 @@ func TestCamelCaseSubscriberID(t *testing.T) {
 			},
 			wantSubID:  "bap-snake.example.com",
 			wantCaller: "bpp-snake.example.com",
+		},
+		// Beckn spec v2: senderId / receiverId
+		{
+			name: "BAP role — senderId resolved as subscriber (spec v2)",
+			role: "bap",
+			contextBody: map[string]interface{}{
+				"senderId":   "sender.example.com",
+				"receiverId": "receiver.example.com",
+			},
+			wantSubID:  "sender.example.com",
+			wantCaller: "receiver.example.com",
+		},
+		{
+			name: "BPP role — receiverId resolved as subscriber (spec v2)",
+			role: "bpp",
+			contextBody: map[string]interface{}{
+				"senderId":   "sender.example.com",
+				"receiverId": "receiver.example.com",
+			},
+			wantSubID:  "receiver.example.com",
+			wantCaller: "sender.example.com",
+		},
+		{
+			name: "camelCase bapId takes precedence over senderId",
+			role: "bap",
+			contextBody: map[string]interface{}{
+				"bapId":    "bap-camel.example.com",
+				"senderId": "sender.example.com",
+				"bppId":    "bpp-camel.example.com",
+			},
+			wantSubID:  "bap-camel.example.com",
+			wantCaller: "bpp-camel.example.com",
 		},
 	}
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -334,6 +334,28 @@ func TestCamelCaseSubscriberID(t *testing.T) {
 			wantSubID:  "bap-camel.example.com",
 			wantCaller: "bpp-camel.example.com",
 		},
+		{
+			name: "BPP role — camelCase bppId takes precedence over receiverId (subID path)",
+			role: "bpp",
+			contextBody: map[string]interface{}{
+				"bppId":      "bpp-camel.example.com",
+				"receiverId": "receiver.example.com",
+				"bapId":      "bap-camel.example.com",
+			},
+			wantSubID:  "bpp-camel.example.com",
+			wantCaller: "bap-camel.example.com",
+		},
+		{
+			name: "BPP role — camelCase bapId takes precedence over senderId (callerID path)",
+			role: "bpp",
+			contextBody: map[string]interface{}{
+				"bapId":      "bap-camel.example.com",
+				"senderId":   "sender.example.com",
+				"receiverId": "receiver.example.com",
+			},
+			wantSubID:  "receiver.example.com",
+			wantCaller: "bap-camel.example.com",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -33,24 +33,28 @@ type Router struct {
 type routingRule struct {
 	Domain     string   `yaml:"domain"`
 	Version    string   `yaml:"version"`
-	TargetType string   `yaml:"targetType"` // "url", "publisher", "bpp", or "bap"
+	TargetType string   `yaml:"targetType"` // "url", "publisher", "bpp"/"receiver", or "bap"/"sender"
 	Target     target   `yaml:"target,omitempty"`
 	Endpoints  []string `yaml:"endpoints"`
 }
 
 // Target contains destination-specific details.
 type target struct {
-	URL         string `yaml:"url,omitempty"`         // URL for "url" or gateway endpoint for "bpp"/"bap"
-	PublisherID string `yaml:"publisherId,omitempty"` // For "msgq" type
-	ExcludeAction bool `yaml:"excludeAction,omitempty"` // For "url" type to exclude appending action to URL path
+	URL           string `yaml:"url,omitempty"`           // URL for "url" or gateway endpoint for "bpp"/"bap"
+	PublisherID   string `yaml:"publisherId,omitempty"`   // For "msgq" type
+	ExcludeAction bool   `yaml:"excludeAction,omitempty"` // For "url" type to exclude appending action to URL path
 }
 
 // TargetType defines possible target destinations.
+// The legacy values "bpp" and "bap" are retained for backward compatibility;
+// new configs should use "receiver" and "sender" respectively.
 const (
 	targetTypeURL       = "url"       // Route to a specific URL
 	targetTypePublisher = "publisher" // Route to a publisher
-	targetTypeBPP       = "bpp"       // Route to a BPP endpoint
-	targetTypeBAP       = "bap"       // Route to a BAP endpoint
+	targetTypeBPP       = "bpp"       // Route to a BPP endpoint (legacy; prefer "receiver")
+	targetTypeBAP       = "bap"       // Route to a BAP endpoint (legacy; prefer "sender")
+	targetTypeReceiver  = "receiver"  // Route to receiver (BPP) endpoint — Beckn spec v2 name
+	targetTypeSender    = "sender"    // Route to sender (BAP) endpoint — Beckn spec v2 name
 )
 
 // New initializes a new Router instance with the provided configuration.
@@ -132,7 +136,7 @@ func (r *Router) loadRules(configPath string) error {
 					TargetType: rule.TargetType,
 					URL:        parsedURL,
 				}
-			case targetTypeBPP, targetTypeBAP:
+			case targetTypeBPP, targetTypeBAP, targetTypeReceiver, targetTypeSender:
 				var parsedURL *url.URL
 				if rule.Target.URL != "" {
 					parsedURL, err = url.Parse(rule.Target.URL)
@@ -185,7 +189,7 @@ func validateRules(rules []routingRule) error {
 			if rule.Target.PublisherID == "" {
 				return fmt.Errorf("invalid rule: publisherID is required for targetType 'publisher'")
 			}
-		case targetTypeBPP, targetTypeBAP:
+		case targetTypeBPP, targetTypeBAP, targetTypeReceiver, targetTypeSender:
 			if rule.Target.URL != "" {
 				if _, err := url.Parse(rule.Target.URL); err != nil {
 					return fmt.Errorf("invalid URL - %s defined in routing config for target type %s: %w", rule.Target.URL, rule.TargetType, err)
@@ -199,15 +203,15 @@ func validateRules(rules []routingRule) error {
 	return nil
 }
 
-// getContextString returns the value for a context field, checking the snake_case
-// key first and falling back to the camelCase key. This supports both the legacy
-// beckn spec (snake_case) and the new camelCase convention transparently.
-func getContextString(ctx map[string]interface{}, snakeKey, camelKey string) string {
-	if v, ok := ctx[snakeKey].(string); ok && v != "" {
-		return v
-	}
-	if v, ok := ctx[camelKey].(string); ok && v != "" {
-		return v
+// getContextString returns the value for a context field, checking each key in
+// order and returning the first non-empty string found. Supports snake_case
+// (legacy), camelCase (Beckn spec v1 preferred), and the new Beckn spec v2
+// camelCase names (e.g. senderUri, receiverUri) transparently.
+func getContextString(ctx map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := ctx[key].(string); ok && v != "" {
+			return v
+		}
 	}
 	return ""
 }
@@ -234,8 +238,9 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 		return nil, fmt.Errorf("error parsing request body: %w", err)
 	}
 
-	// Parse context as a map solely to resolve URI fields that have both
-	// snake_case (bpp_uri, bap_uri) and camelCase (bppUri, bapUri) variants.
+	// Parse context as a map solely to resolve URI fields. Checks legacy
+	// snake_case (bpp_uri, bap_uri), then camelCase (bppUri, bapUri), then
+	// the new Beckn spec v2 names (receiverUri, senderUri).
 	var uriBody struct {
 		Context map[string]interface{} `json:"context"`
 	}
@@ -245,8 +250,8 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	if uriBody.Context == nil {
 		return nil, fmt.Errorf("context field not found or invalid in request body")
 	}
-	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri")
-	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri")
+	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri", "receiverUri")
+	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri", "senderUri")
 
 	// For v2.x.x, ignore domain and use wildcard; for v1.x.x, use actual domain
 	domain := requestBody.Context.Domain
@@ -279,11 +284,12 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 		return nil, fmt.Errorf("endpoint '%s' is not supported for domain %s and version %s in routing config",
 			endpoint, requestBody.Context.Domain, requestBody.Context.Version)
 	}
-	// Handle BPP/BAP routing with request URIs
+	// Handle BPP/BAP routing with request URIs.
+	// Both legacy ("bpp"/"bap") and new spec v2 ("receiver"/"sender") values are accepted.
 	switch route.TargetType {
-	case targetTypeBPP:
+	case targetTypeBPP, targetTypeReceiver:
 		return handleProtocolMapping(route, bppURI, endpoint)
-	case targetTypeBAP:
+	case targetTypeBAP, targetTypeSender:
 		return handleProtocolMapping(route, bapURI, endpoint)
 	}
 	return route, nil
@@ -300,7 +306,7 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 //     catalog GET/DELETE requests through a message queue; this is allowed
 //     rather than rejected to avoid unnecessary constraint, but operators
 //     should not configure publisher targets for bodyless endpoints.
-//   - bpp / bap: rejected — the target URI is read from the request body,
+//   - bpp / bap / receiver / sender: rejected — the target URI is read from the request body,
 //     which is absent for bodyless requests.
 func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 	v2Rules, ok := r.rules["*"]
@@ -313,7 +319,8 @@ func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 		if !ok {
 			continue
 		}
-		if route.TargetType == targetTypeBPP || route.TargetType == targetTypeBAP {
+		if route.TargetType == targetTypeBPP || route.TargetType == targetTypeBAP ||
+			route.TargetType == targetTypeReceiver || route.TargetType == targetTypeSender {
 			return nil, fmt.Errorf("bodyless endpoint '%s' (version %s) is configured with target type '%s': dynamic BAP/BPP URI routing is not supported for bodyless requests", endpoint, version, route.TargetType)
 		}
 		return route, nil

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -319,8 +319,8 @@ func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 		if !ok {
 			continue
 		}
-		if route.TargetType == targetTypeBPP || route.TargetType == targetTypeBAP ||
-			route.TargetType == targetTypeReceiver || route.TargetType == targetTypeSender {
+		switch route.TargetType {
+		case targetTypeBPP, targetTypeBAP, targetTypeReceiver, targetTypeSender:
 			return nil, fmt.Errorf("bodyless endpoint '%s' (version %s) is configured with target type '%s': dynamic BAP/BPP URI routing is not supported for bodyless requests", endpoint, version, route.TargetType)
 		}
 		return route, nil
@@ -329,12 +329,27 @@ func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 	return nil, fmt.Errorf("endpoint '%s' is not supported in v2 routing config", endpoint)
 }
 
+// canonicalRoleName returns a stable, human-readable role label for use in error
+// messages regardless of which targetType alias ("bpp"/"receiver", "bap"/"sender")
+// was used in the routing config.
+func canonicalRoleName(targetType string) string {
+	switch targetType {
+	case targetTypeBPP, targetTypeReceiver:
+		return "BPP"
+	case targetTypeBAP, targetTypeSender:
+		return "BAP"
+	default:
+		return strings.ToUpper(targetType)
+	}
+}
+
 // handleProtocolMapping handles both BPP and BAP routing with proper URL construction
 func handleProtocolMapping(route *model.Route, npURI, endpoint string) (*model.Route, error) {
 	target := strings.TrimSpace(npURI)
+	role := canonicalRoleName(route.TargetType)
 	if len(target) == 0 {
 		if route.URL == nil {
-			return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, strings.ToUpper(route.TargetType))
+			return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, role)
 		}
 		return &model.Route{
 			TargetType: targetTypeURL,
@@ -343,7 +358,7 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint string) (*model.R
 	}
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", strings.ToUpper(route.TargetType), target, endpoint, err)
+		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
 	}
 	targetURL.Path = joinPath(targetURL, endpoint)
 	return &model.Route{

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -978,6 +978,18 @@ func TestRouteBodyless(t *testing.T) {
 			wantErr:        "dynamic BAP/BPP URI routing is not supported for bodyless requests",
 		},
 		{
+			name:           "spec v2: bodyless to receiver target type returns error",
+			configFile:     "v2_catalog_receiver.yaml",
+			endpointAction: "catalog/subscription",
+			wantErr:        "dynamic BAP/BPP URI routing is not supported for bodyless requests",
+		},
+		{
+			name:           "spec v2: bodyless to sender target type returns error",
+			configFile:     "v2_catalog_sender.yaml",
+			endpointAction: "catalog/subscription",
+			wantErr:        "dynamic BAP/BPP URI routing is not supported for bodyless requests",
+		},
+		{
 			name:           "bodyless request with no v2 rules returns error",
 			configFile:     "bpp_receiver.yaml",
 			endpointAction: "catalog/subscription",

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -482,6 +482,32 @@ func TestRouteSuccess(t *testing.T) {
 			endpointAction: "on_select",
 			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bapUri": "https://bap1.example.com"}}`,
 		},
+		// Beckn spec v2: receiverUri / senderUri context fields
+		{
+			name:           "spec v2: receiverUri in context is resolved for bpp routing",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "receiverUri": "https://receiver.example.com"}}`,
+		},
+		{
+			name:           "spec v2: senderUri in context is resolved for bap routing",
+			configFile:     "bpp_caller.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "senderUri": "https://sender.example.com"}}`,
+		},
+		// Beckn spec v2: targetType "receiver" and "sender" values in routing config
+		{
+			name:           "spec v2: targetType receiver routes to receiverUri",
+			configFile:     "bap_caller_v2names.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "receiverUri": "https://receiver.example.com"}}`,
+		},
+		{
+			name:           "spec v2: targetType sender routes to senderUri",
+			configFile:     "bpp_caller_v2names.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "senderUri": "https://sender.example.com"}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -765,58 +791,72 @@ func TestV2ConflictingRules(t *testing.T) {
 	}
 }
 
-// TestGetContextString tests the dual-key lookup helper used to support both
-// snake_case (legacy) and camelCase (new beckn spec) context attribute names.
+// TestGetContextString tests the variadic key lookup helper used to support
+// snake_case (legacy), camelCase (Beckn spec v1), and the new Beckn spec v2
+// names (receiverUri / senderUri) transparently.
 func TestGetContextString(t *testing.T) {
 	tests := []struct {
-		name     string
-		ctx      map[string]interface{}
-		snakeKey string
-		camelKey string
-		want     string
+		name string
+		ctx  map[string]interface{}
+		keys []string
+		want string
 	}{
 		{
-			name:     "snake_case key present",
-			ctx:      map[string]interface{}{"bpp_uri": "https://bpp.example.com"},
-			snakeKey: "bpp_uri",
-			camelKey: "bppUri",
-			want:     "https://bpp.example.com",
+			name: "snake_case key present",
+			ctx:  map[string]interface{}{"bpp_uri": "https://bpp.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://bpp.example.com",
 		},
 		{
-			name:     "camelCase key present",
-			ctx:      map[string]interface{}{"bppUri": "https://bpp.example.com"},
-			snakeKey: "bpp_uri",
-			camelKey: "bppUri",
-			want:     "https://bpp.example.com",
+			name: "camelCase key present",
+			ctx:  map[string]interface{}{"bppUri": "https://bpp.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://bpp.example.com",
 		},
 		{
-			name:     "snake_case takes precedence when both present",
-			ctx:      map[string]interface{}{"bpp_uri": "https://snake.example.com", "bppUri": "https://camel.example.com"},
-			snakeKey: "bpp_uri",
-			camelKey: "bppUri",
-			want:     "https://snake.example.com",
+			name: "snake_case takes precedence when both present",
+			ctx:  map[string]interface{}{"bpp_uri": "https://snake.example.com", "bppUri": "https://camel.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://snake.example.com",
 		},
 		{
-			name:     "neither key present returns empty string",
-			ctx:      map[string]interface{}{"domain": "ONDC:TRV10"},
-			snakeKey: "bpp_uri",
-			camelKey: "bppUri",
-			want:     "",
+			name: "neither key present returns empty string",
+			ctx:  map[string]interface{}{"domain": "ONDC:TRV10"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "",
 		},
 		{
-			name:     "empty snake_case value falls through to camelCase",
-			ctx:      map[string]interface{}{"bpp_uri": "", "bppUri": "https://bpp.example.com"},
-			snakeKey: "bpp_uri",
-			camelKey: "bppUri",
-			want:     "https://bpp.example.com",
+			name: "empty snake_case value falls through to camelCase",
+			ctx:  map[string]interface{}{"bpp_uri": "", "bppUri": "https://bpp.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://bpp.example.com",
+		},
+		// Beckn spec v2: receiverUri / senderUri
+		{
+			name: "spec v2: receiverUri resolved when legacy keys absent",
+			ctx:  map[string]interface{}{"receiverUri": "https://receiver.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://receiver.example.com",
+		},
+		{
+			name: "spec v2: senderUri resolved when legacy keys absent",
+			ctx:  map[string]interface{}{"senderUri": "https://sender.example.com"},
+			keys: []string{"bap_uri", "bapUri", "senderUri"},
+			want: "https://sender.example.com",
+		},
+		{
+			name: "spec v2: camelCase bppUri takes precedence over receiverUri",
+			ctx:  map[string]interface{}{"bppUri": "https://camel.example.com", "receiverUri": "https://receiver.example.com"},
+			keys: []string{"bpp_uri", "bppUri", "receiverUri"},
+			want: "https://camel.example.com",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getContextString(tt.ctx, tt.snakeKey, tt.camelKey)
+			got := getContextString(tt.ctx, tt.keys...)
 			if got != tt.want {
-				t.Errorf("getContextString(%v, %q, %q) = %q, want %q", tt.ctx, tt.snakeKey, tt.camelKey, got, tt.want)
+				t.Errorf("getContextString(%v, %v) = %q, want %q", tt.ctx, tt.keys, got, tt.want)
 			}
 		})
 	}

--- a/pkg/plugin/implementation/router/testData/bap_caller_v2names.yaml
+++ b/pkg/plugin/implementation/router/testData/bap_caller_v2names.yaml
@@ -1,0 +1,17 @@
+routingRules:
+  - domain: ONDC:TRV10
+    version: 1.1.0
+    targetType: receiver
+    target:
+      url: https://gateway.example.com
+    endpoints:
+      - search
+  - domain: ONDC:TRV10
+    version: 1.1.0
+    targetType: receiver
+    endpoints:
+      - select
+      - init
+      - confirm
+      - status
+      - cancel

--- a/pkg/plugin/implementation/router/testData/bpp_caller_v2names.yaml
+++ b/pkg/plugin/implementation/router/testData/bpp_caller_v2names.yaml
@@ -10,3 +10,4 @@ routingRules:
       - on_status
       - on_update
       - on_cancel
+

--- a/pkg/plugin/implementation/router/testData/bpp_caller_v2names.yaml
+++ b/pkg/plugin/implementation/router/testData/bpp_caller_v2names.yaml
@@ -1,0 +1,12 @@
+routingRules:
+  - domain: ONDC:TRV10
+    version: 1.1.0
+    targetType: sender
+    endpoints:
+      - on_search
+      - on_select
+      - on_init
+      - on_confirm
+      - on_status
+      - on_update
+      - on_cancel

--- a/pkg/plugin/implementation/router/testData/v2_catalog_receiver.yaml
+++ b/pkg/plugin/implementation/router/testData/v2_catalog_receiver.yaml
@@ -1,0 +1,5 @@
+routingRules:
+  - version: 2.0.0
+    targetType: receiver
+    endpoints:
+      - catalog/subscription

--- a/pkg/plugin/implementation/router/testData/v2_catalog_sender.yaml
+++ b/pkg/plugin/implementation/router/testData/v2_catalog_sender.yaml
@@ -1,0 +1,5 @@
+routingRules:
+  - version: 2.0.0
+    targetType: sender
+    endpoints:
+      - catalog/subscription


### PR DESCRIPTION
Closes #758

## Summary

Adds backward-compatible support for the Beckn Protocol spec v2 context field rename across three plugins. All existing field names continue to work — new names are resolved as additional fallbacks, so no existing BAP/BPP integrations break.

- **`reqpreprocessor`** — extends `firstNonNil` chains to resolve `senderId` (as BAP subscriber ID) and `receiverId` (as BPP subscriber ID) alongside legacy `bap_id`/`bapId` and `bpp_id`/`bppId`
- **`router`** — adds `targetType: "sender"` and `targetType: "receiver"` as spec v2 aliases for `"bap"` and `"bpp"` in routing config; extends URI lookup to also try `senderUri`/`receiverUri` in the request context; refactors `getContextString` to variadic to cleanly support three key variants
- **`opapolicychecker`** — makes the internal `get()` helper variadic; adds `senderId`/`receiverId` as third fallbacks when populating `BAPID`/`BPPID` in `parsedRequestContext`

## Files changed

| File | Change |
|---|---|
| `reqpreprocessor/reqpreprocessor.go` | Extend `firstNonNil` fallback chains |
| `router/router.go` | New constants, variadic `getContextString`, extended switch/guard branches |
| `opapolicychecker/enforcer.go` | Variadic `get()`, new fallback keys |
| `reqpreprocessor/reqpreprocessor_test.go` | 3 new test cases for spec v2 field names and precedence |
| `router/router_test.go` | Updated `TestGetContextString` to variadic; 4 new `TestRouteSuccess` cases |
| `opapolicychecker/enforcer_test.go` | New `TestParseRequestContext_SenderReceiverIDs` |
| `opapolicychecker/benchmark_test.go` | New fields added to benchmark fixture |
| `router/testData/bap_caller_v2names.yaml` | New test routing config with `targetType: "receiver"` |
| `router/testData/bpp_caller_v2names.yaml` | New test routing config with `targetType: "sender"` |

## Migration note

The `targetType: "bpp"` → `"receiver"` and `targetType: "bap"` → `"sender"` rename in routing config YAML files is **not required yet** — both old and new values are accepted. Operator config migration can happen independently and will be tracked separately before the old values are deprecated.

## Test plan

- [x] All existing tests pass unchanged (backward compat verified)
- [x] New `senderId`/`receiverId` resolved correctly in reqpreprocessor for both BAP and BPP roles
- [x] `senderUri`/`receiverUri` resolved correctly in router URI lookup
- [x] `targetType: "sender"` and `targetType: "receiver"` route correctly in router
- [x] `senderId`/`receiverId` populate `BAPID`/`BPPID` in OPA enforcer
- [x] Precedence order verified: `bap_id` > `bapId` > `senderId` (legacy always wins)
- [x] Full test suite: `go test ./...` — all packages `ok`