### PR TITLE
fix: regenerate beckn-constants signing keypair after key loss

### DIFF
--- a/pkg/beckndefaults/beckn-constants.yaml.sig
+++ b/pkg/beckndefaults/beckn-constants.yaml.sig
@@ -1,1 +1,1 @@
-eTUU2qW8uRV/QXcxB5g+h//hR+xWS/ub5NFdMKjhBCIHtsIb5EkEPqtokeYDU4G/xXHU/m64zhyrVa1gplpjAg==
+dMuqz8FADzgO46KxVr8fTgd9RZ86giA0YfCdaJSDR9JtH2+cHH7VqkK/Y2jnzNNwbNN4TZXmVJwmh7nngk7CCg==

--- a/pkg/beckndefaults/beckn_public_key.pem
+++ b/pkg/beckndefaults/beckn_public_key.pem
@@ -1,3 +1,3 @@
 -----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAXic/54R1FFnDkUaC6u8V6gsYBawpHzggse2pS7k0iJ4=
+MCowBQYDK2VwAyEAdG4rkhClL4sBBvtNqlz/N3INij/2Qidd72zi0+ddlCQ=
 -----END PUBLIC KEY-----


### PR DESCRIPTION
## Problem

After PR #762 merged, the `sign-beckn-constants.yml` workflow failed immediately with:

```
error: decode private key: illegal base64 data at input byte 44
exit status 1
```

The `BECKN_CONSTANTS_SIGNING_KEY` GitHub Actions secret was either never stored or contained a corrupt value. The original private key (generated during the #592 session) was written to `/tmp/beckn_private.key` and was lost when the session ended.

## Fix

Regenerated a fresh Ed25519 keypair:

- `pkg/beckndefaults/beckn_public_key.pem` — new public key (baked into binary via `go:embed`)
- `pkg/beckndefaults/beckn-constants.yaml.sig` — re-signed with the new private key

All `pkg/beckndefaults` tests pass with the new keypair (signature verify, tamper detection, wrong-key rejection).

## ⚠️ Required action before merging

The new private key must be stored in GitHub Actions secrets **before** this is merged, otherwise the workflow will fail again on the next push to `pkg/beckndefaults/beckn-constants.yaml`.

**Steps:**
1. Retrieve the new private key: `cat /tmp/beckn_private_new.key` on the machine where this PR was prepared (or ask the author)
2. Go to **Settings → Secrets and variables → Actions** in the beckn-onix repo
3. Update (or create) the secret named `BECKN_CONSTANTS_SIGNING_KEY` with the base64 value from step 1
4. Then merge this PR

The private key is a single 44-character base64 string — store it exactly as-is, no extra spaces or newlines.

Refs #592