### PR TITLE
feat(router): resolve BPP/BAP URL via DeDi registry NodeID lookup

### DIFF
--- a/cmd/adapter/main_test.go
+++ b/cmd/adapter/main_test.go
@@ -50,7 +50,7 @@ func (m *MockPluginManager) Validator(ctx context.Context, cfg *plugin.Config) (
 }
 
 // Router returns a mock implementation of the Router interface.
-func (m *MockPluginManager) Router(ctx context.Context, cfg *plugin.Config) (definition.Router, error) {
+func (m *MockPluginManager) Router(ctx context.Context, _ definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 

--- a/cmd/adapter/main_test.go
+++ b/cmd/adapter/main_test.go
@@ -50,7 +50,7 @@ func (m *MockPluginManager) Validator(ctx context.Context, cfg *plugin.Config) (
 }
 
 // Router returns a mock implementation of the Router interface.
-func (m *MockPluginManager) Router(ctx context.Context, _ definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error) {
+func (m *MockPluginManager) Router(ctx context.Context, _ definition.RegistryLookup, cfg *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -16,7 +16,7 @@ type PluginManager interface {
 	Middleware(ctx context.Context, cfg *plugin.Config) (func(http.Handler) http.Handler, error)
 	SignValidator(ctx context.Context, cfg *plugin.Config) (definition.SignValidator, error)
 	Validator(ctx context.Context, cfg *plugin.Config) (definition.SchemaValidator, error)
-	Router(ctx context.Context, registry definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error)
+	Router(ctx context.Context, registry definition.RegistryLookup, cfg *plugin.Config) (definition.Router, error)
 	Publisher(ctx context.Context, cfg *plugin.Config) (definition.Publisher, error)
 	Signer(ctx context.Context, cfg *plugin.Config) (definition.Signer, error)
 	Step(ctx context.Context, cfg *plugin.Config) (definition.Step, error)

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -16,7 +16,7 @@ type PluginManager interface {
 	Middleware(ctx context.Context, cfg *plugin.Config) (func(http.Handler) http.Handler, error)
 	SignValidator(ctx context.Context, cfg *plugin.Config) (definition.SignValidator, error)
 	Validator(ctx context.Context, cfg *plugin.Config) (definition.SchemaValidator, error)
-	Router(ctx context.Context, cfg *plugin.Config) (definition.Router, error)
+	Router(ctx context.Context, registry definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error)
 	Publisher(ctx context.Context, cfg *plugin.Config) (definition.Publisher, error)
 	Signer(ctx context.Context, cfg *plugin.Config) (definition.Signer, error)
 	Step(ctx context.Context, cfg *plugin.Config) (definition.Step, error)

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -412,24 +412,14 @@ func loadKeyManager(ctx context.Context, mgr PluginManager, cache definition.Cac
 	return km, nil
 }
 
-// loadRouter initialises the Router plugin, optionally wiring a RegistryMetadataLookup
-// for NodeID-based URL resolution. If the configured registry plugin does not implement
-// RegistryMetadataLookup (e.g. standard registry), the router starts without it and falls
-// back to URI-from-payload and default-URL routing only.
+// loadRouter initialises the Router plugin, optionally wiring a RegistryLookup
+// for NodeID-based URL resolution fallback.
 func loadRouter(ctx context.Context, mgr PluginManager, registry definition.RegistryLookup, cfg *plugin.Config) (definition.Router, error) {
 	if cfg == nil {
 		log.Debug(ctx, "Skipping Router plugin: not configured")
 		return nil, nil
 	}
-	var metadataLookup definition.RegistryMetadataLookup
-	if registry != nil {
-		if ml, ok := registry.(definition.RegistryMetadataLookup); ok {
-			metadataLookup = ml
-		} else {
-			log.Debug(ctx, "Router: registry plugin does not implement RegistryMetadataLookup; NodeID-based URL resolution will not be available")
-		}
-	}
-	r, err := mgr.Router(ctx, metadataLookup, cfg)
+	r, err := mgr.Router(ctx, registry, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load Router plugin (%s): %w", cfg.ID, err)
 	}

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -412,6 +412,31 @@ func loadKeyManager(ctx context.Context, mgr PluginManager, cache definition.Cac
 	return km, nil
 }
 
+// loadRouter initialises the Router plugin, optionally wiring a RegistryMetadataLookup
+// for NodeID-based URL resolution. If the configured registry plugin does not implement
+// RegistryMetadataLookup (e.g. standard registry), the router starts without it and falls
+// back to URI-from-payload and default-URL routing only.
+func loadRouter(ctx context.Context, mgr PluginManager, registry definition.RegistryLookup, cfg *plugin.Config) (definition.Router, error) {
+	if cfg == nil {
+		log.Debug(ctx, "Skipping Router plugin: not configured")
+		return nil, nil
+	}
+	var metadataLookup definition.RegistryMetadataLookup
+	if registry != nil {
+		if ml, ok := registry.(definition.RegistryMetadataLookup); ok {
+			metadataLookup = ml
+		} else {
+			log.Debug(ctx, "Router: registry plugin does not implement RegistryMetadataLookup; NodeID-based URL resolution will not be available")
+		}
+	}
+	r, err := mgr.Router(ctx, metadataLookup, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Router plugin (%s): %w", cfg.ID, err)
+	}
+	log.Debugf(ctx, "Loaded Router plugin: %s", cfg.ID)
+	return r, nil
+}
+
 func loadManifestLoader(ctx context.Context, mgr PluginManager, cache definition.Cache, registry definition.RegistryLookup, cfg *plugin.Config) (definition.ManifestLoader, error) {
 	if cfg == nil {
 		log.Debug(ctx, "Skipping ManifestLoader plugin: not configured")
@@ -508,7 +533,7 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 	if h.schemaValidator, err = loadPlugin(ctx, "SchemaValidator", cfg.SchemaValidator, mgr.SchemaValidator); err != nil {
 		return err
 	}
-	if h.router, err = loadPlugin(ctx, "Router", cfg.Router, mgr.Router); err != nil {
+	if h.router, err = loadRouter(ctx, mgr, h.registry, cfg.Router); err != nil {
 		return err
 	}
 	if h.publisher, err = loadPlugin(ctx, "Publisher", cfg.Publisher, mgr.Publisher); err != nil {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -125,7 +125,7 @@ func (noopPluginManager) SignValidator(context.Context, *plugin.Config) (definit
 func (noopPluginManager) Validator(context.Context, *plugin.Config) (definition.SchemaValidator, error) {
 	return nil, nil
 }
-func (noopPluginManager) Router(context.Context, definition.RegistryMetadataLookup, *plugin.Config) (definition.Router, error) {
+func (noopPluginManager) Router(context.Context, definition.RegistryLookup, *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 func (noopPluginManager) Publisher(context.Context, *plugin.Config) (definition.Publisher, error) {
@@ -166,6 +166,10 @@ type registryWithoutMetadata struct{}
 
 func (registryWithoutMetadata) Lookup(context.Context, *model.Subscription) ([]model.Subscription, error) {
 	return nil, errors.New("not implemented")
+}
+
+func (registryWithoutMetadata) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode not supported (nodeID: %s)", nodeID)
 }
 
 type stubCache struct{}

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -125,7 +125,7 @@ func (noopPluginManager) SignValidator(context.Context, *plugin.Config) (definit
 func (noopPluginManager) Validator(context.Context, *plugin.Config) (definition.SchemaValidator, error) {
 	return nil, nil
 }
-func (noopPluginManager) Router(context.Context, *plugin.Config) (definition.Router, error) {
+func (noopPluginManager) Router(context.Context, definition.RegistryMetadataLookup, *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 func (noopPluginManager) Publisher(context.Context, *plugin.Config) (definition.Publisher, error) {

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -37,7 +37,7 @@ func (m *mockPluginManager) Validator(ctx context.Context, cfg *plugin.Config) (
 }
 
 // Router returns a mock router implementation.
-func (m *mockPluginManager) Router(ctx context.Context, cfg *plugin.Config) (definition.Router, error) {
+func (m *mockPluginManager) Router(ctx context.Context, _ definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -37,7 +37,7 @@ func (m *mockPluginManager) Validator(ctx context.Context, cfg *plugin.Config) (
 }
 
 // Router returns a mock router implementation.
-func (m *mockPluginManager) Router(ctx context.Context, _ definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.Router, error) {
+func (m *mockPluginManager) Router(ctx context.Context, _ definition.RegistryLookup, cfg *plugin.Config) (definition.Router, error) {
 	return nil, nil
 }
 

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -11,7 +11,7 @@ type RegistryLookup interface {
 	Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error)
 
 	// LookupNode looks up a subscriber record by its fully-qualified NodeID.
-	// nodeID must be in namespace/registry/recordId format (exactly 3 non-empty parts separated by "/").
+	// nodeID must be in namespace/registry/recordName format (exactly 3 non-empty parts separated by "/").
 	// Returns the subscriber's Subscription including URL, type, and domain.
 	LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error)
 }

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -9,16 +9,18 @@ import (
 type RegistryLookup interface {
 	// Lookup looks up a registry entry to obtain public keys to validate the signature of the incoming message.
 	Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error)
+}
+
+// RegistryMetadataLookup fetches metadata from the DeDi registry at both the registry and
+// subscriber record level. It is implemented by DeDi-backed registry plugins only.
+type RegistryMetadataLookup interface {
+	// LookupRegistry fetches registry-level metadata for the given namespace/registry path.
+	LookupRegistry(ctx context.Context, namespaceIdentifier, registryName string) (*model.RegistryMetadata, error)
 
 	// LookupNode looks up a subscriber record by its fully-qualified NodeID.
 	// nodeID must be in namespace/registry/recordName format (exactly 3 non-empty parts separated by "/").
 	// Returns the subscriber's Subscription including URL, type, and domain.
 	LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error)
-}
-
-// RegistryMetadataLookup fetches registry-level metadata without addressing a specific record.
-type RegistryMetadataLookup interface {
-	LookupRegistry(ctx context.Context, namespaceIdentifier, registryName string) (*model.RegistryMetadata, error)
 }
 
 // RegistryLookupProvider initializes a new registry lookup instance.

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -7,8 +7,13 @@ import (
 )
 
 type RegistryLookup interface {
-	// looks up Registry entry to obtain public keys to validate signature of the incoming message
+	// Lookup looks up a registry entry to obtain public keys to validate the signature of the incoming message.
 	Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error)
+
+	// LookupNode looks up a subscriber record by its fully-qualified NodeID.
+	// nodeID must be in namespace/registry/recordId format (exactly 3 non-empty parts separated by "/").
+	// Returns the subscriber's Subscription including URL, type, and domain.
+	LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error)
 }
 
 // RegistryMetadataLookup fetches registry-level metadata without addressing a specific record.

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -9,18 +9,18 @@ import (
 type RegistryLookup interface {
 	// Lookup looks up a registry entry to obtain public keys to validate the signature of the incoming message.
 	Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error)
-}
-
-// RegistryMetadataLookup fetches metadata from the DeDi registry at both the registry and
-// subscriber record level. It is implemented by DeDi-backed registry plugins only.
-type RegistryMetadataLookup interface {
-	// LookupRegistry fetches registry-level metadata for the given namespace/registry path.
-	LookupRegistry(ctx context.Context, namespaceIdentifier, registryName string) (*model.RegistryMetadata, error)
 
 	// LookupNode looks up a subscriber record by its fully-qualified NodeID.
 	// nodeID must be in namespace/registry/recordName format (exactly 3 non-empty parts separated by "/").
 	// Returns the subscriber's Subscription including URL, type, and domain.
+	// Implementations backed by the standard Beckn registry should return an appropriate error.
 	LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error)
+}
+
+// RegistryMetadataLookup fetches registry-level metadata for a DeDi registry path.
+type RegistryMetadataLookup interface {
+	// LookupRegistry fetches registry-level metadata for the given namespace/registry path.
+	LookupRegistry(ctx context.Context, namespaceIdentifier, registryName string) (*model.RegistryMetadata, error)
 }
 
 // RegistryLookupProvider initializes a new registry lookup instance.

--- a/pkg/plugin/definition/router.go
+++ b/pkg/plugin/definition/router.go
@@ -8,8 +8,9 @@ import (
 )
 
 // RouterProvider initializes the a new Router instance with the given config.
+// registry is optional; when provided it enables NodeID-based URL resolution fallback.
 type RouterProvider interface {
-	New(ctx context.Context, config map[string]string) (Router, func() error, error)
+	New(ctx context.Context, registry RegistryMetadataLookup, config map[string]string) (Router, func() error, error)
 }
 
 // Router defines the interface for routing requests.

--- a/pkg/plugin/definition/router.go
+++ b/pkg/plugin/definition/router.go
@@ -10,7 +10,7 @@ import (
 // RouterProvider initializes the a new Router instance with the given config.
 // registry is optional; when provided it enables NodeID-based URL resolution fallback.
 type RouterProvider interface {
-	New(ctx context.Context, registry RegistryMetadataLookup, config map[string]string) (Router, func() error, error)
+	New(ctx context.Context, registry RegistryLookup, config map[string]string) (Router, func() error, error)
 }
 
 // Router defines the interface for routing requests.

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
@@ -245,6 +247,64 @@ func (c *DeDiRegistryClient) LookupRegistry(ctx context.Context, namespaceIdenti
 		RegistryName:        registryName,
 		RawMeta:             meta,
 	}, nil
+}
+
+// LookupNode looks up a subscriber record by its fully-qualified NodeID.
+// nodeID must be in namespace/registry/recordId format (exactly 3 non-empty parts separated by "/").
+// Returns the subscriber's Subscription including URL, type, and domain.
+func (c *DeDiRegistryClient) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
+	parts := strings.Split(nodeID, "/")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, fmt.Errorf("nodeID %q must be in namespace/registry/recordId format with 3 non-empty parts", nodeID)
+	}
+
+	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL,
+		url.PathEscape(parts[0]), url.PathEscape(parts[1]), url.PathEscape(parts[2]))
+
+	data, err := c.fetchDeDiData(ctx, lookupURL, "node lookup")
+	if err != nil {
+		return nil, err
+	}
+
+	details, ok := data["details"].(map[string]any)
+	if !ok {
+		log.Errorf(ctx, nil, "Invalid DeDi response format: missing or invalid details field")
+		return nil, fmt.Errorf("invalid response format: missing details field")
+	}
+
+	detailsURL, _ := details["url"].(string)
+	detailsType, _ := details["type"].(string)
+	detailsDomain, _ := details["domain"].(string)
+	detailsSubscriberID, _ := details["subscriber_id"].(string)
+
+	// Validate network memberships if configured.
+	networkMemberships := extractStringSlice(ctx, "network_memberships", data["network_memberships"])
+	if len(c.config.AllowedNetworkIDs) > 0 {
+		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
+			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
+		}
+	}
+
+	signingPublicKey, _ := details["signing_public_key"].(string)
+	encrPublicKey, _ := details["encr_public_key"].(string)
+	createdAt, _ := data["created_at"].(string)
+	updatedAt, _ := data["updated_at"].(string)
+
+	subscription := &model.Subscription{
+		Subscriber: model.Subscriber{
+			SubscriberID: detailsSubscriberID,
+			URL:          detailsURL,
+			Domain:       detailsDomain,
+			Type:         detailsType,
+		},
+		SigningPublicKey: signingPublicKey,
+		EncrPublicKey:   encrPublicKey,
+		Created:         parseTime(createdAt),
+		Updated:         parseTime(updatedAt),
+	}
+
+	log.Debugf(ctx, "DeDi node lookup successful for nodeID: %s, subscriber: %s, url: %s", nodeID, detailsSubscriberID, detailsURL)
+	return subscription, nil
 }
 
 // parseTime converts string timestamp to time.Time

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -131,9 +131,56 @@ func (c *DeDiRegistryClient) fetchDeDiData(ctx context.Context, url, operation s
 	return data, nil
 }
 
+// parseSubscriptionFromData extracts a Subscription from a DeDi response data map.
+// It is shared by Lookup and LookupNode to avoid duplicating response-parsing logic.
+// When requireSigningKey is true, the function returns an error if signing_public_key
+// is absent — this is required for signature validation flows (Lookup) but not for
+// URL resolution flows (LookupNode).
+func (c *DeDiRegistryClient) parseSubscriptionFromData(ctx context.Context, data map[string]any, requireSigningKey bool) (*model.Subscription, error) {
+	details, ok := data["details"].(map[string]any)
+	if !ok {
+		log.Errorf(ctx, nil, "Invalid DeDi response format: missing or invalid details field")
+		return nil, fmt.Errorf("invalid response format: missing details field")
+	}
+
+	signingPublicKey, _ := details["signing_public_key"].(string)
+	if requireSigningKey && signingPublicKey == "" {
+		return nil, fmt.Errorf("invalid or missing signing_public_key in response")
+	}
+
+	detailsURL, _ := details["url"].(string)
+	detailsType, _ := details["type"].(string)
+	detailsDomain, _ := details["domain"].(string)
+	detailsSubscriberID, _ := details["subscriber_id"].(string)
+
+	// Validate network memberships if configured.
+	networkMemberships := extractStringSlice(ctx, "network_memberships", data["network_memberships"])
+	if len(c.config.AllowedNetworkIDs) > 0 {
+		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
+			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
+		}
+	}
+
+	encrPublicKey, _ := details["encr_public_key"].(string)
+	createdAt, _ := data["created_at"].(string)
+	updatedAt, _ := data["updated_at"].(string)
+
+	return &model.Subscription{
+		Subscriber: model.Subscriber{
+			SubscriberID: detailsSubscriberID,
+			URL:          detailsURL,
+			Domain:       detailsDomain,
+			Type:         detailsType,
+		},
+		SigningPublicKey: signingPublicKey,
+		EncrPublicKey:   encrPublicKey,
+		Created:         parseTime(createdAt),
+		Updated:         parseTime(updatedAt),
+	}, nil
+}
+
 // Lookup implements RegistryLookup interface - calls the DeDi wrapper lookup endpoint and returns Subscription.
 func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error) {
-	// Extract subscriber ID and key ID from request (both come from Authorization header parsing)
 	subscriberID := req.SubscriberID
 	keyID := req.KeyID
 	log.Infof(ctx, "DeDi Registry: Looking up subscriber ID: %s, key ID: %s", subscriberID, keyID)
@@ -153,56 +200,14 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 
 	log.Debugf(ctx, "DeDi lookup request successful, parsing response")
 
-	details, ok := data["details"].(map[string]any)
-	if !ok {
-		log.Errorf(ctx, nil, "Invalid DeDi response format: missing or invalid details field")
-		return nil, fmt.Errorf("invalid response format: missing details field")
+	subscription, err := c.parseSubscriptionFromData(ctx, data, true)
+	if err != nil {
+		return nil, err
 	}
+	subscription.KeyID = keyID
 
-	// Extract required fields from details
-	signingPublicKey, ok := details["signing_public_key"].(string)
-	if !ok || signingPublicKey == "" {
-		return nil, fmt.Errorf("invalid or missing signing_public_key in response")
-	}
-
-	// Extract fields from details
-	detailsURL, _ := details["url"].(string)
-	detailsType, _ := details["type"].(string)
-	detailsDomain, _ := details["domain"].(string)
-	detailsSubscriberID, _ := details["subscriber_id"].(string)
-
-	// Validate network memberships if configured.
-	networkMemberships := extractStringSlice(ctx, "network_memberships", data["network_memberships"])
-	if len(c.config.AllowedNetworkIDs) > 0 {
-		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
-			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
-		}
-	}
-
-	// Extract encr_public_key if available (optional field)
-	encrPublicKey, _ := details["encr_public_key"].(string)
-
-	// Extract fields from data level
-	createdAt, _ := data["created_at"].(string)
-	updatedAt, _ := data["updated_at"].(string)
-
-	// Convert to Subscription format
-	subscription := model.Subscription{
-		Subscriber: model.Subscriber{
-			SubscriberID: detailsSubscriberID,
-			URL:          detailsURL,
-			Domain:       detailsDomain,
-			Type:         detailsType,
-		},
-		KeyID:            keyID, // Use original keyID from request
-		SigningPublicKey: signingPublicKey,
-		EncrPublicKey:    encrPublicKey, // May be empty if not provided
-		Created:          parseTime(createdAt),
-		Updated:          parseTime(updatedAt),
-	}
-
-	log.Debugf(ctx, "DeDi lookup successful, found subscription for subscriber: %s", detailsSubscriberID)
-	return []model.Subscription{subscription}, nil
+	log.Debugf(ctx, "DeDi lookup successful, found subscription for subscriber: %s", subscription.SubscriberID)
+	return []model.Subscription{*subscription}, nil
 }
 
 // LookupRegistry fetches registry-level metadata for the given DeDi registry path.
@@ -250,12 +255,12 @@ func (c *DeDiRegistryClient) LookupRegistry(ctx context.Context, namespaceIdenti
 }
 
 // LookupNode looks up a subscriber record by its fully-qualified NodeID.
-// nodeID must be in namespace/registry/recordId format (exactly 3 non-empty parts separated by "/").
+// nodeID must be in namespace/registry/recordName format (exactly 3 non-empty parts separated by "/").
 // Returns the subscriber's Subscription including URL, type, and domain.
 func (c *DeDiRegistryClient) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
 	parts := strings.Split(nodeID, "/")
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-		return nil, fmt.Errorf("nodeID %q must be in namespace/registry/recordId format with 3 non-empty parts", nodeID)
+		return nil, fmt.Errorf("nodeID %q must be in namespace/registry/recordName format with 3 non-empty parts", nodeID)
 	}
 
 	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL,
@@ -266,44 +271,12 @@ func (c *DeDiRegistryClient) LookupNode(ctx context.Context, nodeID string) (*mo
 		return nil, err
 	}
 
-	details, ok := data["details"].(map[string]any)
-	if !ok {
-		log.Errorf(ctx, nil, "Invalid DeDi response format: missing or invalid details field")
-		return nil, fmt.Errorf("invalid response format: missing details field")
+	subscription, err := c.parseSubscriptionFromData(ctx, data, false)
+	if err != nil {
+		return nil, err
 	}
 
-	detailsURL, _ := details["url"].(string)
-	detailsType, _ := details["type"].(string)
-	detailsDomain, _ := details["domain"].(string)
-	detailsSubscriberID, _ := details["subscriber_id"].(string)
-
-	// Validate network memberships if configured.
-	networkMemberships := extractStringSlice(ctx, "network_memberships", data["network_memberships"])
-	if len(c.config.AllowedNetworkIDs) > 0 {
-		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
-			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
-		}
-	}
-
-	signingPublicKey, _ := details["signing_public_key"].(string)
-	encrPublicKey, _ := details["encr_public_key"].(string)
-	createdAt, _ := data["created_at"].(string)
-	updatedAt, _ := data["updated_at"].(string)
-
-	subscription := &model.Subscription{
-		Subscriber: model.Subscriber{
-			SubscriberID: detailsSubscriberID,
-			URL:          detailsURL,
-			Domain:       detailsDomain,
-			Type:         detailsType,
-		},
-		SigningPublicKey: signingPublicKey,
-		EncrPublicKey:   encrPublicKey,
-		Created:         parseTime(createdAt),
-		Updated:         parseTime(updatedAt),
-	}
-
-	log.Debugf(ctx, "DeDi node lookup successful for nodeID: %s, subscriber: %s, url: %s", nodeID, detailsSubscriberID, detailsURL)
+	log.Debugf(ctx, "DeDi node lookup successful for nodeID: %s, subscriber: %s, url: %s", nodeID, subscription.SubscriberID, subscription.URL)
 	return subscription, nil
 }
 

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -615,7 +615,7 @@ func TestLookupNode(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for invalid nodeID format, got nil")
 		}
-		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+		if !strings.Contains(err.Error(), "namespace/registry/recordName format") {
 			t.Errorf("expected format error, got: %v", err)
 		}
 	})
@@ -631,7 +631,7 @@ func TestLookupNode(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for 2-part nodeID, got nil")
 		}
-		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+		if !strings.Contains(err.Error(), "namespace/registry/recordName format") {
 			t.Errorf("expected format error, got: %v", err)
 		}
 	})
@@ -647,7 +647,7 @@ func TestLookupNode(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for empty part in nodeID, got nil")
 		}
-		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+		if !strings.Contains(err.Error(), "namespace/registry/recordName format") {
 			t.Errorf("expected format error, got: %v", err)
 		}
 	})

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -547,6 +548,189 @@ func TestLookup(t *testing.T) {
 		_, err = client.Lookup(ctx, req)
 		if err == nil {
 			t.Error("Expected network error, got nil")
+		}
+	})
+}
+
+func TestLookupNode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful node lookup returns subscription with URL", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("Expected GET request, got %s", r.Method)
+			}
+			if r.URL.Path != "/dedi/lookup/nfo.example.org/retail-net/abc123" {
+				t.Errorf("Unexpected path: %s", r.URL.Path)
+			}
+			response := map[string]interface{}{
+				"message": "Record retrieved from registry cache",
+				"data": map[string]interface{}{
+					"details": map[string]interface{}{
+						"url":                "https://bpp.example.com/beckn",
+						"type":               "BPP",
+						"domain":             "retail",
+						"subscriber_id":      "nfo.example.org/retail-net/abc123",
+						"signing_public_key": "384qqkIIpxo71WaJPsWqQNWUDGAFnfnJPxuDmtuBiLo=",
+					},
+					"network_memberships": []string{"commerce-network.org/prod"},
+					"created_at":          "2025-10-27T11:45:27.963Z",
+					"updated_at":          "2025-10-27T11:46:23.563Z",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client, closer, err := New(ctx, &Config{URL: server.URL + "/dedi"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		sub, err := client.LookupNode(ctx, "nfo.example.org/retail-net/abc123")
+		if err != nil {
+			t.Fatalf("LookupNode() error = %v", err)
+		}
+		if sub.URL != "https://bpp.example.com/beckn" {
+			t.Errorf("expected URL %q, got %q", "https://bpp.example.com/beckn", sub.URL)
+		}
+		if sub.Type != "BPP" {
+			t.Errorf("expected Type %q, got %q", "BPP", sub.Type)
+		}
+		if sub.Domain != "retail" {
+			t.Errorf("expected Domain %q, got %q", "retail", sub.Domain)
+		}
+	})
+
+	t.Run("invalid nodeID format - only 1 part", func(t *testing.T) {
+		client, closer, err := New(ctx, &Config{URL: "https://test.example.com"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "plainid")
+		if err == nil {
+			t.Fatal("expected error for invalid nodeID format, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+			t.Errorf("expected format error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid nodeID format - only 2 parts", func(t *testing.T) {
+		client, closer, err := New(ctx, &Config{URL: "https://test.example.com"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "nfo.example.org/retail-net")
+		if err == nil {
+			t.Fatal("expected error for 2-part nodeID, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+			t.Errorf("expected format error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid nodeID format - empty part", func(t *testing.T) {
+		client, closer, err := New(ctx, &Config{URL: "https://test.example.com"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "nfo.example.org//abc123")
+		if err == nil {
+			t.Fatal("expected error for empty part in nodeID, got nil")
+		}
+		if !strings.Contains(err.Error(), "namespace/registry/recordId format") {
+			t.Errorf("expected format error, got: %v", err)
+		}
+	})
+
+	t.Run("http error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+
+		client, closer, err := New(ctx, &Config{URL: server.URL + "/dedi"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "nfo.example.org/retail-net/abc123")
+		if err == nil {
+			t.Fatal("expected error for 404 response, got nil")
+		}
+	})
+
+	t.Run("missing details field in response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := map[string]interface{}{
+				"data": map[string]interface{}{
+					"record_id": "abc123",
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client, closer, err := New(ctx, &Config{URL: server.URL + "/dedi"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "nfo.example.org/retail-net/abc123")
+		if err == nil {
+			t.Fatal("expected error for missing details field, got nil")
+		}
+		if !strings.Contains(err.Error(), "missing details field") {
+			t.Errorf("expected missing details error, got: %v", err)
+		}
+	})
+
+	t.Run("network membership mismatch returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := map[string]interface{}{
+				"data": map[string]interface{}{
+					"details": map[string]interface{}{
+						"url":                "https://bpp.example.com",
+						"type":               "BPP",
+						"subscriber_id":      "abc123",
+						"signing_public_key": "key",
+					},
+					"network_memberships": []string{"other-network.org/prod"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client, closer, err := New(ctx, &Config{
+			URL:               server.URL + "/dedi",
+			AllowedNetworkIDs: []string{"commerce-network.org/prod"},
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.LookupNode(ctx, "nfo.example.org/retail-net/abc123")
+		if err == nil {
+			t.Fatal("expected error for network membership mismatch, got nil")
+		}
+		if !strings.Contains(err.Error(), "does not belong to any configured networks") {
+			t.Errorf("expected network membership error, got: %v", err)
 		}
 	})
 }

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -287,6 +287,8 @@ func (km *KeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyset, erro
 }
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
+// When subscriberID is in namespace/registry/recordName format (3-part NodeID), it uses LookupNode
+// to resolve the record directly via the DeDi registry path. Otherwise it falls back to the standard Lookup.
 func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
 	cacheKey := fmt.Sprintf("%s_%s", subscriberID, uniqueKeyID)
 	cachedData, err := km.Cache.Get(ctx, cacheKey)
@@ -296,19 +298,33 @@ func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID st
 			return keys.SigningPublic, keys.EncrPublic, nil
 		}
 	}
-	subscribers, err := km.Registry.Lookup(ctx, &model.Subscription{
-		Subscriber: model.Subscriber{
-			SubscriberID: subscriberID,
-		},
-		KeyID: uniqueKeyID,
-	})
-	if err != nil {
-		return "", "", fmt.Errorf("failed to lookup registry: %w", err)
+
+	var signingKey, encrKey string
+	if parts := strings.Split(subscriberID, "/"); len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+		// 3-part NodeID — resolve directly via DeDi node lookup.
+		subscription, err := km.Registry.LookupNode(ctx, subscriberID)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to lookup registry node: %w", err)
+		}
+		signingKey = subscription.SigningPublicKey
+		encrKey = subscription.EncrPublicKey
+	} else {
+		subscribers, err := km.Registry.Lookup(ctx, &model.Subscription{
+			Subscriber: model.Subscriber{
+				SubscriberID: subscriberID,
+			},
+			KeyID: uniqueKeyID,
+		})
+		if err != nil {
+			return "", "", fmt.Errorf("failed to lookup registry: %w", err)
+		}
+		if len(subscribers) == 0 {
+			return "", "", ErrSubscriberNotFound
+		}
+		signingKey = subscribers[0].SigningPublicKey
+		encrKey = subscribers[0].EncrPublicKey
 	}
-	if len(subscribers) == 0 {
-		return "", "", ErrSubscriberNotFound
-	}
-	return subscribers[0].SigningPublicKey, subscribers[0].EncrPublicKey, nil
+	return signingKey, encrKey, nil
 }
 
 // validateParams checks that subscriberID and uniqueKeyID are not empty.

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -25,6 +25,10 @@ type mockRegistry struct {
 	LookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
 }
 
+func (m *mockRegistry) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode not implemented in mockRegistry (nodeID: %s)", nodeID)
+}
+
 func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 	if m.LookupFunc != nil {
 		return m.LookupFunc(ctx, sub)
@@ -353,6 +357,10 @@ func TestGetVaultClient_Success(t *testing.T) {
 }
 
 type mockRegistryLookup struct{}
+
+func (m *mockRegistryLookup) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode not implemented in mockRegistryLookup (nodeID: %s)", nodeID)
+}
 
 func (m *mockRegistryLookup) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 	return []model.Subscription{

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -1069,6 +1069,107 @@ func TestLookupNPKeysSuccess(t *testing.T) {
 	}
 }
 
+func TestLookupNPKeysNodeID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("3-part NodeID uses LookupNode instead of Lookup", func(t *testing.T) {
+		lookupNodeCalled := false
+		lookupCalled := false
+
+		km := &KeyMgr{
+			Cache: &mockCache{
+				GetFunc: func(_ context.Context, _ string) (string, error) {
+					return "", fmt.Errorf("cache miss")
+				},
+			},
+			Registry: &mockRegistry{
+				LookupFunc: func(_ context.Context, _ *model.Subscription) ([]model.Subscription, error) {
+					lookupCalled = true
+					return nil, fmt.Errorf("Lookup should not be called for NodeID")
+				},
+			},
+		}
+		// Override LookupNode on the mock for this test via a wrapper.
+		nodeRegistry := &nodeIDMockRegistry{
+			lookupNodeFn: func(_ context.Context, nodeID string) (*model.Subscription, error) {
+				lookupNodeCalled = true
+				return &model.Subscription{
+					Subscriber:      model.Subscriber{SubscriberID: nodeID},
+					SigningPublicKey: "node-signing-key",
+					EncrPublicKey:   "node-encr-key",
+				}, nil
+			},
+		}
+		km.Registry = nodeRegistry
+
+		signing, encr, err := km.LookupNPKeys(ctx, "beckn.one/example-NPs/example-bpp", "any-key-id")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !lookupNodeCalled {
+			t.Error("expected LookupNode to be called for 3-part NodeID")
+		}
+		if lookupCalled {
+			t.Error("Lookup should not be called for 3-part NodeID")
+		}
+		if signing != "node-signing-key" {
+			t.Errorf("SigningPublicKey = %q, want %q", signing, "node-signing-key")
+		}
+		if encr != "node-encr-key" {
+			t.Errorf("EncrPublicKey = %q, want %q", encr, "node-encr-key")
+		}
+	})
+
+	t.Run("plain subscriber ID still uses Lookup", func(t *testing.T) {
+		lookupNodeCalled := false
+
+		nodeRegistry := &nodeIDMockRegistry{
+			lookupNodeFn: func(_ context.Context, _ string) (*model.Subscription, error) {
+				lookupNodeCalled = true
+				return nil, fmt.Errorf("LookupNode should not be called for plain ID")
+			},
+			lookupFn: func(_ context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{SigningPublicKey: "plain-signing-key", EncrPublicKey: "plain-encr-key"}}, nil
+			},
+		}
+		km := &KeyMgr{
+			Cache:    &mockCache{GetFunc: func(_ context.Context, _ string) (string, error) { return "", fmt.Errorf("miss") }},
+			Registry: nodeRegistry,
+		}
+
+		signing, _, err := km.LookupNPKeys(ctx, "plain-subscriber-id", "key-id")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lookupNodeCalled {
+			t.Error("LookupNode should not be called for plain subscriber ID")
+		}
+		if signing != "plain-signing-key" {
+			t.Errorf("SigningPublicKey = %q, want %q", signing, "plain-signing-key")
+		}
+	})
+}
+
+// nodeIDMockRegistry is a flexible mock supporting both Lookup and LookupNode control.
+type nodeIDMockRegistry struct {
+	lookupNodeFn func(ctx context.Context, nodeID string) (*model.Subscription, error)
+	lookupFn     func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
+}
+
+func (m *nodeIDMockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
+	if m.lookupNodeFn != nil {
+		return m.lookupNodeFn(ctx, nodeID)
+	}
+	return nil, fmt.Errorf("LookupNode not configured")
+}
+
+func (m *nodeIDMockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+	if m.lookupFn != nil {
+		return m.lookupFn(ctx, sub)
+	}
+	return nil, fmt.Errorf("Lookup not configured")
+}
+
 func TestLookupNPKeysFailure(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -53,6 +54,10 @@ type mockRegistry struct {
 func (m *mockRegistry) LookupRegistry(ctx context.Context, namespaceIdentifier, registryName string) (*model.RegistryMetadata, error) {
 	m.calls++
 	return m.meta, m.err
+}
+
+func (m *mockRegistry) LookupNode(_ context.Context, _ string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode not implemented in mockRegistry")
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -56,9 +55,6 @@ func (m *mockRegistry) LookupRegistry(ctx context.Context, namespaceIdentifier, 
 	return m.meta, m.err
 }
 
-func (m *mockRegistry) LookupNode(_ context.Context, _ string) (*model.Subscription, error) {
-	return nil, fmt.Errorf("LookupNode not implemented in mockRegistry")
-}
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 

--- a/pkg/plugin/implementation/manifestloader/manifestloader_test.go
+++ b/pkg/plugin/implementation/manifestloader/manifestloader_test.go
@@ -55,7 +55,6 @@ func (m *mockRegistry) LookupRegistry(ctx context.Context, namespaceIdentifier, 
 	return m.meta, m.err
 }
 
-
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/pkg/plugin/implementation/registry/registry.go
+++ b/pkg/plugin/implementation/registry/registry.go
@@ -157,6 +157,7 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 
 // LookupNode is not supported by the standard Beckn registry.
 // Use the dediregistry plugin for NodeID-based (namespace/registry/recordName) lookups.
-func (c *RegistryClient) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+func (c *RegistryClient) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
+	log.Errorf(ctx, nil, "LookupNode called on standard registry (nodeID: %s); configure dediregistry for NodeID-based lookups", nodeID)
 	return nil, fmt.Errorf("LookupNode is not supported by the standard registry (nodeID: %s); configure dediregistry for NodeID-based lookups", nodeID)
 }

--- a/pkg/plugin/implementation/registry/registry.go
+++ b/pkg/plugin/implementation/registry/registry.go
@@ -154,3 +154,9 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 	log.Debugf(ctx, "Lookup request successful, found %d subscriptions", len(results))
 	return results, nil
 }
+
+// LookupNode is not supported by the standard Beckn registry.
+// Use the dediregistry plugin for NodeID-based (namespace/registry/recordName) lookups.
+func (c *RegistryClient) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode is not supported by the standard registry (nodeID: %s); configure dediregistry for NodeID-based lookups", nodeID)
+}

--- a/pkg/plugin/implementation/router/cmd/plugin.go
+++ b/pkg/plugin/implementation/router/cmd/plugin.go
@@ -14,7 +14,7 @@ type RouterProvider struct{}
 // New initializes a new Router instance.
 // registry is an optional dependency; when provided it is used to resolve
 // subscriber URLs via NodeID lookup when no URI is present in the payload context.
-func (rp RouterProvider) New(ctx context.Context, registry definition.RegistryLookup, config map[string]string) (definition.Router, func() error, error) {
+func (rp RouterProvider) New(ctx context.Context, registry definition.RegistryMetadataLookup, config map[string]string) (definition.Router, func() error, error) {
 	if ctx == nil {
 		return nil, nil, errors.New("context cannot be nil")
 	}

--- a/pkg/plugin/implementation/router/cmd/plugin.go
+++ b/pkg/plugin/implementation/router/cmd/plugin.go
@@ -14,7 +14,7 @@ type RouterProvider struct{}
 // New initializes a new Router instance.
 // registry is an optional dependency; when provided it is used to resolve
 // subscriber URLs via NodeID lookup when no URI is present in the payload context.
-func (rp RouterProvider) New(ctx context.Context, registry definition.RegistryMetadataLookup, config map[string]string) (definition.Router, func() error, error) {
+func (rp RouterProvider) New(ctx context.Context, registry definition.RegistryLookup, config map[string]string) (definition.Router, func() error, error) {
 	if ctx == nil {
 		return nil, nil, errors.New("context cannot be nil")
 	}

--- a/pkg/plugin/implementation/router/cmd/plugin.go
+++ b/pkg/plugin/implementation/router/cmd/plugin.go
@@ -12,7 +12,9 @@ import (
 type RouterProvider struct{}
 
 // New initializes a new Router instance.
-func (rp RouterProvider) New(ctx context.Context, config map[string]string) (definition.Router, func() error, error) {
+// registry is an optional dependency; when provided it is used to resolve
+// subscriber URLs via NodeID lookup when no URI is present in the payload context.
+func (rp RouterProvider) New(ctx context.Context, registry definition.RegistryLookup, config map[string]string) (definition.Router, func() error, error) {
 	if ctx == nil {
 		return nil, nil, errors.New("context cannot be nil")
 	}
@@ -22,7 +24,7 @@ func (rp RouterProvider) New(ctx context.Context, config map[string]string) (def
 	if !ok {
 		return nil, nil, errors.New("routingConfig is required in the configuration")
 	}
-	return router.New(ctx, &router.Config{
+	return router.New(ctx, registry, &router.Config{
 		RoutingConfig: routingConfig,
 	})
 }

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -9,7 +9,9 @@ import (
 	"path"
 	"strings"
 
+	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 
 	"gopkg.in/yaml.v3"
 )
@@ -26,7 +28,8 @@ type routingConfig struct {
 
 // Router implements Router interface.
 type Router struct {
-	rules map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
+	rules    map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
+	registry definition.RegistryLookup                    // optional; used for NodeID-based URL resolution
 }
 
 // RoutingRule represents a single routing rule.
@@ -59,14 +62,17 @@ const (
 
 // New initializes a new Router instance with the provided configuration.
 // It loads and validates the routing rules from the specified YAML file.
+// registry is optional; when provided it is used to resolve subscriber URLs via NodeID lookup
+// when no URI is present in the payload context.
 // Returns an error if the configuration is invalid or the rules cannot be loaded.
-func New(ctx context.Context, config *Config) (*Router, func() error, error) {
+func New(ctx context.Context, registry definition.RegistryLookup, config *Config) (*Router, func() error, error) {
 	// Check if config is nil
 	if config == nil {
 		return nil, nil, fmt.Errorf("config cannot be nil")
 	}
 	router := &Router{
-		rules: make(map[string]map[string]map[string]*model.Route),
+		rules:    make(map[string]map[string]map[string]*model.Route),
+		registry: registry,
 	}
 
 	// Load rules at bootup
@@ -252,6 +258,8 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	}
 	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri", "receiverUri")
 	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri", "senderUri")
+	bppNodeID := getContextString(uriBody.Context, "bpp_id", "bppId", "receiverId")
+	bapNodeID := getContextString(uriBody.Context, "bap_id", "bapId", "senderId")
 
 	// For v2.x.x, ignore domain and use wildcard; for v1.x.x, use actual domain
 	domain := requestBody.Context.Domain
@@ -288,9 +296,9 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	// Both legacy ("bpp"/"bap") and new spec v2 ("receiver"/"sender") values are accepted.
 	switch route.TargetType {
 	case targetTypeBPP, targetTypeReceiver:
-		return handleProtocolMapping(route, bppURI, endpoint)
+		return handleProtocolMapping(ctx, route, bppURI, bppNodeID, endpoint, r.registry)
 	case targetTypeBAP, targetTypeSender:
-		return handleProtocolMapping(route, bapURI, endpoint)
+		return handleProtocolMapping(ctx, route, bapURI, bapNodeID, endpoint, r.registry)
 	}
 	return route, nil
 }
@@ -343,28 +351,61 @@ func canonicalRoleName(targetType string) string {
 	}
 }
 
-// handleProtocolMapping handles both BPP and BAP routing with proper URL construction
-func handleProtocolMapping(route *model.Route, npURI, endpoint string) (*model.Route, error) {
-	target := strings.TrimSpace(npURI)
+// handleProtocolMapping handles both BPP and BAP routing with proper URL construction.
+// Resolution order:
+//  1. URI from payload context (npURI) — existing behaviour.
+//  2. NodeID-based registry lookup (nodeID) — when URI is absent and a NodeID in
+//     namespace/registry/recordId format is present; requires a registry plugin.
+//  3. Default URL configured in routing rules (route.URL).
+//  4. Error — none of the above resolved a destination.
+func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryLookup) (*model.Route, error) {
 	role := canonicalRoleName(route.TargetType)
-	if len(target) == 0 {
-		if route.URL == nil {
-			return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, role)
+
+	// 1. URI present in payload — use it directly.
+	if target := strings.TrimSpace(npURI); target != "" {
+		targetURL, err := url.Parse(target)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
 		}
-		return &model.Route{
-			TargetType: targetTypeURL,
-			URL:        route.URL,
-		}, nil
+		targetURL.Path = joinPath(targetURL, endpoint)
+		return &model.Route{TargetType: targetTypeURL, URL: targetURL}, nil
 	}
-	targetURL, err := url.Parse(target)
-	if err != nil {
-		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
+
+	// 2. NodeID present — resolve URL via registry lookup.
+	if nodeID = strings.TrimSpace(nodeID); nodeID != "" {
+		// Validate 3-part format before making any network call.
+		parts := strings.Split(nodeID, "/")
+		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			log.Errorf(ctx, nil, "Router: %s nodeID '%s' for endpoint '%s' is not in namespace/registry/recordId format", role, nodeID, endpoint)
+			return nil, fmt.Errorf("could not resolve %s destination for endpoint '%s': nodeID '%s' is not in namespace/registry/recordId format", role, endpoint, nodeID)
+		}
+		if registry == nil {
+			log.Errorf(ctx, nil, "Router: %s nodeID '%s' present for endpoint '%s' but no registry plugin is configured", role, nodeID, endpoint)
+			return nil, fmt.Errorf("could not resolve %s destination for endpoint '%s': nodeID '%s' present but no registry plugin is configured", role, endpoint, nodeID)
+		}
+		subscription, err := registry.LookupNode(ctx, nodeID)
+		if err != nil {
+			log.Errorf(ctx, err, "Router: registry lookup failed for %s nodeID '%s' on endpoint '%s'", role, nodeID, endpoint)
+			return nil, fmt.Errorf("registry lookup failed for %s nodeID '%s' on endpoint '%s': %w", role, nodeID, endpoint, err)
+		}
+		if subscription.URL == "" {
+			log.Errorf(ctx, nil, "Router: registry entry for %s nodeID '%s' has no URL", role, nodeID)
+			return nil, fmt.Errorf("registry entry for %s nodeID '%s' has no URL configured", role, nodeID)
+		}
+		resolvedURL, err := url.Parse(subscription.URL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URL '%s' returned from registry for %s nodeID '%s': %w", subscription.URL, role, nodeID, err)
+		}
+		resolvedURL.Path = joinPath(resolvedURL, endpoint)
+		log.Debugf(ctx, "Router: resolved %s URL '%s' via registry NodeID '%s' for endpoint '%s'", role, subscription.URL, nodeID, endpoint)
+		return &model.Route{TargetType: targetTypeURL, URL: resolvedURL}, nil
 	}
-	targetURL.Path = joinPath(targetURL, endpoint)
-	return &model.Route{
-		TargetType: targetTypeURL,
-		URL:        targetURL,
-	}, nil
+
+	// 3. Fall back to default URL from routing config.
+	if route.URL == nil {
+		return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, role)
+	}
+	return &model.Route{TargetType: targetTypeURL, URL: route.URL}, nil
 }
 
 func joinPath(u *url.URL, endpoint string) string {

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -355,7 +355,7 @@ func canonicalRoleName(targetType string) string {
 // Resolution order:
 //  1. URI from payload context (npURI) — existing behaviour.
 //  2. NodeID-based registry lookup (nodeID) — when URI is absent and a NodeID in
-//     namespace/registry/recordId format is present; requires a registry plugin.
+//     namespace/registry/recordName format is present; requires a registry plugin.
 //  3. Default URL configured in routing rules (route.URL).
 //  4. Error — none of the above resolved a destination.
 func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryLookup) (*model.Route, error) {
@@ -376,8 +376,8 @@ func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeI
 		// Validate 3-part format before making any network call.
 		parts := strings.Split(nodeID, "/")
 		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-			log.Errorf(ctx, nil, "Router: %s nodeID '%s' for endpoint '%s' is not in namespace/registry/recordId format", role, nodeID, endpoint)
-			return nil, fmt.Errorf("could not resolve %s destination for endpoint '%s': nodeID '%s' is not in namespace/registry/recordId format", role, endpoint, nodeID)
+			log.Errorf(ctx, nil, "Router: %s nodeID '%s' for endpoint '%s' is not in namespace/registry/recordName format", role, nodeID, endpoint)
+			return nil, fmt.Errorf("could not resolve %s destination for endpoint '%s': nodeID '%s' is not in namespace/registry/recordName format", role, endpoint, nodeID)
 		}
 		if registry == nil {
 			log.Errorf(ctx, nil, "Router: %s nodeID '%s' present for endpoint '%s' but no registry plugin is configured", role, nodeID, endpoint)

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -29,7 +29,7 @@ type routingConfig struct {
 // Router implements Router interface.
 type Router struct {
 	rules    map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
-	registry definition.RegistryMetadataLookup             // optional; used for NodeID-based URL resolution
+	registry definition.RegistryLookup             // optional; used for NodeID-based URL resolution
 }
 
 // RoutingRule represents a single routing rule.
@@ -65,7 +65,7 @@ const (
 // registry is optional; when provided it is used to resolve subscriber URLs via NodeID lookup
 // when no URI is present in the payload context.
 // Returns an error if the configuration is invalid or the rules cannot be loaded.
-func New(ctx context.Context, registry definition.RegistryMetadataLookup, config *Config) (*Router, func() error, error) {
+func New(ctx context.Context, registry definition.RegistryLookup, config *Config) (*Router, func() error, error) {
 	// Check if config is nil
 	if config == nil {
 		return nil, nil, fmt.Errorf("config cannot be nil")
@@ -358,7 +358,7 @@ func canonicalRoleName(targetType string) string {
 //     namespace/registry/recordName format is present; requires a registry plugin.
 //  3. Default URL configured in routing rules (route.URL).
 //  4. Error — none of the above resolved a destination.
-func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryMetadataLookup) (*model.Route, error) {
+func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryLookup) (*model.Route, error) {
 	role := canonicalRoleName(route.TargetType)
 
 	// 1. URI present in payload — use it directly.

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -29,7 +29,7 @@ type routingConfig struct {
 // Router implements Router interface.
 type Router struct {
 	rules    map[string]map[string]map[string]*model.Route // domain -> version -> endpoint -> route
-	registry definition.RegistryLookup                    // optional; used for NodeID-based URL resolution
+	registry definition.RegistryMetadataLookup             // optional; used for NodeID-based URL resolution
 }
 
 // RoutingRule represents a single routing rule.
@@ -65,7 +65,7 @@ const (
 // registry is optional; when provided it is used to resolve subscriber URLs via NodeID lookup
 // when no URI is present in the payload context.
 // Returns an error if the configuration is invalid or the rules cannot be loaded.
-func New(ctx context.Context, registry definition.RegistryLookup, config *Config) (*Router, func() error, error) {
+func New(ctx context.Context, registry definition.RegistryMetadataLookup, config *Config) (*Router, func() error, error) {
 	// Check if config is nil
 	if config == nil {
 		return nil, nil, fmt.Errorf("config cannot be nil")
@@ -358,7 +358,7 @@ func canonicalRoleName(targetType string) string {
 //     namespace/registry/recordName format is present; requires a registry plugin.
 //  3. Default URL configured in routing rules (route.URL).
 //  4. Error — none of the above resolved a destination.
-func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryLookup) (*model.Route, error) {
+func handleProtocolMapping(ctx context.Context, route *model.Route, npURI, nodeID, endpoint string, registry definition.RegistryMetadataLookup) (*model.Route, error) {
 	role := canonicalRoleName(route.TargetType)
 
 	// 1. URI present in payload — use it directly.

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -41,7 +41,7 @@ func setupRouter(t *testing.T, configFile string) (*Router, func() error, string
 }
 
 // setupRouterWithRegistry is a helper function to create router instance with an optional registry plugin.
-func setupRouterWithRegistry(t *testing.T, configFile string, registry definition.RegistryMetadataLookup) (*Router, func() error, string) {
+func setupRouterWithRegistry(t *testing.T, configFile string, registry definition.RegistryLookup) (*Router, func() error, string) {
 	rulesFilePath := setupTestConfig(t, configFile)
 	config := &Config{
 		RoutingConfig: rulesFilePath,
@@ -952,13 +952,13 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	}
 }
 
-// mockRegistry is a test double for definition.RegistryMetadataLookup.
+// mockRegistry is a test double for definition.RegistryLookup.
 type mockRegistry struct {
 	lookupNodeFn func(ctx context.Context, nodeID string) (*model.Subscription, error)
 }
 
-func (m *mockRegistry) LookupRegistry(_ context.Context, _, _ string) (*model.RegistryMetadata, error) {
-	return nil, fmt.Errorf("LookupRegistry not implemented in mock")
+func (m *mockRegistry) Lookup(_ context.Context, _ *model.Subscription) ([]model.Subscription, error) {
+	return nil, fmt.Errorf("Lookup not implemented in mock")
 }
 
 func (m *mockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
@@ -966,7 +966,7 @@ func (m *mockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Su
 }
 
 // Ensure mockRegistry satisfies the interface at compile time.
-var _ definition.RegistryMetadataLookup = (*mockRegistry)(nil)
+var _ definition.RegistryLookup = (*mockRegistry)(nil)
 
 // TestRouteNodeIDFallback tests URL resolution via NodeID registry lookup.
 func TestRouteNodeIDFallback(t *testing.T) {
@@ -988,7 +988,7 @@ func TestRouteNodeIDFallback(t *testing.T) {
 		configFile     string
 		endpointAction string
 		body           string
-		registry       definition.RegistryMetadataLookup
+		registry       definition.RegistryLookup
 		wantErr        string
 	}{
 		{

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"embed"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 //go:embed testData/*
@@ -33,13 +35,18 @@ func setupTestConfig(t *testing.T, yamlFileName string) string {
 	return rulesPath
 }
 
-// setupRouter is a helper function to create router instance.
+// setupRouter is a helper function to create router instance without a registry plugin.
 func setupRouter(t *testing.T, configFile string) (*Router, func() error, string) {
+	return setupRouterWithRegistry(t, configFile, nil)
+}
+
+// setupRouterWithRegistry is a helper function to create router instance with an optional registry plugin.
+func setupRouterWithRegistry(t *testing.T, configFile string, registry definition.RegistryLookup) (*Router, func() error, string) {
 	rulesFilePath := setupTestConfig(t, configFile)
 	config := &Config{
 		RoutingConfig: rulesFilePath,
 	}
-	router, _, err := New(context.Background(), config)
+	router, _, err := New(context.Background(), registry, config)
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
@@ -58,7 +65,7 @@ func TestNew(t *testing.T) {
 		RoutingConfig: rulesFilePath,
 	}
 
-	router, _, err := New(ctx, config)
+	router, _, err := New(ctx, nil, config)
 	if err != nil {
 		t.Errorf("New(%v) = %v, want nil error", config, err)
 		return
@@ -96,7 +103,7 @@ func TestNewErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router, _, err := New(ctx, tt.config)
+			router, _, err := New(ctx, nil, tt.config)
 
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("New(%v) = %v, want error containing %q", tt.config, err, tt.wantErr)
@@ -940,6 +947,135 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
 			if err != nil {
 				t.Errorf("Route() = %v, want nil error", err)
+			}
+		})
+	}
+}
+
+// mockRegistry is a test double for definition.RegistryLookup.
+type mockRegistry struct {
+	lookupNodeFn func(ctx context.Context, nodeID string) (*model.Subscription, error)
+}
+
+func (m *mockRegistry) Lookup(_ context.Context, _ *model.Subscription) ([]model.Subscription, error) {
+	return nil, fmt.Errorf("Lookup not implemented in mock")
+}
+
+func (m *mockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
+	return m.lookupNodeFn(ctx, nodeID)
+}
+
+// Ensure mockRegistry satisfies the interface at compile time.
+var _ definition.RegistryLookup = (*mockRegistry)(nil)
+
+// TestRouteNodeIDFallback tests URL resolution via NodeID registry lookup.
+func TestRouteNodeIDFallback(t *testing.T) {
+	ctx := context.Background()
+
+	successRegistry := &mockRegistry{
+		lookupNodeFn: func(_ context.Context, nodeID string) (*model.Subscription, error) {
+			return &model.Subscription{
+				Subscriber: model.Subscriber{
+					SubscriberID: nodeID,
+					URL:          "https://resolved.example.com",
+				},
+			}, nil
+		},
+	}
+
+	tests := []struct {
+		name           string
+		configFile     string
+		endpointAction string
+		body           string
+		registry       definition.RegistryLookup
+		wantErr        string
+	}{
+		{
+			name:           "bpp_id resolves BPP URL when bppUri absent",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net/abc123"}}`,
+			registry:       successRegistry,
+		},
+		{
+			name:           "bap_id resolves BAP URL when bapUri absent",
+			configFile:     "bpp_caller.yaml",
+			endpointAction: "on_select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bap_id": "nfo.example.org/retail-net/bap456"}}`,
+			registry:       successRegistry,
+		},
+		{
+			name:           "bppId (camelCase) resolves BPP URL",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bppId": "nfo.example.org/retail-net/abc123"}}`,
+			registry:       successRegistry,
+		},
+		{
+			name:           "nodeID present but no registry configured returns error",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net/abc123"}}`,
+			registry:       nil,
+			wantErr:        "no registry plugin is configured",
+		},
+		{
+			name:           "invalid nodeID format (2 parts) returns error",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net"}}`,
+			registry:       successRegistry,
+			wantErr:        "namespace/registry/recordId format",
+		},
+		{
+			name:           "invalid nodeID format (1 part) returns error",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "plainid"}}`,
+			registry:       successRegistry,
+			wantErr:        "namespace/registry/recordId format",
+		},
+		{
+			name:           "registry lookup failure returns error",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net/abc123"}}`,
+			registry: &mockRegistry{
+				lookupNodeFn: func(_ context.Context, _ string) (*model.Subscription, error) {
+					return nil, fmt.Errorf("registry unavailable")
+				},
+			},
+			wantErr: "registry lookup failed",
+		},
+		{
+			name:           "registry returns empty URL returns error",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net/abc123"}}`,
+			registry: &mockRegistry{
+				lookupNodeFn: func(_ context.Context, _ string) (*model.Subscription, error) {
+					return &model.Subscription{Subscriber: model.Subscriber{SubscriberID: "abc123"}}, nil
+				},
+			},
+			wantErr: "has no URL configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, _, rulesFilePath := setupRouterWithRegistry(t, tt.configFile, tt.registry)
+			defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+			_, err := router.Route(ctx, &url.URL{Path: tt.endpointAction}, []byte(tt.body))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Route() = %v, want nil error", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Route() = %v, want error containing %q", err, tt.wantErr)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -41,7 +41,7 @@ func setupRouter(t *testing.T, configFile string) (*Router, func() error, string
 }
 
 // setupRouterWithRegistry is a helper function to create router instance with an optional registry plugin.
-func setupRouterWithRegistry(t *testing.T, configFile string, registry definition.RegistryLookup) (*Router, func() error, string) {
+func setupRouterWithRegistry(t *testing.T, configFile string, registry definition.RegistryMetadataLookup) (*Router, func() error, string) {
 	rulesFilePath := setupTestConfig(t, configFile)
 	config := &Config{
 		RoutingConfig: rulesFilePath,
@@ -952,13 +952,13 @@ func TestRouteCompoundEndpointSuccess(t *testing.T) {
 	}
 }
 
-// mockRegistry is a test double for definition.RegistryLookup.
+// mockRegistry is a test double for definition.RegistryMetadataLookup.
 type mockRegistry struct {
 	lookupNodeFn func(ctx context.Context, nodeID string) (*model.Subscription, error)
 }
 
-func (m *mockRegistry) Lookup(_ context.Context, _ *model.Subscription) ([]model.Subscription, error) {
-	return nil, fmt.Errorf("Lookup not implemented in mock")
+func (m *mockRegistry) LookupRegistry(_ context.Context, _, _ string) (*model.RegistryMetadata, error) {
+	return nil, fmt.Errorf("LookupRegistry not implemented in mock")
 }
 
 func (m *mockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
@@ -966,7 +966,7 @@ func (m *mockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Su
 }
 
 // Ensure mockRegistry satisfies the interface at compile time.
-var _ definition.RegistryLookup = (*mockRegistry)(nil)
+var _ definition.RegistryMetadataLookup = (*mockRegistry)(nil)
 
 // TestRouteNodeIDFallback tests URL resolution via NodeID registry lookup.
 func TestRouteNodeIDFallback(t *testing.T) {
@@ -988,7 +988,7 @@ func TestRouteNodeIDFallback(t *testing.T) {
 		configFile     string
 		endpointAction string
 		body           string
-		registry       definition.RegistryLookup
+		registry       definition.RegistryMetadataLookup
 		wantErr        string
 	}{
 		{

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -1026,7 +1026,7 @@ func TestRouteNodeIDFallback(t *testing.T) {
 			endpointAction: "select",
 			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "nfo.example.org/retail-net"}}`,
 			registry:       successRegistry,
-			wantErr:        "namespace/registry/recordId format",
+			wantErr:        "namespace/registry/recordName format",
 		},
 		{
 			name:           "invalid nodeID format (1 part) returns error",
@@ -1034,7 +1034,7 @@ func TestRouteNodeIDFallback(t *testing.T) {
 			endpointAction: "select",
 			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_id": "plainid"}}`,
 			registry:       successRegistry,
-			wantErr:        "namespace/registry/recordId format",
+			wantErr:        "namespace/registry/recordName format",
 		},
 		{
 			name:           "registry lookup failure returns error",

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -267,28 +267,41 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 	}
 
 	log.Debugf(ctx, "Cache miss, looking up registry for subscriber: %s, uniqueKeyID: %s", subscriberID, uniqueKeyID)
-	var subscribers []model.Subscription
+
+	var signingKey, encrKey string
 	{
 		spanCtx, span := tracer.Start(ctx, "registry lookup")
 		defer span.End()
-		var err error
 
-		subscribers, err = skm.Registry.Lookup(spanCtx, &model.Subscription{
-			Subscriber: model.Subscriber{
-				SubscriberID: subscriberID,
-			},
-			KeyID: uniqueKeyID,
-		})
-		if err != nil {
-			return "", "", fmt.Errorf("failed to lookup registry: %w", err)
-		}
-		if len(subscribers) == 0 {
-			return "", "", ErrSubscriberNotFound
+		parts := strings.Split(subscriberID, "/")
+		if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+			// 3-part NodeID — resolve directly via DeDi node lookup.
+			subscription, err := skm.Registry.LookupNode(spanCtx, subscriberID)
+			if err != nil {
+				return "", "", fmt.Errorf("failed to lookup registry node: %w", err)
+			}
+			signingKey = subscription.SigningPublicKey
+			encrKey = subscription.EncrPublicKey
+		} else {
+			subscribers, err := skm.Registry.Lookup(spanCtx, &model.Subscription{
+				Subscriber: model.Subscriber{
+					SubscriberID: subscriberID,
+				},
+				KeyID: uniqueKeyID,
+			})
+			if err != nil {
+				return "", "", fmt.Errorf("failed to lookup registry: %w", err)
+			}
+			if len(subscribers) == 0 {
+				return "", "", ErrSubscriberNotFound
+			}
+			signingKey = subscribers[0].SigningPublicKey
+			encrKey = subscribers[0].EncrPublicKey
 		}
 	}
 
 	log.Debugf(ctx, "Successfully looked up keys for subscriber: %s, uniqueKeyID: %s", subscriberID, uniqueKeyID)
-	return subscribers[0].SigningPublicKey, subscribers[0].EncrPublicKey, nil
+	return signingKey, encrKey, nil
 }
 
 // loadKeysFromConfig loads keys from configuration if they exist

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -3,6 +3,7 @@ package simplekeymanager
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,6 +30,10 @@ func (m *mockCache) Delete(ctx context.Context, key string) error {
 }
 
 type mockRegistry struct{}
+
+func (m *mockRegistry) LookupNode(_ context.Context, nodeID string) (*model.Subscription, error) {
+	return nil, fmt.Errorf("LookupNode not supported by standard registry (nodeID: %s)", nodeID)
+}
 
 func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 	return []model.Subscription{

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -48,6 +48,26 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 	}, nil
 }
 
+// flexMockRegistry allows per-test control of both Lookup and LookupNode.
+type flexMockRegistry struct {
+	lookupFn     func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
+	lookupNodeFn func(ctx context.Context, nodeID string) (*model.Subscription, error)
+}
+
+func (m *flexMockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+	if m.lookupFn != nil {
+		return m.lookupFn(ctx, sub)
+	}
+	return nil, fmt.Errorf("Lookup not configured")
+}
+
+func (m *flexMockRegistry) LookupNode(ctx context.Context, nodeID string) (*model.Subscription, error) {
+	if m.lookupNodeFn != nil {
+		return m.lookupNodeFn(ctx, nodeID)
+	}
+	return nil, fmt.Errorf("LookupNode not configured")
+}
+
 func TestValidateCfg(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -363,6 +383,74 @@ func TestLookupNPKeys(t *testing.T) {
 	if err == nil {
 		t.Error("LookupNPKeys() should fail with empty uniqueKeyID")
 	}
+}
+
+func TestLookupNPKeysNodeID(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("3-part NodeID uses LookupNode not Lookup", func(t *testing.T) {
+		lookupNodeCalled := false
+		lookupCalled := false
+
+		reg := &flexMockRegistry{
+			lookupNodeFn: func(_ context.Context, nodeID string) (*model.Subscription, error) {
+				lookupNodeCalled = true
+				return &model.Subscription{
+					Subscriber:      model.Subscriber{SubscriberID: nodeID},
+					SigningPublicKey: "node-signing-key",
+					EncrPublicKey:   "node-encr-key",
+				}, nil
+			},
+			lookupFn: func(_ context.Context, _ *model.Subscription) ([]model.Subscription, error) {
+				lookupCalled = true
+				return nil, fmt.Errorf("Lookup should not be called for NodeID")
+			},
+		}
+		skm := &SimpleKeyMgr{Cache: &mockCache{}, Registry: reg}
+
+		signing, encr, err := skm.LookupNPKeys(ctx, "beckn.one/example-NPs/example-bpp", "any-key")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !lookupNodeCalled {
+			t.Error("expected LookupNode to be called for 3-part NodeID")
+		}
+		if lookupCalled {
+			t.Error("Lookup should not be called for 3-part NodeID")
+		}
+		if signing != "node-signing-key" {
+			t.Errorf("SigningPublicKey = %q, want %q", signing, "node-signing-key")
+		}
+		if encr != "node-encr-key" {
+			t.Errorf("EncrPublicKey = %q, want %q", encr, "node-encr-key")
+		}
+	})
+
+	t.Run("plain subscriber ID uses Lookup not LookupNode", func(t *testing.T) {
+		lookupNodeCalled := false
+
+		reg := &flexMockRegistry{
+			lookupFn: func(_ context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{SigningPublicKey: "plain-signing-key", EncrPublicKey: "plain-encr-key"}}, nil
+			},
+			lookupNodeFn: func(_ context.Context, _ string) (*model.Subscription, error) {
+				lookupNodeCalled = true
+				return nil, fmt.Errorf("LookupNode should not be called for plain ID")
+			},
+		}
+		skm := &SimpleKeyMgr{Cache: &mockCache{}, Registry: reg}
+
+		signing, _, err := skm.LookupNPKeys(ctx, "plain-subscriber-id", "key-id")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lookupNodeCalled {
+			t.Error("LookupNode should not be called for plain subscriber ID")
+		}
+		if signing != "plain-signing-key" {
+			t.Errorf("SigningPublicKey = %q, want %q", signing, "plain-signing-key")
+		}
+	})
 }
 
 func TestParseKey(t *testing.T) {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -169,12 +169,12 @@ func (m *Manager) SchemaValidator(ctx context.Context, cfg *Config) (definition.
 
 // Router returns a Router instance based on the provided configuration.
 // It registers a cleanup function for resource management.
-func (m *Manager) Router(ctx context.Context, cfg *Config) (definition.Router, error) {
+func (m *Manager) Router(ctx context.Context, registry definition.RegistryMetadataLookup, cfg *Config) (definition.Router, error) {
 	rp, err := provider[definition.RouterProvider](m.plugins, cfg.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
 	}
-	router, closer, err := rp.New(ctx, cfg.Config)
+	router, closer, err := rp.New(ctx, registry, cfg.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -169,7 +169,7 @@ func (m *Manager) SchemaValidator(ctx context.Context, cfg *Config) (definition.
 
 // Router returns a Router instance based on the provided configuration.
 // It registers a cleanup function for resource management.
-func (m *Manager) Router(ctx context.Context, registry definition.RegistryMetadataLookup, cfg *Config) (definition.Router, error) {
+func (m *Manager) Router(ctx context.Context, registry definition.RegistryLookup, cfg *Config) (definition.Router, error) {
 	rp, err := provider[definition.RouterProvider](m.plugins, cfg.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -141,7 +141,7 @@ type mockRouterProvider struct {
 	errFunc func() error
 }
 
-func (m *mockRouterProvider) New(ctx context.Context, _ definition.RegistryMetadataLookup, config map[string]string) (definition.Router, func() error, error) {
+func (m *mockRouterProvider) New(ctx context.Context, _ definition.RegistryLookup, config map[string]string) (definition.Router, func() error, error) {
 	if m.err != nil {
 		return nil, nil, m.err
 	}

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -141,7 +141,7 @@ type mockRouterProvider struct {
 	errFunc func() error
 }
 
-func (m *mockRouterProvider) New(ctx context.Context, config map[string]string) (definition.Router, func() error, error) {
+func (m *mockRouterProvider) New(ctx context.Context, _ definition.RegistryMetadataLookup, config map[string]string) (definition.Router, func() error, error) {
 	if m.err != nil {
 		return nil, nil, m.err
 	}
@@ -654,7 +654,7 @@ func TestRouterSuccess(t *testing.T) {
 		}
 
 		// Call Router.
-		router, err := m.Router(context.Background(), cfg)
+		router, err := m.Router(context.Background(), nil, cfg)
 
 		// Check success case.
 		if err != nil {
@@ -721,7 +721,7 @@ func TestRouterFailure(t *testing.T) {
 			}
 
 			// Call Router.
-			router, err := m.Router(context.Background(), tt.cfg)
+			router, err := m.Router(context.Background(), nil, tt.cfg)
 
 			// Check error.
 			if err == nil {


### PR DESCRIPTION
## Summary

Closes #778

When \`bppUri\`/\`receiverUri\` (or \`bapUri\`/\`senderUri\`) is absent from the Beckn context, the router now falls back to resolving the destination URL by looking up the subscriber record in the DeDi registry using the \`bpp_id\`/\`bap_id\` (referred to as **NodeID**).

NodeID must follow the 3-part DeDi format: \`namespace/registry/recordName\`. If the format is invalid, the router fails with a clear error — no silent fallback.

## Changes

- **\`pkg/plugin/definition/registry.go\`** — added \`LookupNode(ctx, nodeID string) (*model.Subscription, error)\` to \`RegistryLookup\` interface; standard \`RegistryClient\` implements a stub that logs and returns an error
- **\`pkg/plugin/implementation/dediregistry/dediregistry.go\`** — implemented \`LookupNode\`: validates 3-part format, calls \`/lookup/{namespace}/{registry}/{recordName}\`, returns \`*model.Subscription\` with URL, type, domain; applies \`AllowedNetworkIDs\` check; extracted \`parseSubscriptionFromData\` helper shared with \`Lookup\`
- **\`pkg/plugin/implementation/router/router.go\`** — added optional \`registry definition.RegistryLookup\` field; extended \`handleProtocolMapping\` with NodeID fallback (format validation → registry lookup → empty URL check → configured default → error); extracts \`bpp_id\`/\`bppId\`/\`receiverId\` and \`bap_id\`/\`bapId\`/\`senderId\` from payload context
- **\`pkg/plugin/implementation/router/cmd/plugin.go\`** — added \`definition.RegistryLookup\` parameter to provider \`New()\` consistent with other plugin dependency injection patterns
- **\`pkg/plugin/implementation/keymanager/keymanager.go\`** — \`LookupNPKeys\` detects 3-part NodeID and calls \`LookupNode\` instead of \`Lookup\` for sign validation
- **\`pkg/plugin/implementation/simplekeymanager/simplekeymanager.go\`** — same NodeID detection in \`LookupNPKeys\`

## Routing resolution order (BPP/BAP target types)

1. URI from payload context (\`bppUri\` / \`receiverUri\` / \`bap_uri\` etc.) — existing behaviour, unchanged
2. NodeID registry lookup (\`bpp_id\` / \`bppId\` / \`receiverId\`) — **new**
3. Default URL configured in routing rules
4. Error

## Test plan

- [x] All existing router and dediregistry tests pass
- [x] \`TestLookupNode\` — 7 cases: successful lookup, invalid format (1-part, 2-part, empty part), HTTP error, missing details, network membership mismatch
- [x] \`TestRouteNodeIDFallback\` — 8 cases: BPP/BAP NodeID resolution, camelCase field variant, no registry configured, invalid format, registry failure, empty URL returned
- [x] \`TestLookupNPKeysNodeID\` (keymanager + simplekeymanager) — verifies 3-part NodeID routes to \`LookupNode\` and plain ID still routes to \`Lookup\`