### PR TITLE
fix: migrate manifest YAML fields and registry metadata keys to camelCase

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -42,10 +42,10 @@ const (
 
 // NetworkManifest is the typed YAML schema for a network-manifest document.
 type NetworkManifest struct {
-	ManifestVersion string                    `yaml:"manifest_version"`
-	ManifestType    string                    `yaml:"manifest_type"`
-	NetworkID       string                    `yaml:"network_id"`
-	ReleaseID       any                       `yaml:"release_id"`
+	ManifestVersion string                    `yaml:"manifestVersion"`
+	ManifestType    string                    `yaml:"manifestType"`
+	NetworkID       string                    `yaml:"networkId"`
+	ReleaseID       any                       `yaml:"releaseId"`
 	Publisher       NetworkManifestPublisher  `yaml:"publisher"`
 	Policies        *NetworkManifestPolicies  `yaml:"policies"`
 	Governance      NetworkManifestGovernance `yaml:"governance"`
@@ -69,25 +69,25 @@ type NetworkManifestPolicies struct {
 type NetworkManifestBundle struct {
 	ID                       string `yaml:"id"`
 	URL                      string `yaml:"url"`
-	PolicyQueryPath          string `yaml:"policy_query_path"`
+	PolicyQueryPath          string `yaml:"policyQueryPath"`
 	Signed                   bool   `yaml:"signed"`
-	SigningPublicKeyLookupURL string `yaml:"signing_public_key_lookup_url"`
+	SigningPublicKeyLookupURL string `yaml:"signingPublicKeyLookupUrl"`
 }
 
 // NetworkManifestFile describes a single Rego policy artifact.
 type NetworkManifestFile struct {
 	ID                       string `yaml:"id"`
 	URL                      string `yaml:"url"`
-	PolicyQueryPath          string `yaml:"policy_query_path"`
+	PolicyQueryPath          string `yaml:"policyQueryPath"`
 	Signed                   bool   `yaml:"signed"`
-	SignatureURL             string `yaml:"signature_url"`
-	SigningPublicKeyLookupURL string `yaml:"signing_public_key_lookup_url"`
+	SignatureURL             string `yaml:"signatureUrl"`
+	SigningPublicKeyLookupURL string `yaml:"signingPublicKeyLookupUrl"`
 }
 
 // NetworkManifestGovernance describes validity and signature metadata.
 type NetworkManifestGovernance struct {
-	EffectiveFrom  string `yaml:"effective_from"`
-	EffectiveUntil string `yaml:"effective_until"`
+	EffectiveFrom  string `yaml:"effectiveFrom"`
+	EffectiveUntil string `yaml:"effectiveUntil"`
 	Signed         *bool  `yaml:"signed"`
 }
 
@@ -106,19 +106,19 @@ func (m *NetworkManifest) Validate(expectedNetworkID string, now time.Time) erro
 		return fmt.Errorf("manifest for network %q cannot be nil", expectedNetworkID)
 	}
 	if strings.TrimSpace(m.ManifestVersion) == "" {
-		return fmt.Errorf("manifest for network %q is missing manifest_version", expectedNetworkID)
+		return fmt.Errorf("manifest for network %q is missing manifestVersion", expectedNetworkID)
 	}
 	if m.ManifestType != NetworkManifestType {
-		return fmt.Errorf("manifest for network %q must have manifest_type=\"network-manifest\"", expectedNetworkID)
+		return fmt.Errorf("manifest for network %q must have manifestType=\"network-manifest\"", expectedNetworkID)
 	}
 	if m.NetworkID == "" {
-		return fmt.Errorf("manifest for network %q is missing network_id", expectedNetworkID)
+		return fmt.Errorf("manifest for network %q is missing networkId", expectedNetworkID)
 	}
 	if m.NetworkID != expectedNetworkID {
-		return fmt.Errorf("manifest network_id %q does not match configured network %q", m.NetworkID, expectedNetworkID)
+		return fmt.Errorf("manifest networkId %q does not match configured network %q", m.NetworkID, expectedNetworkID)
 	}
 	if m.ReleaseID == nil || strings.TrimSpace(fmt.Sprintf("%v", m.ReleaseID)) == "" {
-		return fmt.Errorf("manifest for network %q is missing release_id", expectedNetworkID)
+		return fmt.Errorf("manifest for network %q is missing releaseId", expectedNetworkID)
 	}
 	if strings.TrimSpace(m.Publisher.Role) == "" || strings.TrimSpace(m.Publisher.Domain) == "" {
 		return fmt.Errorf("manifest for network %q must include publisher.role and publisher.domain", expectedNetworkID)
@@ -135,7 +135,7 @@ func (m *NetworkManifest) Validate(expectedNetworkID string, now time.Time) erro
 
 	effectiveFrom, err := time.Parse(time.RFC3339, m.Governance.EffectiveFrom)
 	if err != nil {
-		return fmt.Errorf("manifest for network %q has invalid governance.effective_from: %w", expectedNetworkID, err)
+		return fmt.Errorf("manifest for network %q has invalid governance.effectiveFrom: %w", expectedNetworkID, err)
 	}
 	if now.Before(effectiveFrom) {
 		return fmt.Errorf("manifest for network %q is not active until %s", expectedNetworkID, effectiveFrom.Format(time.RFC3339))
@@ -144,10 +144,10 @@ func (m *NetworkManifest) Validate(expectedNetworkID string, now time.Time) erro
 	if m.Governance.EffectiveUntil != "" {
 		effectiveUntil, err := time.Parse(time.RFC3339, m.Governance.EffectiveUntil)
 		if err != nil {
-			return fmt.Errorf("manifest for network %q has invalid governance.effective_until: %w", expectedNetworkID, err)
+			return fmt.Errorf("manifest for network %q has invalid governance.effectiveUntil: %w", expectedNetworkID, err)
 		}
 		if !effectiveUntil.After(effectiveFrom) {
-			return fmt.Errorf("manifest for network %q must have governance.effective_until later than governance.effective_from", expectedNetworkID)
+			return fmt.Errorf("manifest for network %q must have governance.effectiveUntil later than governance.effectiveFrom", expectedNetworkID)
 		}
 		if now.After(effectiveUntil) {
 			return fmt.Errorf("manifest for network %q expired at %s", expectedNetworkID, effectiveUntil.Format(time.RFC3339))
@@ -168,7 +168,7 @@ func (m *NetworkManifest) Validate(expectedNetworkID string, now time.Time) erro
 			return fmt.Errorf("manifest for network %q is missing required policies.bundle fields", expectedNetworkID)
 		}
 		if m.Policies.Bundle.Signed && strings.TrimSpace(m.Policies.Bundle.SigningPublicKeyLookupURL) == "" {
-			return fmt.Errorf("manifest for network %q requires policies.bundle.signing_public_key_lookup_url when policies.bundle.signed=true", expectedNetworkID)
+			return fmt.Errorf("manifest for network %q requires policies.bundle.signingPublicKeyLookupUrl when policies.bundle.signed=true", expectedNetworkID)
 		}
 	case PolicySourceFile:
 		if m.Policies.File == nil {
@@ -184,10 +184,10 @@ func (m *NetworkManifest) Validate(expectedNetworkID string, now time.Time) erro
 		}
 		if m.Policies.File.Signed {
 			if strings.TrimSpace(m.Policies.File.SignatureURL) == "" {
-				return fmt.Errorf("manifest for network %q requires policies.file.signature_url when policies.file.signed=true", expectedNetworkID)
+				return fmt.Errorf("manifest for network %q requires policies.file.signatureUrl when policies.file.signed=true", expectedNetworkID)
 			}
 			if strings.TrimSpace(m.Policies.File.SigningPublicKeyLookupURL) == "" {
-				return fmt.Errorf("manifest for network %q requires policies.file.signing_public_key_lookup_url when policies.file.signed=true", expectedNetworkID)
+				return fmt.Errorf("manifest for network %q requires policies.file.signingPublicKeyLookupUrl when policies.file.signed=true", expectedNetworkID)
 			}
 		}
 	default:

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -54,7 +54,7 @@ func TestValidateNetworkManifest(t *testing.T) {
 			mutate: func(manifest *NetworkManifest) {
 				manifest.ManifestType = "other"
 			},
-			wantErrSub: `must have manifest_type="network-manifest"`,
+			wantErrSub: `must have manifestType="network-manifest"`,
 		},
 		{
 			name: "missing policies section",
@@ -75,7 +75,7 @@ func TestValidateNetworkManifest(t *testing.T) {
 			mutate: func(manifest *NetworkManifest) {
 				manifest.Governance.EffectiveUntil = "not-a-timestamp"
 			},
-			wantErrSub: "invalid governance.effective_until",
+			wantErrSub: "invalid governance.effectiveUntil",
 		},
 		{
 			name: "expired manifest",
@@ -97,7 +97,7 @@ func TestValidateNetworkManifest(t *testing.T) {
 			mutate: func(manifest *NetworkManifest) {
 				manifest.Policies.File.SignatureURL = ""
 			},
-			wantErrSub: "requires policies.file.signature_url",
+			wantErrSub: "requires policies.file.signatureUrl",
 		},
 		{
 			name: "signed bundle missing public key lookup",
@@ -111,7 +111,7 @@ func TestValidateNetworkManifest(t *testing.T) {
 					Signed:          true,
 				}
 			},
-			wantErrSub: "requires policies.bundle.signing_public_key_lookup_url",
+			wantErrSub: "requires policies.bundle.signingPublicKeyLookupUrl",
 		},
 	}
 

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -568,9 +568,9 @@ func TestLookupRegistry(t *testing.T) {
 				"data": map[string]interface{}{
 					"registry_name": "mobility-network",
 					"meta": map[string]interface{}{
-						"manifest_url":                  "https://example.org/manifest.yaml",
-						"manifest_signature_url":        "https://example.org/manifest.yaml.sig",
-						"signing_public_key_lookup_url": "https://example.org/keys/manifest",
+						"manifestUrl":                  "https://example.org/manifest.yaml",
+						"manifestSignatureUrl":        "https://example.org/manifest.yaml.sig",
+						"signingPublicKeyLookupUrl": "https://example.org/keys/manifest",
 					},
 				},
 			}
@@ -597,7 +597,7 @@ func TestLookupRegistry(t *testing.T) {
 		if got.RegistryName != "mobility-network" {
 			t.Fatalf("expected RegistryName %q, got %q", "mobility-network", got.RegistryName)
 		}
-		if got.RawMeta["manifest_url"] != "https://example.org/manifest.yaml" {
+		if got.RawMeta["manifestUrl"] != "https://example.org/manifest.yaml" {
 			t.Fatalf("expected manifest_url metadata to be preserved")
 		}
 	})
@@ -632,7 +632,7 @@ func TestLookupRegistry(t *testing.T) {
 			response := map[string]interface{}{
 				"data": map[string]interface{}{
 					"meta": map[string]interface{}{
-						"manifest_url":   "https://example.org/manifest.yaml",
+						"manifestUrl":   "https://example.org/manifest.yaml",
 						"non_string_key": true,
 					},
 				},

--- a/pkg/plugin/implementation/manifestloader/README.md
+++ b/pkg/plugin/implementation/manifestloader/README.md
@@ -36,7 +36,7 @@ Supported config keys:
 
 ## Verification payloads
 
-- `manifest_signature_url` may return raw detached signature bytes, base64-encoded signature text, or JSON with a top-level `signature` field.
+- `manifestSignatureUrl` may return raw detached signature bytes, base64-encoded signature text, or JSON with a top-level `signature` field.
 - Signing public key lookup JSON is read only from supported fields: `data.details.publicKey`, `data.details.signing_public_key`, `data.details.public_key`, or legacy top-level `publicKey`, `signing_public_key`, and `public_key`.
 - Public key fields in arbitrary nested JSON locations are ignored.
 

--- a/pkg/plugin/implementation/manifestloader/manifestloader.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader.go
@@ -291,23 +291,23 @@ func metadataFromRegistry(meta *model.RegistryMetadata, skipSig bool) (model.Man
 		return model.ManifestMetadata{}, fmt.Errorf("registry metadata cannot be nil")
 	}
 	result := model.ManifestMetadata{
-		ManifestURL:               meta.RawMeta["manifest_url"],
-		ManifestSignatureURL:      meta.RawMeta["manifest_signature_url"],
-		SigningPublicKeyLookupURL: meta.RawMeta["signing_public_key_lookup_url"],
+		ManifestURL:               meta.RawMeta["manifestUrl"],
+		ManifestSignatureURL:      meta.RawMeta["manifestSignatureUrl"],
+		SigningPublicKeyLookupURL: meta.RawMeta["signingPublicKeyLookupUrl"],
 	}
 	return result, validateMetadata(result, skipSig)
 }
 
 func validateMetadata(metadata model.ManifestMetadata, skipSig bool) error {
 	if strings.TrimSpace(metadata.ManifestURL) == "" {
-		return fmt.Errorf("manifest_url missing in metadata")
+		return fmt.Errorf("manifestUrl missing in metadata")
 	}
 	if !skipSig {
 		if strings.TrimSpace(metadata.ManifestSignatureURL) == "" {
-			return fmt.Errorf("manifest_signature_url missing in metadata")
+			return fmt.Errorf("manifestSignatureUrl missing in metadata")
 		}
 		if strings.TrimSpace(metadata.SigningPublicKeyLookupURL) == "" {
-			return fmt.Errorf("signing_public_key_lookup_url missing in metadata")
+			return fmt.Errorf("signingPublicKeyLookupUrl missing in metadata")
 		}
 	}
 	return nil

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -195,9 +195,9 @@ func TestGetByNetworkIDResolvesMetadata(t *testing.T) {
 			NamespaceIdentifier: "nfo.example.org",
 			RegistryName:        "network",
 			RawMeta: map[string]string{
-				"manifest_url":                  "https://example.org/manifest",
-				"manifest_signature_url":        "https://example.org/manifest.sig",
-				"signing_public_key_lookup_url": "https://example.org/pubkey",
+				"manifestUrl":                  "https://example.org/manifest",
+				"manifestSignatureUrl":        "https://example.org/manifest.sig",
+				"signingPublicKeyLookupUrl": "https://example.org/pubkey",
 			},
 		},
 	}
@@ -292,9 +292,9 @@ func TestGetByNetworkID_CacheWriteErrorStillReturnsManifest(t *testing.T) {
 			NamespaceIdentifier: "nfo.example.org",
 			RegistryName:        "network",
 			RawMeta: map[string]string{
-				"manifest_url":                  "https://example.org/manifest",
-				"manifest_signature_url":        "https://example.org/manifest.sig",
-				"signing_public_key_lookup_url": "https://example.org/pubkey",
+				"manifestUrl":                  "https://example.org/manifest",
+				"manifestSignatureUrl":        "https://example.org/manifest.sig",
+				"signingPublicKeyLookupUrl": "https://example.org/pubkey",
 			},
 		},
 	}
@@ -473,9 +473,9 @@ func TestGetByNetworkID_DisableCacheBypassesAndDoesNotStore(t *testing.T) {
 			NamespaceIdentifier: "nfo.example.org",
 			RegistryName:        "network",
 			RawMeta: map[string]string{
-				"manifest_url":                  "https://example.org/manifest",
-				"manifest_signature_url":        "https://example.org/manifest.sig",
-				"signing_public_key_lookup_url": "https://example.org/pubkey",
+				"manifestUrl":                  "https://example.org/manifest",
+				"manifestSignatureUrl":        "https://example.org/manifest.sig",
+				"signingPublicKeyLookupUrl": "https://example.org/pubkey",
 			},
 		},
 	}
@@ -537,9 +537,9 @@ func TestGetByNetworkID_ForceRefreshOnStartBypassesOnce(t *testing.T) {
 			NamespaceIdentifier: "nfo.example.org",
 			RegistryName:        "network",
 			RawMeta: map[string]string{
-				"manifest_url":                  metadata.ManifestURL,
-				"manifest_signature_url":        metadata.ManifestSignatureURL,
-				"signing_public_key_lookup_url": metadata.SigningPublicKeyLookupURL,
+				"manifestUrl":                  metadata.ManifestURL,
+				"manifestSignatureUrl":        metadata.ManifestSignatureURL,
+				"signingPublicKeyLookupUrl": metadata.SigningPublicKeyLookupURL,
 			},
 		},
 	}
@@ -640,7 +640,7 @@ func TestGetByNetworkID_SkipSignatureVerification(t *testing.T) {
 			NamespaceIdentifier: "nfo.example.org",
 			RegistryName:        "network",
 			RawMeta: map[string]string{
-				"manifest_url": "https://example.org/manifest",
+				"manifestUrl": "https://example.org/manifest",
 			},
 		},
 	}

--- a/pkg/plugin/implementation/opapolicychecker/README.md
+++ b/pkg/plugin/implementation/opapolicychecker/README.md
@@ -537,7 +537,7 @@ The patterns above are about how the engine sees your policy. The practices belo
 ### Maintainability
 
 - Ship `*_test.rego` next to every policy file. Run `opa test . -v` in CI for the bundle.
-- Version policies explicitly. Use `release_id` in the network manifest and bump it on every change so participants can see which policy version they are enforcing.
+- Version policies explicitly. Use `releaseId` in the network manifest and bump it on every change so participants can see which policy version they are enforcing.
 - Sign every bundle. Unsigned policies are not safe to fetch from any URL the adapter does not control — see [Signature Verification](#signature-verification).
 - Document the input contract at the top of the policy file. List the Beckn fields the policy relies on; that doc is what changes when the underlying message schema changes.
 - Keep policy artifacts at immutable URLs whenever possible. Mutable URLs work (the plugin will pick up changes on hot reload), but they are harder to audit.
@@ -547,7 +547,7 @@ The patterns above are about how the engine sees your policy. The practices belo
 
 ## Publishing Policies as a Network Facilitator
 
-A Network Facilitator Organization (NFO) publishes policies that every participant on a given `network_id` then enforces locally via this plugin. The end-to-end flow is owned by NFH Fabric documentation; this section covers the build / sign / publish steps and points at the authoritative source for the rest.
+A Network Facilitator Organization (NFO) publishes policies that every participant on a given `networkId` then enforces locally via this plugin. The end-to-end flow is owned by NFH Fabric documentation; this section covers the build / sign / publish steps and points at the authoritative source for the rest.
 
 **Authoritative reference:** [Configuring Network Policies — docs.nfh.global](https://docs.nfh.global/beckn/creating-an-open-network/configuring-network-policies)
 
@@ -561,7 +561,7 @@ A Network Facilitator Organization (NFO) publishes policies that every participa
 6. Publish the verifying public key in DeDi.
 7. Reference the bundle, signature, and key in a network manifest published by the NFO.
 8. Publish the manifest URL, manifest signature URL, and key lookup URL as metadata on the NFO's network registry in DeDi.
-9. Participants configure `type: manifest` keyed by `network_id` — the plugin resolves the manifest, verifies the signature chain, and loads the bundle.
+9. Participants configure `type: manifest` keyed by `networkId` — the plugin resolves the manifest, verifies the signature chain, and loads the bundle.
 
 The plugin sits at step 9. Everything above it is NFO operational work; the plugin assumes it has been done correctly and treats anything missing or unverifiable as a hard failure.
 
@@ -622,19 +622,19 @@ In your DeDi namespace, create a public key registry with the Public Key schema.
 - `keyFormat`: `base64`
 - `publicKey`: the Base64-encoded contents of `public.pem` excluding the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` lines
 
-Once the record is live, copy its lookup URL. That URL goes into the bundle's `signing_public_key_lookup_url` on the network manifest, and (mirrored) into `verification.publicKeyLookupUrl` if a participant configures `type: file` or `type: bundle` directly. With `type: manifest`, the plugin reads it from the manifest automatically.
+Once the record is live, copy its lookup URL. That URL goes into the bundle's `signingPublicKeyLookupUrl` on the network manifest, and (mirrored) into `verification.publicKeyLookupUrl` if a participant configures `type: file` or `type: bundle` directly. With `type: manifest`, the plugin reads it from the manifest automatically.
 
 ### Publishing the bundle and referencing it from a manifest
 
-Host the bundle at a stable URL — GitHub releases, object storage, or a CDN. Immutable per-release URLs are recommended (`/releases/v1.2.0/retail.tar.gz`); mutable latest URLs also work, in which case bump `release_id` in the manifest on every change.
+Host the bundle at a stable URL — GitHub releases, object storage, or a CDN. Immutable per-release URLs are recommended (`/releases/v1.2.0/retail.tar.gz`); mutable latest URLs also work, in which case bump `releaseId` in the manifest on every change.
 
 A minimal manifest:
 
 ```yaml
-manifest_version: "1.0"
-manifest_type: "network-manifest"
-network_id: "nfo.com/production"
-release_id: "2026.05"
+manifestVersion: "1.0"
+manifestType: "network-manifest"
+networkId: "nfo.com/production"
+releaseId: "2026.05"
 
 publisher:
   role: "NFO"
@@ -646,13 +646,13 @@ policies:
   bundle:
     id: "retail-policy-bundle"
     url: "https://nfo.example.org/policies/retail-bundle.tar.gz"
-    policy_query_path: "data.retail.result"
+    policyQueryPath: "data.retail.result"
     signed: true
-    signing_public_key_lookup_url: "https://api.dedi.global/dedi/lookup/example-nfo.com/public_key/retail-key"
+    signingPublicKeyLookupUrl: "https://api.dedi.global/dedi/lookup/example-nfo.com/public_key/retail-key"
 
 governance:
-  effective_from: "2026-05-15T00:00:00Z"
-  effective_until: "2027-05-15T00:00:00Z"
+  effectiveFrom: "2026-05-15T00:00:00Z"
+  effectiveUntil: "2027-05-15T00:00:00Z"
   signed: true
 ```
 
@@ -684,8 +684,8 @@ Participants can also stand the plugin up directly against a local bundle to smo
 
 Two supported flows:
 
-- **New version.** Build a new bundle at a new immutable URL. Update the manifest. Bump `release_id`. This is the recommended default.
-- **In-place at the same URL.** Update the bundle at the existing URL. Bump `release_id` in the manifest so participants see the change. The plugin's hot reload (`refreshInterval`) will pick up the new bundle without an adapter restart, subject to manifest cache TTL.
+- **New version.** Build a new bundle at a new immutable URL. Update the manifest. Bump `releaseId`. This is the recommended default.
+- **In-place at the same URL.** Update the bundle at the existing URL. Bump `releaseId` in the manifest so participants see the change. The plugin's hot reload (`refreshInterval`) will pick up the new bundle without an adapter restart, subject to manifest cache TTL.
 
 For the in-place flow, ensure `manifestloader.cacheTTL` is short enough relative to the policy refresh cadence you want to support, or use `disableCache` while debugging.
 
@@ -732,17 +732,17 @@ All fields below are validated by the adapter at startup and on every hot-reload
 
 | Field | Required value / constraint |
 |---|---|
-| `manifest_version` | Non-empty string |
-| `manifest_type` | `"network-manifest"` |
-| `network_id` | Must match the network policy config key exactly |
-| `release_id` | Non-empty (any scalar) |
+| `manifestVersion` | Non-empty string |
+| `manifestType` | `"network-manifest"` |
+| `networkId` | Must match the network policy config key exactly |
+| `releaseId` | Non-empty (any scalar) |
 | `publisher.role` | Non-empty string |
 | `publisher.domain` | Non-empty string |
 | `policies.type` | `"rego"` |
 | `policies.source` | `"file"` or `"bundle"` |
 | `governance.signed` | Must be present (boolean) |
-| `governance.effective_from` | ISO 8601 timestamp; must be in the past |
-| `governance.effective_until` | Optional; if present, must be after `effective_from` and not expired |
+| `governance.effectiveFrom` | ISO 8601 timestamp; must be in the past |
+| `governance.effectiveUntil` | Optional; if present, must be after `effectiveFrom` and not expired |
 
 **When `policies.source: bundle`**
 
@@ -750,9 +750,9 @@ All fields below are validated by the adapter at startup and on every hot-reload
 |---|---|
 | `policies.bundle.id` | Non-empty string |
 | `policies.bundle.url` | URL to the `.tar.gz` bundle |
-| `policies.bundle.policy_query_path` | OPA query path (e.g. `data.policy.result`) |
+| `policies.bundle.policyQueryPath` | OPA query path (e.g. `data.policy.result`) |
 | `policies.bundle.signed` | Boolean; when `true`, the field below is also required |
-| `policies.bundle.signing_public_key_lookup_url` | Required when `policies.bundle.signed: true` |
+| `policies.bundle.signingPublicKeyLookupUrl` | Required when `policies.bundle.signed: true` |
 
 `policies.file` must **not** be present when `policies.source: bundle`.
 
@@ -762,10 +762,10 @@ All fields below are validated by the adapter at startup and on every hot-reload
 |---|---|
 | `policies.file.id` | Non-empty string |
 | `policies.file.url` | URL to the `.rego` file |
-| `policies.file.policy_query_path` | OPA query path (e.g. `data.policy.result`) |
+| `policies.file.policyQueryPath` | OPA query path (e.g. `data.policy.result`) |
 | `policies.file.signed` | Boolean; when `true`, the two fields below are also required |
-| `policies.file.signature_url` | Required when `policies.file.signed: true` |
-| `policies.file.signing_public_key_lookup_url` | Required when `policies.file.signed: true` |
+| `policies.file.signatureUrl` | Required when `policies.file.signed: true` |
+| `policies.file.signingPublicKeyLookupUrl` | Required when `policies.file.signed: true` |
 
 `policies.bundle` must **not** be present when `policies.source: file`.
 

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -83,7 +83,7 @@ func writeDefaultOnlyNetworkPolicyConfig(t *testing.T, entry string) string {
 }
 
 func validManifestGovernanceYAML() string {
-	return fmt.Sprintf("governance:\n  effective_from: %q\n  effective_until: %q\n  signed: true\n",
+	return fmt.Sprintf("governance:\n  effectiveFrom: %q\n  effectiveUntil: %q\n  signed: true\n",
 		time.Now().UTC().Add(-1*time.Hour).Format(time.RFC3339),
 		time.Now().UTC().Add(1*time.Hour).Format(time.RFC3339),
 	)
@@ -1791,10 +1791,10 @@ result := {"valid": false, "violations": ["missing provider"]} if {
 	defer server.Close()
 
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/production"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/production"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -1804,10 +1804,10 @@ result := {"valid": false, "violations": ["missing provider"]} if {
 		`  file:`,
 		`    id: "network-policy-file"`,
 		`    url: "` + server.URL + `/policy.rego"`,
-		`    policy_query_path: "data.policy.result"`,
+		`    policyQueryPath: "data.policy.result"`,
 		`    signed: true`,
-		`    signature_url: "` + server.URL + `/policy.rego.sig"`,
-		`    signing_public_key_lookup_url: "` + server.URL + `/public.pem"`,
+		`    signatureUrl: "`+ server.URL + `/policy.rego.sig"`,
+		`    signingPublicKeyLookupUrl: "`+ server.URL + `/public.pem"`,
 		strings.TrimSuffix(validManifestGovernanceYAML(), "\n"),
 	}, "\n") + "\n"
 
@@ -1860,10 +1860,10 @@ result := {"valid": false, "violations": ["bundle blocked"]} if {
 	defer server.Close()
 
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/production"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/production"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -1873,7 +1873,7 @@ result := {"valid": false, "violations": ["bundle blocked"]} if {
 		`  bundle:`,
 		`    id: "network-policy-bundle"`,
 		`    url: "` + server.URL + `/policy-bundle.tar.gz"`,
-		`    policy_query_path: "data.retail.policy.result"`,
+		`    policyQueryPath: "data.retail.policy.result"`,
 		`    signed: false`,
 		strings.TrimSuffix(validManifestGovernanceYAML(), "\n"),
 	}, "\n") + "\n"
@@ -1916,10 +1916,10 @@ networkPolicies:
 
 func TestEnforcer_ManifestPolicyMissingPoliciesSection(t *testing.T) {
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/production"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/production"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -1944,10 +1944,10 @@ networkPolicies:
 
 func TestEnforcer_ManifestPolicyUnsupportedSource(t *testing.T) {
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/production"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/production"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -1975,10 +1975,10 @@ networkPolicies:
 
 func TestEnforcer_ManifestPolicyNetworkMismatch(t *testing.T) {
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/sandbox"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/sandbox"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -1988,7 +1988,7 @@ func TestEnforcer_ManifestPolicyNetworkMismatch(t *testing.T) {
 		`  file:`,
 		`    id: "network-policy-file"`,
 		`    url: "https://example.org/policy.rego"`,
-		`    policy_query_path: "data.policy.result"`,
+		`    policyQueryPath: "data.policy.result"`,
 		`    signed: false`,
 		strings.TrimSuffix(validManifestGovernanceYAML(), "\n"),
 	}, "\n") + "\n"
@@ -2011,10 +2011,10 @@ networkPolicies:
 
 func TestEnforcer_ManifestPolicyExpired(t *testing.T) {
 	manifest := strings.Join([]string{
-		`manifest_version: "1.0"`,
-		`manifest_type: "network-manifest"`,
-		`network_id: "retail.network/production"`,
-		`release_id: "2026.04"`,
+		`manifestVersion: "1.0"`,
+		`manifestType: "network-manifest"`,
+		`networkId: "retail.network/production"`,
+		`releaseId: "2026.04"`,
 		`publisher:`,
 		`  role: "NFO"`,
 		`  domain: "example.org"`,
@@ -2024,9 +2024,9 @@ func TestEnforcer_ManifestPolicyExpired(t *testing.T) {
 		`  file:`,
 		`    id: "network-policy-file"`,
 		`    url: "https://example.org/policy.rego"`,
-		`    policy_query_path: "data.policy.result"`,
+		`    policyQueryPath: "data.policy.result"`,
 		`    signed: false`,
-		fmt.Sprintf("governance:\n  effective_from: %q\n  effective_until: %q\n  signed: true\n",
+		fmt.Sprintf("governance:\n  effectiveFrom: %q\n  effectiveUntil: %q\n  signed: true\n",
 			time.Now().UTC().Add(-2*time.Hour).Format(time.RFC3339),
 			time.Now().UTC().Add(-1*time.Hour).Format(time.RFC3339),
 		),


### PR DESCRIPTION
## Summary

The network manifest YAML schema and registry metadata keys currently use `snake_case` field names. This causes a silent failure when manifest files are written in camelCase — `gopkg.in/yaml.v3` performs exact-match key lookups with no case normalization, so mismatched keys are silently ignored and required fields appear missing, causing validation to fail with confusing errors.

## Problem

`gopkg.in/yaml.v3` resolves struct fields strictly by their `yaml:"..."` tag. A manifest file written with camelCase keys (e.g. `manifestVersion`) does **not** match a tag of `manifest_version` — the field is silently zeroed out and `Validate()` then reports it as missing.

Version 2 of the protocol uses camelCase. This makes the implementation in line with the version 2 updates. 

## Changes

### Manifest YAML schema (`pkg/model/manifest.go`)
Updated `yaml` struct tags from snake_case to camelCase:

| Old | New |
|-----|-----|
| `manifest_version` | `manifestVersion` |
| `manifest_type` | `manifestType` |
| `network_id` | `networkId` |
| `release_id` | `releaseId` |
| `policy_query_path` | `policyQueryPath` |
| `effective_from` | `effectiveFrom` |
| `effective_until` | `effectiveUntil` |
| `signature_url` | `signatureUrl` |
| `signing_public_key_lookup_url` | `signingPublicKeyLookupUrl` |

Validation error messages updated to reference the new field names.

### Registry metadata keys (`pkg/plugin/implementation/manifestloader/manifestloader.go`)
Keys read from the registry `meta` object updated to camelCase:

| Old | New |
|-----|-----|
| `manifest_url` | `manifestUrl` |
| `manifest_signature_url` | `manifestSignatureUrl` |
| `signing_public_key_lookup_url` | `signingPublicKeyLookupUrl` |

> **Note:** This is a breaking change for the registry server — the `meta` object it returns must also use the new camelCase keys.

### Tests
All inline manifest YAML strings and registry metadata fixture maps updated accordingly across:
- `pkg/model/manifest_test.go`
- `pkg/plugin/implementation/opapolicychecker/enforcer_test.go`
- `pkg/plugin/implementation/manifestloader/manifestloader_test.go`
- `pkg/plugin/implementation/dediregistry/dediregistry_test.go`

## What is not changing
- `ManifestDocument` JSON tags — internal cache representation, not user-facing
- Plugin config keys (`cacheTTL`, `fetchTimeoutSeconds`, etc.) — handler configuration, not manifest content
- Constant values like `"network-manifest"` — values, not keys
