### PR TITLE
fix(ci): pull --rebase before push in sign-beckn-constants workflow

### DIFF
--- a/.github/workflows/sign-beckn-constants.yml
+++ b/.github/workflows/sign-beckn-constants.yml
@@ -40,4 +40,5 @@ jobs:
           git config user.email "bot@becknprotocol.io"
           git add pkg/beckndefaults/beckn-constants.yaml.sig
           git diff --cached --quiet || git commit -m "chore: re-sign beckn-constants.yaml [skip ci]"
+          git pull --rebase origin main
           git push


### PR DESCRIPTION
## Problem

On workflow retry, the `sign-beckn-constants` job succeeded at signing but failed to push:

```
! [rejected] main -> main (fetch first)
error: failed to push some refs to 'https://github.com/beckn/beckn-onix'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

The job checks out the commit that triggered the run. When main moves forward between that checkout and the bot's push (e.g. the keypair rotation PR #781 landed in between), the push is rejected as non-fast-forward.

## Fix

Add `git pull --rebase origin main` immediately before `git push` in the commit step. This syncs the bot's local branch with whatever landed on main since checkout, then pushes cleanly.

The `.sig` file is always deterministic for the same `beckn-constants.yaml` content and key, so a rebase here is always safe.

Refs #592