### PR TITLE
feat(schemav2validator): auxiliary spec support for non-Beckn and extended-verb deployments

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -779,8 +779,8 @@ schemaValidator:
     type: url
     location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
     cacheTTL: "3600"
-    auxiliary_types: "file,dir"
-    auxiliary_locations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
+    auxiliaryTypes: "file,dir"
+    auxiliaryLocations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
 ```
 
 Auxiliary specs are additive — they may only introduce new action verbs not already present in the primary spec. A collision with the primary spec is a hard error and the adapter will not start. If an auxiliary spec fails to load at startup, it is skipped and an error is logged; the primary spec remains active. The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory.
@@ -789,8 +789,8 @@ Auxiliary specs are additive — they may only introduce new action verbs not al
 - `type`: **Injected automatically** from beckn constants (default: `"url"`). Set to `"file"` for local specs; ONIX will log a WARN at startup.
 - `location`: **Injected automatically** from beckn constants when `type` is `"url"`. Set freely when `type` is `"file"`.
 - `cacheTTL`: Cache TTL in seconds before reloading all specs (default: `"3600"`)
-- `auxiliary_types`: Comma-separated list of source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`)
-- `auxiliary_locations`: Comma-separated list of locations for auxiliary specs — must have the same number of entries as `auxiliary_types`
+- `auxiliaryTypes`: Comma-separated list of source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`)
+- `auxiliaryLocations`: Comma-separated list of locations for auxiliary specs — must have the same number of entries as `auxiliaryTypes`
 - `extendedSchema_enabled`: Enable extended schema validation for `@context` objects (default: `"false"`)
 - `extendedSchema_cacheTTL`: Domain schema cache TTL in seconds (default: `"86400"`)
 - `extendedSchema_maxCacheSize`: Max cached schemas (default: `"100"`)

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -744,7 +744,7 @@ schemaValidator:
 
 #### 6. Schema2Validator Plugin
 
-**Purpose**: Validate requests against OpenAPI 3.x specifications. Supports core protocol validation and optional extended validation for domain-specific objects with `@context` references.
+**Purpose**: Validate requests against OpenAPI 3.x specifications. Supports core protocol validation, optional auxiliary specs for extended action verbs, and optional extended validation for domain-specific objects with `@context` references.
 
 ```yaml
 schemaValidator:
@@ -770,10 +770,27 @@ schemaValidator:
     extendedSchema_enabled: "false"
 ```
 
+**With auxiliary specs** (to add network-specific or domain-specific action verbs on top of the primary Beckn spec):
+
+```yaml
+schemaValidator:
+  id: schemav2validator
+  config:
+    type: url
+    location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+    cacheTTL: "3600"
+    auxiliary_types: "file,dir"
+    auxiliary_locations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
+```
+
+Auxiliary specs are additive — they may only introduce new action verbs not already present in the primary spec. A collision with the primary spec is a hard error and the adapter will not start. If an auxiliary spec fails to load at startup, it is skipped and an error is logged; the primary spec remains active. The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory.
+
 **Parameters**:
 - `type`: **Injected automatically** from beckn constants (default: `"url"`). Set to `"file"` for local specs; ONIX will log a WARN at startup.
 - `location`: **Injected automatically** from beckn constants when `type` is `"url"`. Set freely when `type` is `"file"`.
-- `cacheTTL`: Cache TTL in seconds before reloading spec (default: `"3600"`)
+- `cacheTTL`: Cache TTL in seconds before reloading all specs (default: `"3600"`)
+- `auxiliary_types`: Comma-separated list of source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`)
+- `auxiliary_locations`: Comma-separated list of locations for auxiliary specs — must have the same number of entries as `auxiliary_types`
 - `extendedSchema_enabled`: Enable extended schema validation for `@context` objects (default: `"false"`)
 - `extendedSchema_cacheTTL`: Domain schema cache TTL in seconds (default: `"86400"`)
 - `extendedSchema_maxCacheSize`: Max cached schemas (default: `"100"`)

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -50,7 +50,7 @@ Auxiliary specs allow operators to extend schema validation with additional acti
 
 **Rules:**
 - Auxiliary specs are loaded after the primary spec; their actions are merged into a single index
-- An auxiliary spec may only **add** new actions — any action already defined in the primary spec causes a hard error at startup
+- An auxiliary spec may only **add** new actions — any action already defined in any previously loaded spec (primary or an earlier auxiliary) causes a hard error at startup
 - If an auxiliary spec fails to load, it is skipped with an error logged; the primary spec remains active
 - The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory (no recursion); duplicate action definitions across files within the same dir are a hard error — the entire dir spec is rejected and startup fails
 - All specs (primary and auxiliary) share the same `cacheTTL` refresh cycle
@@ -76,7 +76,7 @@ A startup warning is logged if no schemas are found, which usually means the dir
 
 **Spec Loading**:
 1. **Load Primary Spec**: Loads the primary spec from `location` (URL, file, or dir) with external `$ref` resolution and builds its action index
-2. **Load Auxiliary Specs**: Each auxiliary spec is loaded independently in order; its action index is merged into the shared map. Hard error if any action collides with the primary — the adapter will not start
+2. **Load Auxiliary Specs**: Each auxiliary spec is loaded independently in order; its action index is merged into the shared map. Hard error if any action collides with any previously loaded spec (primary or earlier auxiliary) — the adapter will not start
 3. **Merged Action Index**: A single flat `action → schema` map is built from all specs for O(1) lookup at runtime
 4. **Start Background Refresh**: Launches goroutine; every `cacheTTL` seconds the entire index is rebuilt from scratch (primary first, then auxiliaries). On failure the previous valid index is retained and an error is logged
 
@@ -238,7 +238,7 @@ schemaValidator:
 | Action not in spec | `"unsupported action: <action>"` |
 | Invalid URL | `"Invalid URL or unreachable: <url>"` |
 | Schema validation fails | Returns detailed field-level errors |
-| Auxiliary action collides with primary | `"auxiliary spec[N] (<location>) defines action \"<action>\" which is already defined in a previously loaded spec — auxiliary specs may only add new actions"` |
+| Auxiliary action collides with primary or another auxiliary | `"auxiliary spec[N] (<location>) defines action \"<action>\" which is already defined in a previously loaded spec — auxiliary specs may only add new actions"` |
 | Within-dir action collision | Error logged; dir spec skipped; startup fails with `"no actions indexed"` if no other spec is available |
 | No specs loaded / all specs failed | `"schemav2validator: no actions indexed after loading all specs — configure at least one valid primary or auxiliary spec"` |
 | `auxiliaryTypes` set without `auxiliaryLocations` | `"auxiliaryTypes is set but auxiliaryLocations is missing"` |

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -52,7 +52,7 @@ Auxiliary specs allow operators to extend schema validation with additional acti
 - Auxiliary specs are loaded after the primary spec; their actions are merged into a single index
 - An auxiliary spec may only **add** new actions — any action already defined in the primary spec causes a hard error at startup
 - If an auxiliary spec fails to load, it is skipped with an error logged; the primary spec remains active
-- The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory (no recursion); within a single dir, later files win on collision with a warning logged
+- The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory (no recursion); duplicate action definitions across files within the same dir are a hard error — the entire dir spec is rejected and startup fails
 - All specs (primary and auxiliary) share the same `cacheTTL` refresh cycle
 
 ### Local Schema Directory Layout

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -32,8 +32,8 @@ schemaValidator:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `type` | string | No | - | Primary spec source type: `"url"`, `"file"`, or `"dir"`. Optional — omit to run without a primary spec (auxiliary-only mode for non-Beckn deployments). If `location` is set, `type` must also be set. |
-| `location` | string | No | - | URL or file path to the primary OpenAPI 3.1 spec. Optional — omit alongside `type` to use auxiliary-only mode. If `type` is set, `location` must also be set. |
+| `type` | string | No | - | Primary spec source type: `"url"`, `"file"`, or `"dir"`. **In standard Beckn deployments this is injected automatically from the signed beckn-constants file — do not set it manually.** Set to `"file"` (or `"dir"`) only for non-Beckn or offline deployments; ONIX will log a WARN at startup. Omit entirely for auxiliary-only mode. If `location` is set, `type` must also be set. |
+| `location` | string | No | - | URL or file path to the primary OpenAPI 3.1 spec. **In standard Beckn deployments this is injected automatically from the signed beckn-constants file — do not set it manually.** Set freely when `type` is `"file"` or `"dir"`. Omit entirely for auxiliary-only mode. If `type` is set, `location` must also be set. |
 | `cacheTTL` | string | No | `"3600"` | Cache TTL in seconds before reloading all specs (primary + auxiliary) |
 | `auxiliaryTypes` | string | No | - | Comma-separated source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`) |
 | `auxiliaryLocations` | string | No | - | Comma-separated locations for auxiliary specs — must have the same number of entries as `auxiliaryTypes` |

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -32,8 +32,8 @@ schemaValidator:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `type` | string | Yes | - | Primary spec source type: `"url"`, `"file"`, or `"dir"` |
-| `location` | string | Yes | - | URL or file path to the primary OpenAPI 3.1 spec |
+| `type` | string | No | - | Primary spec source type: `"url"`, `"file"`, or `"dir"`. Optional — omit to run without a primary spec (auxiliary-only mode for non-Beckn deployments). If `location` is set, `type` must also be set. |
+| `location` | string | No | - | URL or file path to the primary OpenAPI 3.1 spec. Optional — omit alongside `type` to use auxiliary-only mode. If `type` is set, `location` must also be set. |
 | `cacheTTL` | string | No | `"3600"` | Cache TTL in seconds before reloading all specs (primary + auxiliary) |
 | `auxiliaryTypes` | string | No | - | Comma-separated source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`) |
 | `auxiliaryLocations` | string | No | - | Comma-separated locations for auxiliary specs — must have the same number of entries as `auxiliaryTypes` |

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -32,15 +32,28 @@ schemaValidator:
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `type` | string | Yes | - | Type of spec source: "url" or "file" ("dir" reserved for future) |
-| `location` | string | Yes | - | URL or file path to OpenAPI 3.1 spec |
-| `cacheTTL` | string | No | "3600" | Cache TTL in seconds before reloading spec |
-| `extendedSchema_enabled` | string | No | "false" | Enable extended schema validation for `@context` objects |
-| `extendedSchema_cacheTTL` | string | No | "86400" | Domain schema cache TTL in seconds |
-| `extendedSchema_maxCacheSize` | string | No | "100" | Maximum number of cached domain schemas |
-| `extendedSchema_downloadTimeout` | string | No | "30" | Timeout for downloading domain schemas |
-| `extendedSchema_allowedDomains` | string | No | "" | Comma-separated domain whitelist (empty = all allowed) |
-| `extendedSchema_localSchemaPath` | string | No | "" | Path to local schema directory; schemas preloaded at startup, network used as fallback |
+| `type` | string | Yes | - | Primary spec source type: `"url"`, `"file"`, or `"dir"` |
+| `location` | string | Yes | - | URL or file path to the primary OpenAPI 3.1 spec |
+| `cacheTTL` | string | No | `"3600"` | Cache TTL in seconds before reloading all specs (primary + auxiliary) |
+| `auxiliary_types` | string | No | - | Comma-separated source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`) |
+| `auxiliary_locations` | string | No | - | Comma-separated locations for auxiliary specs — must have the same number of entries as `auxiliary_types` |
+| `extendedSchema_enabled` | string | No | `"false"` | Enable extended schema validation for `@context` objects |
+| `extendedSchema_cacheTTL` | string | No | `"86400"` | Domain schema cache TTL in seconds |
+| `extendedSchema_maxCacheSize` | string | No | `"100"` | Maximum number of cached domain schemas |
+| `extendedSchema_downloadTimeout` | string | No | `"30"` | Timeout for downloading domain schemas |
+| `extendedSchema_allowedDomains` | string | No | `""` | Comma-separated domain whitelist (empty = all allowed) |
+| `extendedSchema_localSchemaPath` | string | No | `""` | Path to local schema directory; schemas preloaded at startup, network used as fallback |
+
+### Auxiliary Specs
+
+Auxiliary specs allow operators to extend schema validation with additional action verbs beyond those defined in the primary Beckn spec. Both `auxiliary_types` and `auxiliary_locations` must be set together as matching comma-separated lists.
+
+**Rules:**
+- Auxiliary specs are loaded after the primary spec; their actions are merged into a single index
+- An auxiliary spec may only **add** new actions — any action already defined in the primary spec causes a hard error at startup
+- If an auxiliary spec fails to load, it is skipped with an error logged; the primary spec remains active
+- The `dir` type loads all top-level `*.yaml`, `*.yml`, and `*.json` files in the specified directory (no recursion); within a single dir, later files win on collision with a warning logged
+- All specs (primary and auxiliary) share the same `cacheTTL` refresh cycle
 
 ### Local Schema Directory Layout
 
@@ -61,17 +74,15 @@ A startup warning is logged if no schemas are found, which usually means the dir
 
 ### Initialization (Load Time)
 
-**Core Protocol Validation Setup**:
-1. **Load OpenAPI Spec**: Loads main spec from `location` (URL or file) with external `$ref` resolution
-2. **Build Action Index**: Creates action→schema map for O(1) lookup by scanning all paths/methods
-3. **Validate Spec**: Validates OpenAPI spec structure (warnings logged, non-fatal)
-4. **Cache Spec**: Stores loaded spec with `loadedAt` timestamp
+**Spec Loading**:
+1. **Load Primary Spec**: Loads the primary spec from `location` (URL, file, or dir) with external `$ref` resolution and builds its action index
+2. **Load Auxiliary Specs**: Each auxiliary spec is loaded independently in order; its action index is merged into the shared map. Hard error if any action collides with the primary — the adapter will not start
+3. **Merged Action Index**: A single flat `action → schema` map is built from all specs for O(1) lookup at runtime
+4. **Start Background Refresh**: Launches goroutine; every `cacheTTL` seconds the entire index is rebuilt from scratch (primary first, then auxiliaries). On failure the previous valid index is retained and an error is logged
 
 **Extended Schema Setup** (if `extendedSchema_enabled: "true"`):
 5. **Initialize Schema Cache**: Creates LRU cache with `maxCacheSize` (default: 100)
-6. **Start Background Refresh**: Launches goroutine with two tickers:
-   - Core spec refresh every `cacheTTL` seconds (default: 3600)
-   - Extended schema cleanup every `extendedSchema_cacheTTL` seconds (default: 86400)
+6. **Extended schema cleanup** ticker runs every `extendedSchema_cacheTTL` seconds (default: 86400)
 
 ### Request Validation (Runtime)
 
@@ -149,7 +160,7 @@ The loader will automatically fetch and resolve the external reference.
 
 ## Example Usage
 
-### Remote URL
+### Remote URL (Primary only)
 
 ```yaml
 schemaValidator:
@@ -160,7 +171,7 @@ schemaValidator:
     cacheTTL: "7200"
 ```
 
-### Local File
+### Local File (Primary only)
 
 ```yaml
 schemaValidator:
@@ -169,6 +180,21 @@ schemaValidator:
     type: file
     location: ./validation-scripts/l2-config/mobility_1.1.0_openapi_3.1.yaml
     cacheTTL: "3600"
+```
+
+### Primary with Auxiliary Specs
+
+Extends the Beckn core spec with additional action verbs from a local file and a directory of domain schemas:
+
+```yaml
+schemaValidator:
+  id: schemav2validator
+  config:
+    type: url
+    location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+    cacheTTL: "3600"
+    auxiliary_types: "file,dir"
+    auxiliary_locations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
 ```
 
 ### With Extended Schema Validation
@@ -212,4 +238,8 @@ schemaValidator:
 | Action not in spec | `"unsupported action: <action>"` |
 | Invalid URL | `"Invalid URL or unreachable: <url>"` |
 | Schema validation fails | Returns detailed field-level errors |
+| Auxiliary action collides with primary | `"auxiliary spec[N] (<location>) defines action \"<action>\" which is already defined in a previously loaded spec — auxiliary specs may only add new actions"` |
+| `auxiliary_types` set without `auxiliary_locations` | `"auxiliary_types is set but auxiliary_locations is missing"` |
+| `auxiliary_locations` set without `auxiliary_types` | `"auxiliary_locations is set but auxiliary_types is missing"` |
+| Mismatched auxiliary list lengths | `"auxiliary_types and auxiliary_locations must have the same number of comma-separated entries"` |
 

--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -35,8 +35,8 @@ schemaValidator:
 | `type` | string | Yes | - | Primary spec source type: `"url"`, `"file"`, or `"dir"` |
 | `location` | string | Yes | - | URL or file path to the primary OpenAPI 3.1 spec |
 | `cacheTTL` | string | No | `"3600"` | Cache TTL in seconds before reloading all specs (primary + auxiliary) |
-| `auxiliary_types` | string | No | - | Comma-separated source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`) |
-| `auxiliary_locations` | string | No | - | Comma-separated locations for auxiliary specs — must have the same number of entries as `auxiliary_types` |
+| `auxiliaryTypes` | string | No | - | Comma-separated source types for auxiliary specs (`"url"`, `"file"`, or `"dir"`) |
+| `auxiliaryLocations` | string | No | - | Comma-separated locations for auxiliary specs — must have the same number of entries as `auxiliaryTypes` |
 | `extendedSchema_enabled` | string | No | `"false"` | Enable extended schema validation for `@context` objects |
 | `extendedSchema_cacheTTL` | string | No | `"86400"` | Domain schema cache TTL in seconds |
 | `extendedSchema_maxCacheSize` | string | No | `"100"` | Maximum number of cached domain schemas |
@@ -46,7 +46,7 @@ schemaValidator:
 
 ### Auxiliary Specs
 
-Auxiliary specs allow operators to extend schema validation with additional action verbs beyond those defined in the primary Beckn spec. Both `auxiliary_types` and `auxiliary_locations` must be set together as matching comma-separated lists.
+Auxiliary specs allow operators to extend schema validation with additional action verbs beyond those defined in the primary Beckn spec. Both `auxiliaryTypes` and `auxiliaryLocations` must be set together as matching comma-separated lists.
 
 **Rules:**
 - Auxiliary specs are loaded after the primary spec; their actions are merged into a single index
@@ -193,8 +193,8 @@ schemaValidator:
     type: url
     location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
     cacheTTL: "3600"
-    auxiliary_types: "file,dir"
-    auxiliary_locations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
+    auxiliaryTypes: "file,dir"
+    auxiliaryLocations: "/etc/onix/schemas/energy-verbs.yaml,/etc/onix/schemas/domain/"
 ```
 
 ### With Extended Schema Validation
@@ -239,7 +239,9 @@ schemaValidator:
 | Invalid URL | `"Invalid URL or unreachable: <url>"` |
 | Schema validation fails | Returns detailed field-level errors |
 | Auxiliary action collides with primary | `"auxiliary spec[N] (<location>) defines action \"<action>\" which is already defined in a previously loaded spec — auxiliary specs may only add new actions"` |
-| `auxiliary_types` set without `auxiliary_locations` | `"auxiliary_types is set but auxiliary_locations is missing"` |
-| `auxiliary_locations` set without `auxiliary_types` | `"auxiliary_locations is set but auxiliary_types is missing"` |
-| Mismatched auxiliary list lengths | `"auxiliary_types and auxiliary_locations must have the same number of comma-separated entries"` |
+| Within-dir action collision | Error logged; dir spec skipped; startup fails with `"no actions indexed"` if no other spec is available |
+| No specs loaded / all specs failed | `"schemav2validator: no actions indexed after loading all specs — configure at least one valid primary or auxiliary spec"` |
+| `auxiliaryTypes` set without `auxiliaryLocations` | `"auxiliaryTypes is set but auxiliaryLocations is missing"` |
+| `auxiliaryLocations` set without `auxiliaryTypes` | `"auxiliaryLocations is set but auxiliaryTypes is missing"` |
+| Mismatched auxiliary list lengths | `"auxiliaryTypes and auxiliaryLocations must have the same number of comma-separated entries"` |
 

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
@@ -43,6 +43,16 @@ func (vp schemav2ValidatorProvider) New(ctx context.Context, config map[string]s
 	auxLocations := config["auxiliary_locations"]
 
 	if auxTypes != "" || auxLocations != "" {
+		// Guard against one key being set without the other before splitting —
+		// strings.Split("", ",") returns [""] (length 1), not [], which would
+		// pass the length check but produce a misleading empty-entry error.
+		if auxTypes == "" {
+			return nil, nil, errors.New("auxiliary_locations is set but auxiliary_types is missing")
+		}
+		if auxLocations == "" {
+			return nil, nil, errors.New("auxiliary_types is set but auxiliary_locations is missing")
+		}
+
 		types := strings.Split(auxTypes, ",")
 		locations := strings.Split(auxLocations, ",")
 

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
@@ -19,20 +19,45 @@ func (vp schemav2ValidatorProvider) New(ctx context.Context, config map[string]s
 		return nil, nil, errors.New("context cannot be nil")
 	}
 
-	typeVal, hasType := config["type"]
-	locVal, hasLoc := config["location"]
+	typeVal := config["type"]
+	locVal := config["location"]
 
-	if !hasType || typeVal == "" {
-		return nil, nil, errors.New("type not configured")
-	}
-	if !hasLoc || locVal == "" {
+	// Primary spec is optional — a non-Beckn deployment may rely solely on auxiliary specs.
+	// Validation that at least something is loaded happens inside schemav2validator.New.
+	if typeVal != "" && locVal == "" {
 		return nil, nil, errors.New("location not configured")
+	}
+	if locVal != "" && typeVal == "" {
+		return nil, nil, errors.New("type not configured")
 	}
 
 	cfg := &schemav2validator.Config{
 		Type:     typeVal,
 		Location: locVal,
 		CacheTTL: 3600,
+	}
+
+	// Parse auxiliary specs from comma-separated auxiliary_types and auxiliary_locations.
+	// Both lists must have the same length.
+	auxTypes := config["auxiliary_types"]
+	auxLocations := config["auxiliary_locations"]
+
+	if auxTypes != "" || auxLocations != "" {
+		types := strings.Split(auxTypes, ",")
+		locations := strings.Split(auxLocations, ",")
+
+		if len(types) != len(locations) {
+			return nil, nil, errors.New("auxiliary_types and auxiliary_locations must have the same number of comma-separated entries")
+		}
+
+		for i := range types {
+			t := strings.TrimSpace(types[i])
+			l := strings.TrimSpace(locations[i])
+			if t == "" || l == "" {
+				return nil, nil, errors.New("auxiliary_types and auxiliary_locations entries must not be empty")
+			}
+			cfg.Auxiliary = append(cfg.Auxiliary, schemav2validator.AuxSpec{Type: t, Location: l})
+		}
 	}
 
 	if ttlStr, ok := config["cacheTTL"]; ok {

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin.go
@@ -37,34 +37,34 @@ func (vp schemav2ValidatorProvider) New(ctx context.Context, config map[string]s
 		CacheTTL: 3600,
 	}
 
-	// Parse auxiliary specs from comma-separated auxiliary_types and auxiliary_locations.
+	// Parse auxiliary specs from comma-separated auxiliaryTypes and auxiliaryLocations.
 	// Both lists must have the same length.
-	auxTypes := config["auxiliary_types"]
-	auxLocations := config["auxiliary_locations"]
+	auxTypes := config["auxiliaryTypes"]
+	auxLocations := config["auxiliaryLocations"]
 
 	if auxTypes != "" || auxLocations != "" {
 		// Guard against one key being set without the other before splitting —
 		// strings.Split("", ",") returns [""] (length 1), not [], which would
 		// pass the length check but produce a misleading empty-entry error.
 		if auxTypes == "" {
-			return nil, nil, errors.New("auxiliary_locations is set but auxiliary_types is missing")
+			return nil, nil, errors.New("auxiliaryLocations is set but auxiliaryTypes is missing")
 		}
 		if auxLocations == "" {
-			return nil, nil, errors.New("auxiliary_types is set but auxiliary_locations is missing")
+			return nil, nil, errors.New("auxiliaryTypes is set but auxiliaryLocations is missing")
 		}
 
 		types := strings.Split(auxTypes, ",")
 		locations := strings.Split(auxLocations, ",")
 
 		if len(types) != len(locations) {
-			return nil, nil, errors.New("auxiliary_types and auxiliary_locations must have the same number of comma-separated entries")
+			return nil, nil, errors.New("auxiliaryTypes and auxiliaryLocations must have the same number of comma-separated entries")
 		}
 
 		for i := range types {
 			t := strings.TrimSpace(types[i])
 			l := strings.TrimSpace(locations[i])
 			if t == "" || l == "" {
-				return nil, nil, errors.New("auxiliary_types and auxiliary_locations entries must not be empty")
+				return nil, nil, errors.New("auxiliaryTypes and auxiliaryLocations entries must not be empty")
 			}
 			cfg.Auxiliary = append(cfg.Auxiliary, schemav2validator.AuxSpec{Type: t, Location: l})
 		}

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
@@ -178,12 +178,12 @@ func TestProvider_AuxiliaryConfig(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid auxiliary config",
+			name: "auxiliary collides with primary",
 			config: map[string]string{
-				"type":               "url",
-				"location":           primary.URL,
-				"auxiliary_types":    "url",
-				"auxiliary_locations": aux.URL,
+				"type":              "url",
+				"location":          primary.URL,
+				"auxiliaryTypes":    "url",
+				"auxiliaryLocations": aux.URL,
 			},
 			// aux and primary serve the same spec — collision on "test" action.
 			wantErr: true,
@@ -194,8 +194,8 @@ func TestProvider_AuxiliaryConfig(t *testing.T) {
 			config: map[string]string{
 				"type":               "url",
 				"location":           primary.URL,
-				"auxiliary_types":    "url,file",
-				"auxiliary_locations": aux.URL,
+				"auxiliaryTypes":     "url,file",
+				"auxiliaryLocations": aux.URL,
 			},
 			wantErr: true,
 			errMsg:  "same number",
@@ -203,33 +203,33 @@ func TestProvider_AuxiliaryConfig(t *testing.T) {
 		{
 			name: "empty auxiliary entry",
 			config: map[string]string{
-				"type":                "url",
-				"location":            primary.URL,
-				"auxiliary_types":     "url,",
-				"auxiliary_locations": aux.URL + ",",
+				"type":               "url",
+				"location":           primary.URL,
+				"auxiliaryTypes":     "url,",
+				"auxiliaryLocations": aux.URL + ",",
 			},
 			wantErr: true,
 			errMsg:  "must not be empty",
 		},
 		{
-			name: "auxiliary_types set without auxiliary_locations",
+			name: "auxiliaryTypes set without auxiliaryLocations",
 			config: map[string]string{
-				"type":            "url",
-				"location":        primary.URL,
-				"auxiliary_types": "url",
+				"type":           "url",
+				"location":       primary.URL,
+				"auxiliaryTypes": "url",
 			},
 			wantErr: true,
-			errMsg:  "auxiliary_locations is missing",
+			errMsg:  "auxiliaryLocations is missing",
 		},
 		{
-			name: "auxiliary_locations set without auxiliary_types",
+			name: "auxiliaryLocations set without auxiliaryTypes",
 			config: map[string]string{
-				"type":                "url",
-				"location":            primary.URL,
-				"auxiliary_locations": aux.URL,
+				"type":               "url",
+				"location":           primary.URL,
+				"auxiliaryLocations": aux.URL,
 			},
 			wantErr: true,
-			errMsg:  "auxiliary_types is missing",
+			errMsg:  "auxiliaryTypes is missing",
 		},
 		{
 			name: "no auxiliary keys — primary only",

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
@@ -160,6 +160,100 @@ func TestProvider_New(t *testing.T) {
 	}
 }
 
+func TestProvider_AuxiliaryConfig(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer primary.Close()
+
+	aux := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer aux.Close()
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid auxiliary config",
+			config: map[string]string{
+				"type":               "url",
+				"location":           primary.URL,
+				"auxiliary_types":    "url",
+				"auxiliary_locations": aux.URL,
+			},
+			// aux and primary serve the same spec — collision on "test" action.
+			wantErr: true,
+			errMsg:  "already defined",
+		},
+		{
+			name: "mismatched auxiliary list lengths",
+			config: map[string]string{
+				"type":               "url",
+				"location":           primary.URL,
+				"auxiliary_types":    "url,file",
+				"auxiliary_locations": aux.URL,
+			},
+			wantErr: true,
+			errMsg:  "same number",
+		},
+		{
+			name: "empty auxiliary entry",
+			config: map[string]string{
+				"type":               "url",
+				"location":           primary.URL,
+				"auxiliary_types":    "url,",
+				"auxiliary_locations": aux.URL + ",",
+			},
+			wantErr: true,
+			errMsg:  "must not be empty",
+		},
+		{
+			name: "no auxiliary keys — primary only",
+			config: map[string]string{
+				"type":     "url",
+				"location": primary.URL,
+			},
+			wantErr: false,
+		},
+		{
+			name: "type without location",
+			config: map[string]string{
+				"type": "url",
+			},
+			wantErr: true,
+			errMsg:  "location not configured",
+		},
+		{
+			name: "location without type",
+			config: map[string]string{
+				"location": primary.URL,
+			},
+			wantErr: true,
+			errMsg:  "type not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := schemav2ValidatorProvider{}
+			_, _, err := provider.New(context.Background(), tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" && err != nil {
+				if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("New() error = %v, want it to contain %q", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
 func TestProvider_ExportedVariable(t *testing.T) {
 	if Provider == (schemav2ValidatorProvider{}) {
 		t.Log("Provider variable is properly exported")

--- a/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/schemav2validator/cmd/plugin_test.go
@@ -203,13 +203,33 @@ func TestProvider_AuxiliaryConfig(t *testing.T) {
 		{
 			name: "empty auxiliary entry",
 			config: map[string]string{
-				"type":               "url",
-				"location":           primary.URL,
-				"auxiliary_types":    "url,",
+				"type":                "url",
+				"location":            primary.URL,
+				"auxiliary_types":     "url,",
 				"auxiliary_locations": aux.URL + ",",
 			},
 			wantErr: true,
 			errMsg:  "must not be empty",
+		},
+		{
+			name: "auxiliary_types set without auxiliary_locations",
+			config: map[string]string{
+				"type":            "url",
+				"location":        primary.URL,
+				"auxiliary_types": "url",
+			},
+			wantErr: true,
+			errMsg:  "auxiliary_locations is missing",
+		},
+		{
+			name: "auxiliary_locations set without auxiliary_types",
+			config: map[string]string{
+				"type":                "url",
+				"location":            primary.URL,
+				"auxiliary_locations": aux.URL,
+			},
+			wantErr: true,
+			errMsg:  "auxiliary_types is missing",
 		},
 		{
 			name: "no auxiliary keys — primary only",

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -24,10 +25,11 @@ type payload struct {
 
 // schemav2Validator implements the SchemaValidator interface.
 type schemav2Validator struct {
-	config      *Config
-	spec        *cachedSpec
-	specMutex   sync.RWMutex
-	schemaCache *schemaCache // cache for extended schemas
+	config          *Config
+	specMutex       sync.RWMutex
+	actionSchemas   map[string]*openapi3.SchemaRef // merged across primary + all auxiliary specs
+	bodylessActions map[string]struct{}             // merged across primary + all auxiliary specs
+	schemaCache     *schemaCache                    // cache for extended schemas
 }
 
 // cachedSpec holds a cached OpenAPI spec.
@@ -38,11 +40,21 @@ type cachedSpec struct {
 	loadedAt        time.Time
 }
 
-// Config struct for Schemav2Validator.
-type Config struct {
+// AuxSpec holds the type and location for a single auxiliary OpenAPI spec.
+type AuxSpec struct {
 	Type     string // "url", "file", or "dir"
 	Location string // URL, file path, or directory path
+}
+
+// Config struct for Schemav2Validator.
+type Config struct {
+	Type     string // "url", "file", or "dir" — primary spec
+	Location string // URL, file path, or directory path — primary spec
 	CacheTTL int
+
+	// Auxiliary specs — operator-defined, unsigned, additive only.
+	// Actions defined here must not overlap with the primary spec.
+	Auxiliary []AuxSpec
 
 	// Extended Schema configuration
 	EnableExtendedSchema bool
@@ -54,14 +66,19 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 	if config == nil {
 		return nil, nil, fmt.Errorf("config cannot be nil")
 	}
-	if config.Type == "" {
-		return nil, nil, fmt.Errorf("config type cannot be empty")
-	}
-	if config.Location == "" {
-		return nil, nil, fmt.Errorf("config location cannot be empty")
-	}
-	if config.Type != "url" && config.Type != "file" && config.Type != "dir" {
-		return nil, nil, fmt.Errorf("config type must be 'url', 'file', or 'dir'")
+
+	// Primary spec is optional — a non-Beckn deployment may use only auxiliary specs.
+	// If one of type/location is set, both must be set and type must be valid.
+	if config.Type != "" || config.Location != "" {
+		if config.Type == "" {
+			return nil, nil, fmt.Errorf("config type cannot be empty when location is set")
+		}
+		if config.Location == "" {
+			return nil, nil, fmt.Errorf("config location cannot be empty when type is set")
+		}
+		if config.Type != "url" && config.Type != "file" && config.Type != "dir" {
+			return nil, nil, fmt.Errorf("config type must be 'url', 'file', or 'dir'")
+		}
 	}
 
 	if config.CacheTTL == 0 {
@@ -69,7 +86,9 @@ func New(ctx context.Context, config *Config) (*schemav2Validator, func() error,
 	}
 
 	v := &schemav2Validator{
-		config: config,
+		config:          config,
+		actionSchemas:   make(map[string]*openapi3.SchemaRef),
+		bodylessActions: make(map[string]struct{}),
 	}
 
 	// Initialize extended schema cache if enabled
@@ -114,10 +133,10 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 		}
 
 		v.specMutex.RLock()
-		spec := v.spec
+		bodylessActions := v.bodylessActions
 		v.specMutex.RUnlock()
 
-		if spec == nil || spec.doc == nil {
+		if len(bodylessActions) == 0 {
 			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 		}
 
@@ -126,7 +145,7 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 		// Empty-body POST requests are rejected upstream by validateSchemaStep before
 		// reaching here, so only GET/DELETE arrive at this branch.
 		action := reqURL.Path
-		if _, ok := spec.bodylessActions[action]; !ok {
+		if _, ok := bodylessActions[action]; !ok {
 			return model.NewBadReqErr(fmt.Errorf("unsupported bodyless request for endpoint: %s", action))
 		}
 
@@ -145,17 +164,17 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	}
 
 	v.specMutex.RLock()
-	spec := v.spec
+	actionSchemas := v.actionSchemas
 	v.specMutex.RUnlock()
 
-	if spec == nil || spec.doc == nil {
+	if len(actionSchemas) == 0 {
 		return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 	}
 
 	action := payloadData.Context.Action
 
-	// O(1) lookup from action index
-	schema := spec.actionSchemas[action]
+	// O(1) lookup from merged action index
+	schema := actionSchemas[action]
 	if schema == nil || schema.Value == nil {
 		return model.NewBadReqErr(fmt.Errorf("unsupported action: %s", action))
 	}
@@ -192,66 +211,173 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	return nil
 }
 
-// initialise loads the OpenAPI spec from the configuration.
+// initialise loads all specs (primary + auxiliary) from the configuration.
 func (v *schemav2Validator) initialise(ctx context.Context) error {
-	return v.loadSpec(ctx)
+	return v.loadAllSpecs(ctx)
 }
 
-// loadSpec loads the OpenAPI spec from URL or local path.
-func (v *schemav2Validator) loadSpec(ctx context.Context) error {
-	loader := openapi3.NewLoader()
+// loadAllSpecs loads the primary spec (if configured) and all auxiliary specs,
+// merging their action indexes into the validator-level maps.
+// Auxiliary specs may only add new actions — any collision with the primary
+// is a hard error and the adapter will not start.
+func (v *schemav2Validator) loadAllSpecs(ctx context.Context) error {
+	mergedActionSchemas := make(map[string]*openapi3.SchemaRef)
+	mergedBodylessActions := make(map[string]struct{})
 
-	// Allow external references
+	hasPrimary := v.config.Type != "" && v.config.Location != ""
+
+	if !hasPrimary {
+		log.Warnf(ctx, "schemav2validator: no primary spec configured — operating without a signed trust anchor")
+	}
+
+	// Load primary spec first.
+	if hasPrimary {
+		spec, err := v.loadSingleSpec(ctx, v.config.Type, v.config.Location)
+		if err != nil {
+			return fmt.Errorf("failed to load primary spec: %w", err)
+		}
+		for action, schema := range spec.actionSchemas {
+			mergedActionSchemas[action] = schema
+		}
+		for action := range spec.bodylessActions {
+			mergedBodylessActions[action] = struct{}{}
+		}
+		log.Debugf(ctx, "Primary spec loaded: %d body actions, %d bodyless actions", len(spec.actionSchemas), len(spec.bodylessActions))
+	}
+
+	// Load each auxiliary spec and merge — hard-reject on action collision.
+	for i, aux := range v.config.Auxiliary {
+		spec, err := v.loadSingleSpec(ctx, aux.Type, aux.Location)
+		if err != nil {
+			log.Errorf(ctx, err, "Failed to load auxiliary spec[%d] (%s: %s) — skipping", i, aux.Type, aux.Location)
+			continue
+		}
+		for action, schema := range spec.actionSchemas {
+			if _, exists := mergedActionSchemas[action]; exists {
+				return fmt.Errorf("auxiliary spec[%d] (%s) defines action %q which is already defined in a previously loaded spec — auxiliary specs may only add new actions",
+					i, aux.Location, action)
+			}
+			mergedActionSchemas[action] = schema
+		}
+		for action := range spec.bodylessActions {
+			if _, exists := mergedBodylessActions[action]; exists {
+				return fmt.Errorf("auxiliary spec[%d] (%s) defines bodyless action %q which is already defined in a previously loaded spec — auxiliary specs may only add new actions",
+					i, aux.Location, action)
+			}
+			mergedBodylessActions[action] = struct{}{}
+		}
+		log.Debugf(ctx, "Auxiliary spec[%d] loaded from %s: %d body actions, %d bodyless actions", i, aux.Location, len(spec.actionSchemas), len(spec.bodylessActions))
+	}
+
+	if len(mergedActionSchemas) == 0 && len(mergedBodylessActions) == 0 {
+		log.Warnf(ctx, "schemav2validator: no actions indexed — all requests will fail schema validation")
+	}
+
+	v.specMutex.Lock()
+	v.actionSchemas = mergedActionSchemas
+	v.bodylessActions = mergedBodylessActions
+	v.specMutex.Unlock()
+
+	log.Debugf(ctx, "schemav2validator: merged index ready — %d body actions, %d bodyless actions",
+		len(mergedActionSchemas), len(mergedBodylessActions))
+	return nil
+}
+
+// loadSingleSpec loads one OpenAPI document from the given type and location.
+// For type "dir", all top-level *.yaml and *.json files are loaded and their
+// action indexes are merged into a single cachedSpec.
+func (v *schemav2Validator) loadSingleSpec(ctx context.Context, specType, location string) (*cachedSpec, error) {
+	if specType == "dir" {
+		return v.loadSpecFromDir(ctx, location)
+	}
+
+	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 
 	var doc *openapi3.T
 	var err error
 
-	switch v.config.Type {
+	switch specType {
 	case "url":
-		u, parseErr := url.Parse(v.config.Location)
+		u, parseErr := url.Parse(location)
 		if parseErr != nil {
-			return fmt.Errorf("failed to parse URL: %v", parseErr)
+			return nil, fmt.Errorf("failed to parse URL: %v", parseErr)
 		}
 		doc, err = loader.LoadFromURI(u)
 	case "file":
-		doc, err = loader.LoadFromFile(v.config.Location)
-	case "dir":
-		return fmt.Errorf("directory loading not yet implemented")
+		doc, err = loader.LoadFromFile(location)
 	default:
-		return fmt.Errorf("unsupported type: %s", v.config.Type)
+		return nil, fmt.Errorf("unsupported type: %s", specType)
 	}
 
 	if err != nil {
-		log.Errorf(ctx, err, "Failed to load from %s: %s", v.config.Type, v.config.Location)
-		return fmt.Errorf("failed to load OpenAPI document: %v", err)
+		log.Errorf(ctx, err, "Failed to load from %s: %s", specType, location)
+		return nil, fmt.Errorf("failed to load OpenAPI document: %v", err)
 	}
 
-	// Validate spec (skip strict validation to allow JSON Schema keywords)
 	if err := doc.Validate(ctx); err != nil {
-		log.Debugf(ctx, "Spec validation warnings (non-fatal): %v", err)
-	} else {
-		log.Debugf(ctx, "Spec validation passed")
+		log.Debugf(ctx, "Spec validation warnings (non-fatal) for %s: %v", location, err)
 	}
 
-	// Build action→schema index (body operations) and bodyless action set (GET/DELETE)
 	actionSchemas, bodylessActions := v.buildActionIndex(ctx, doc)
 
-	v.specMutex.Lock()
-	v.spec = &cachedSpec{
+	log.Debugf(ctx, "Loaded spec from %s: %s — %d body actions, %d bodyless actions",
+		specType, location, len(actionSchemas), len(bodylessActions))
+
+	return &cachedSpec{
 		doc:             doc,
 		actionSchemas:   actionSchemas,
 		bodylessActions: bodylessActions,
 		loadedAt:        time.Now(),
-	}
-	v.specMutex.Unlock()
-
-	log.Debugf(ctx, "Loaded OpenAPI spec from %s: %s with %d body actions and %d bodyless actions indexed",
-		v.config.Type, v.config.Location, len(actionSchemas), len(bodylessActions))
-	return nil
+	}, nil
 }
 
-// refreshLoop periodically reloads expired specs based on TTL.
+// loadSpecFromDir loads all top-level *.yaml and *.json files in the given
+// directory as independent specs and merges their action indexes.
+func (v *schemav2Validator) loadSpecFromDir(ctx context.Context, dir string) (*cachedSpec, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+
+	merged := &cachedSpec{
+		actionSchemas:   make(map[string]*openapi3.SchemaRef),
+		bodylessActions: make(map[string]struct{}),
+		loadedAt:        time.Now(),
+	}
+
+	loaded := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		filePath := dir + "/" + name
+		spec, err := v.loadSingleSpec(ctx, "file", filePath)
+		if err != nil {
+			log.Errorf(ctx, err, "Skipping file in dir spec: %s", filePath)
+			continue
+		}
+		for action, schema := range spec.actionSchemas {
+			merged.actionSchemas[action] = schema
+		}
+		for action := range spec.bodylessActions {
+			merged.bodylessActions[action] = struct{}{}
+		}
+		loaded++
+	}
+
+	if loaded == 0 {
+		log.Warnf(ctx, "No valid OpenAPI files found in directory: %s", dir)
+	}
+
+	return merged, nil
+}
+
+// refreshLoop periodically reloads all specs based on TTL.
 func (v *schemav2Validator) refreshLoop(ctx context.Context) {
 	coreTicker := time.NewTicker(time.Duration(v.config.CacheTTL) * time.Second)
 	defer coreTicker.Stop()
@@ -275,7 +401,7 @@ func (v *schemav2Validator) refreshLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-coreTicker.C:
-			v.reloadExpiredSpec(ctx)
+			v.reloadAllSpecs(ctx)
 		case <-refTickerCh:
 			if v.schemaCache != nil {
 				count := v.schemaCache.cleanupExpired()
@@ -287,22 +413,14 @@ func (v *schemav2Validator) refreshLoop(ctx context.Context) {
 	}
 }
 
-// reloadExpiredSpec reloads spec if it has exceeded its TTL.
-func (v *schemav2Validator) reloadExpiredSpec(ctx context.Context) {
-	v.specMutex.RLock()
-	if v.spec == nil {
-		v.specMutex.RUnlock()
-		return
-	}
-	needsReload := time.Since(v.spec.loadedAt) >= time.Duration(v.config.CacheTTL)*time.Second
-	v.specMutex.RUnlock()
-
-	if needsReload {
-		if err := v.loadSpec(ctx); err != nil {
-			log.Errorf(ctx, err, "Failed to reload spec")
-		} else {
-			log.Debugf(ctx, "Reloaded spec from %s: %s", v.config.Type, v.config.Location)
-		}
+// reloadAllSpecs rebuilds the merged action index from all specs on TTL expiry.
+// If the reload fails (e.g. a collision introduced by a refreshed auxiliary),
+// the previous valid index is retained and an error is logged.
+func (v *schemav2Validator) reloadAllSpecs(ctx context.Context) {
+	if err := v.loadAllSpecs(ctx); err != nil {
+		log.Errorf(ctx, err, "Failed to reload specs — retaining previous action index")
+	} else {
+		log.Debugf(ctx, "Reloaded all specs successfully")
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -27,9 +28,10 @@ type payload struct {
 type schemav2Validator struct {
 	config          *Config
 	specMutex       sync.RWMutex
-	actionSchemas   map[string]*openapi3.SchemaRef // merged across primary + all auxiliary specs
-	bodylessActions map[string]struct{}             // merged across primary + all auxiliary specs
-	schemaCache     *schemaCache                    // cache for extended schemas
+	specsLoaded     bool                            // true once at least one successful loadAllSpecs has completed
+	actionSchemas   map[string]*openapi3.SchemaRef  // merged across primary + all auxiliary specs
+	bodylessActions map[string]struct{}              // merged across primary + all auxiliary specs
+	schemaCache     *schemaCache                     // cache for extended schemas
 }
 
 // cachedSpec holds a cached OpenAPI spec.
@@ -133,10 +135,11 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 		}
 
 		v.specMutex.RLock()
+		specsLoaded := v.specsLoaded
 		bodylessActions := v.bodylessActions
 		v.specMutex.RUnlock()
 
-		if len(bodylessActions) == 0 {
+		if !specsLoaded {
 			return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 		}
 
@@ -164,10 +167,11 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	}
 
 	v.specMutex.RLock()
+	specsLoaded := v.specsLoaded
 	actionSchemas := v.actionSchemas
 	v.specMutex.RUnlock()
 
-	if len(actionSchemas) == 0 {
+	if !specsLoaded {
 		return model.NewBadReqErr(fmt.Errorf("no OpenAPI spec loaded"))
 	}
 
@@ -274,6 +278,7 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context) error {
 	}
 
 	v.specMutex.Lock()
+	v.specsLoaded = true
 	v.actionSchemas = mergedActionSchemas
 	v.bodylessActions = mergedBodylessActions
 	v.specMutex.Unlock()
@@ -355,16 +360,22 @@ func (v *schemav2Validator) loadSpecFromDir(ctx context.Context, dir string) (*c
 		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".json") {
 			continue
 		}
-		filePath := dir + "/" + name
+		filePath := filepath.Join(dir, name)
 		spec, err := v.loadSingleSpec(ctx, "file", filePath)
 		if err != nil {
 			log.Errorf(ctx, err, "Skipping file in dir spec: %s", filePath)
 			continue
 		}
 		for action, schema := range spec.actionSchemas {
+			if _, exists := merged.actionSchemas[action]; exists {
+				log.Warnf(ctx, "Dir spec: action %q defined in multiple files — later file %s wins", action, filePath)
+			}
 			merged.actionSchemas[action] = schema
 		}
 		for action := range spec.bodylessActions {
+			if _, exists := merged.bodylessActions[action]; exists {
+				log.Warnf(ctx, "Dir spec: bodyless action %q defined in multiple files — later file %s wins", action, filePath)
+			}
 			merged.bodylessActions[action] = struct{}{}
 		}
 		loaded++
@@ -418,7 +429,7 @@ func (v *schemav2Validator) refreshLoop(ctx context.Context) {
 // the previous valid index is retained and an error is logged.
 func (v *schemav2Validator) reloadAllSpecs(ctx context.Context) {
 	if err := v.loadAllSpecs(ctx); err != nil {
-		log.Errorf(ctx, err, "Failed to reload specs — retaining previous action index")
+		log.Errorf(ctx, err, "Failed to reload specs — serving stale action index until next TTL cycle")
 	} else {
 		log.Debugf(ctx, "Reloaded all specs successfully")
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -216,15 +216,23 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 }
 
 // initialise loads all specs (primary + auxiliary) from the configuration.
+// Auxiliary load failures are skipped at startup — the adapter starts with whatever loaded.
 func (v *schemav2Validator) initialise(ctx context.Context) error {
-	return v.loadAllSpecs(ctx)
+	return v.loadAllSpecs(ctx, false)
 }
 
 // loadAllSpecs loads the primary spec (if configured) and all auxiliary specs,
 // merging their action indexes into the validator-level maps.
-// Auxiliary specs may only add new actions — any collision with the primary
-// is a hard error and the adapter will not start.
-func (v *schemav2Validator) loadAllSpecs(ctx context.Context) error {
+//
+// failOnAuxError controls auxiliary failure handling:
+//   - false (startup): a failed auxiliary is skipped and logged; the adapter starts
+//     with whatever was successfully loaded.
+//   - true (TTL refresh): any auxiliary failure returns an error so the caller
+//     retains the previous valid index intact rather than silently dropping
+//     the actions that were contributed by the failed spec.
+//
+// Auxiliary specs may only add new actions — any collision is always a hard error.
+func (v *schemav2Validator) loadAllSpecs(ctx context.Context, failOnAuxError bool) error {
 	mergedActionSchemas := make(map[string]*openapi3.SchemaRef)
 	mergedBodylessActions := make(map[string]struct{})
 
@@ -253,6 +261,13 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context) error {
 	for i, aux := range v.config.Auxiliary {
 		spec, err := v.loadSingleSpec(ctx, aux.Type, aux.Location)
 		if err != nil {
+			if failOnAuxError {
+				// On TTL refresh: propagate the error so reloadAllSpecs retains
+				// the previous valid index rather than committing an index that
+				// is missing this auxiliary's actions.
+				return fmt.Errorf("auxiliary spec[%d] (%s: %s) failed to reload — retaining previous index: %w",
+					i, aux.Type, aux.Location, err)
+			}
 			log.Errorf(ctx, err, "Failed to load auxiliary spec[%d] (%s: %s) — skipping", i, aux.Type, aux.Location)
 			continue
 		}
@@ -425,10 +440,10 @@ func (v *schemav2Validator) refreshLoop(ctx context.Context) {
 }
 
 // reloadAllSpecs rebuilds the merged action index from all specs on TTL expiry.
-// If the reload fails (e.g. a collision introduced by a refreshed auxiliary),
-// the previous valid index is retained and an error is logged.
+// Any failure (primary, auxiliary, or collision) causes the previous valid index
+// to be retained — the new index is only committed when all specs load cleanly.
 func (v *schemav2Validator) reloadAllSpecs(ctx context.Context) {
-	if err := v.loadAllSpecs(ctx); err != nil {
+	if err := v.loadAllSpecs(ctx, true); err != nil {
 		log.Errorf(ctx, err, "Failed to reload specs — serving stale action index until next TTL cycle")
 	} else {
 		log.Debugf(ctx, "Reloaded all specs successfully")

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -274,7 +274,7 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context) error {
 	}
 
 	if len(mergedActionSchemas) == 0 && len(mergedBodylessActions) == 0 {
-		log.Warnf(ctx, "schemav2validator: no actions indexed — all requests will fail schema validation")
+		return fmt.Errorf("schemav2validator: no actions indexed after loading all specs — configure at least one valid primary or auxiliary spec")
 	}
 
 	v.specMutex.Lock()
@@ -368,13 +368,13 @@ func (v *schemav2Validator) loadSpecFromDir(ctx context.Context, dir string) (*c
 		}
 		for action, schema := range spec.actionSchemas {
 			if _, exists := merged.actionSchemas[action]; exists {
-				log.Warnf(ctx, "Dir spec: action %q defined in multiple files — later file %s wins", action, filePath)
+				return nil, fmt.Errorf("dir spec %q: action %q defined in multiple files — last seen in %s; remove the duplicate", dir, action, filePath)
 			}
 			merged.actionSchemas[action] = schema
 		}
 		for action := range spec.bodylessActions {
 			if _, exists := merged.bodylessActions[action]; exists {
-				log.Warnf(ctx, "Dir spec: bodyless action %q defined in multiple files — later file %s wins", action, filePath)
+				return nil, fmt.Errorf("dir spec %q: bodyless action %q defined in multiple files — last seen in %s; remove the duplicate", dir, action, filePath)
 			}
 			merged.bodylessActions[action] = struct{}{}
 		}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -135,8 +135,8 @@ func TestNew(t *testing.T) {
 		wantErr bool
 	}{
 		{"nil config", nil, true},
-		{"empty type", &Config{Type: "", Location: "http://example.com"}, true},
-		{"empty location", &Config{Type: "url", Location: ""}, true},
+		{"empty type with location set", &Config{Type: "", Location: "http://example.com"}, true},
+		{"empty location with type set", &Config{Type: "url", Location: ""}, true},
 		{"invalid type", &Config{Type: "invalid", Location: "http://example.com"}, true},
 		{"invalid URL", &Config{Type: "url", Location: "http://invalid-domain-12345.com/spec.yaml"}, true},
 	}
@@ -366,8 +366,8 @@ func TestLoadSpec_LocalFile(t *testing.T) {
 	validator.specMutex.RLock()
 	defer validator.specMutex.RUnlock()
 
-	if validator.spec == nil || validator.spec.doc == nil {
-		t.Error("Spec not loaded from local file")
+	if len(validator.actionSchemas) == 0 {
+		t.Error("Spec not loaded from local file — action index is empty")
 	}
 }
 
@@ -437,6 +437,235 @@ func TestValidate_EdgeCases(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// auxSpec mirrors the schemav2validator.AuxSpec type for test use.
+const testSpecAux = `openapi: 3.1.0
+info:
+  title: Auxiliary API
+  version: 1.0.0
+paths:
+  /subscribe:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context, message]
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: subscribe
+                message:
+                  type: object
+  /renew:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context, message]
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: renew
+                message:
+                  type: object
+`
+
+// testSpecConflict defines "search" — same action as testSpec — to trigger hard-reject.
+const testSpecConflict = `openapi: 3.1.0
+info:
+  title: Conflict API
+  version: 1.0.0
+paths:
+  /search:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: search
+`
+
+func TestAuxiliary_AddsNewActions(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer primary.Close()
+
+	auxiliary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpecAux))
+	}))
+	defer auxiliary.Close()
+
+	validator, _, err := New(context.Background(), &Config{
+		Type:     "url",
+		Location: primary.URL,
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: auxiliary.URL},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		action  string
+		payload string
+	}{
+		{"search", `{"context":{"action":"search","domain":"retail"},"message":{}}`},
+		{"select", `{"context":{"action":"select"},"message":{"order":{}}}`},
+		{"subscribe", `{"context":{"action":"subscribe"},"message":{}}`},
+		{"renew", `{"context":{"action":"renew"},"message":{}}`},
+	}
+	for _, c := range cases {
+		if err := validator.Validate(context.Background(), nil, []byte(c.payload)); err != nil {
+			t.Errorf("action %q: unexpected validation error: %v", c.action, err)
+		}
+	}
+}
+
+func TestAuxiliary_ShadowPrimaryHardRejects(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer primary.Close()
+
+	conflict := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpecConflict))
+	}))
+	defer conflict.Close()
+
+	_, _, err := New(context.Background(), &Config{
+		Type:     "url",
+		Location: primary.URL,
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: conflict.URL},
+		},
+	})
+	if err == nil {
+		t.Fatal("New() expected error for action collision, got nil")
+	}
+	if !contains(err.Error(), "already defined") {
+		t.Errorf("New() error = %v, want it to mention 'already defined'", err)
+	}
+}
+
+func TestAuxiliary_DirType(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(dir+"/aux1.yaml", []byte(testSpecAux), 0644); err != nil {
+		t.Fatalf("failed to write aux1.yaml: %v", err)
+	}
+
+	// A second spec with a unique action to confirm both files are loaded.
+	spec2 := `openapi: 3.1.0
+info:
+  title: Dir Spec 2
+  version: 1.0.0
+paths:
+  /cancel:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                context:
+                  type: object
+                  properties:
+                    action:
+                      const: cancel
+`
+	if err := os.WriteFile(dir+"/aux2.yaml", []byte(spec2), 0644); err != nil {
+		t.Fatalf("failed to write aux2.yaml: %v", err)
+	}
+
+	validator, _, err := New(context.Background(), &Config{
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "dir", Location: dir},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	for _, payload := range []string{
+		`{"context":{"action":"subscribe"},"message":{}}`,
+		`{"context":{"action":"renew"},"message":{}}`,
+		`{"context":{"action":"cancel"}}`,
+	} {
+		if err := validator.Validate(context.Background(), nil, []byte(payload)); err != nil {
+			t.Errorf("dir type validation failed for %s: %v", payload, err)
+		}
+	}
+}
+
+func TestAuxiliary_NoPrimary_NonBeckn(t *testing.T) {
+	auxiliary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpecAux))
+	}))
+	defer auxiliary.Close()
+
+	validator, _, err := New(context.Background(), &Config{
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: auxiliary.URL},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"subscribe"},"message":{}}`)); err != nil {
+		t.Errorf("non-Beckn deployment: unexpected validation error: %v", err)
+	}
+}
+
+func TestAuxiliary_BadLocationSkipped(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer primary.Close()
+
+	// Adapter should still start; the bad auxiliary is skipped.
+	validator, _, err := New(context.Background(), &Config{
+		Type:     "url",
+		Location: primary.URL,
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: "http://invalid-domain-99999.example.com/spec.yaml"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error for bad auxiliary: %v", err)
+	}
+
+	// Primary actions still available.
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
+		t.Errorf("primary action failed after bad auxiliary skipped: %v", err)
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -670,6 +670,57 @@ func TestAuxiliary_BadLocationSkipped(t *testing.T) {
 	}
 }
 
+func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer primary.Close()
+
+	// Auxiliary starts healthy.
+	auxHealthy := true
+	aux := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auxHealthy {
+			w.Write([]byte(testSpecAux))
+		} else {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		}
+	}))
+	defer aux.Close()
+
+	validator, _, err := New(context.Background(), &Config{
+		Type:     "url",
+		Location: primary.URL,
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: aux.URL},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	// Auxiliary actions should be available after startup.
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"subscribe"},"message":{}}`)); err != nil {
+		t.Fatalf("auxiliary action unavailable at startup: %v", err)
+	}
+
+	// Auxiliary goes down — simulate a transient failure.
+	auxHealthy = false
+
+	// Force a TTL refresh.
+	validator.reloadAllSpecs(context.Background())
+
+	// Previous index must still be served — auxiliary actions must still work.
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"subscribe"},"message":{}}`)); err != nil {
+		t.Errorf("auxiliary action dropped after failed refresh — old index should have been retained: %v", err)
+	}
+
+	// Primary actions must also still work.
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
+		t.Errorf("primary action dropped after failed refresh: %v", err)
+	}
+}
+
 func TestAuxiliary_DirType_IntraDirCollisionHardRejects(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -666,6 +667,50 @@ func TestAuxiliary_BadLocationSkipped(t *testing.T) {
 	// Primary actions still available.
 	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
 		t.Errorf("primary action failed after bad auxiliary skipped: %v", err)
+	}
+}
+
+func TestAuxiliary_DirType_IntraDirCollisionHardRejects(t *testing.T) {
+	dir := t.TempDir()
+
+	// Both files define "subscribe" — within-dir collision must cause New() to fail.
+	// The specific collision error is logged; New() surfaces "no actions indexed"
+	// because the colliding dir spec is skipped (same skip policy as load failures)
+	// and no other spec is configured.
+	for _, name := range []string{"a.yaml", "b.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(testSpecAux), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	_, _, err := New(context.Background(), &Config{
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "dir", Location: dir},
+		},
+	})
+	if err == nil {
+		t.Fatal("New() expected error for intra-dir action collision, got nil")
+	}
+	// The adapter refuses to start; the specific collision detail appears in error logs.
+	if !contains(err.Error(), "no actions indexed") {
+		t.Errorf("New() error = %v, want it to mention 'no actions indexed'", err)
+	}
+}
+
+func TestAuxiliary_AllSpecsFail_HardRejects(t *testing.T) {
+	// No primary, no valid auxiliary — adapter must refuse to start.
+	_, _, err := New(context.Background(), &Config{
+		CacheTTL: 3600,
+		Auxiliary: []AuxSpec{
+			{Type: "url", Location: "http://invalid-domain-99999.example.com/spec.yaml"},
+		},
+	})
+	if err == nil {
+		t.Fatal("New() expected error when all specs fail to load, got nil")
+	}
+	if !contains(err.Error(), "no actions indexed") {
+		t.Errorf("New() error = %v, want it to mention 'no actions indexed'", err)
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -671,6 +671,17 @@ func TestAuxiliary_BadLocationSkipped(t *testing.T) {
 	}
 }
 
+// TestAuxiliary_RefreshRetainsIndexOnAuxFailure verifies that actions remain
+// available after a TTL refresh attempt.
+//
+// NOTE: this test does NOT exercise the failOnAuxError retain-old-index path.
+// kin-openapi's package-level URIMapCache (DefaultReadFromURI) caches raw bytes
+// keyed by URI for the entire process lifetime. Setting auxHealthy=false makes
+// the httptest server return a 503, but the reload never reaches the server —
+// kin-openapi returns the bytes it cached at startup, so the reload silently
+// succeeds from cache rather than failing. Once #795 is fixed (per-call
+// ReadFromURIFunc bypasses the global cache), this test will properly exercise
+// the retain-old-index path.
 func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(testSpec))
@@ -708,12 +719,16 @@ func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 	}
 
 	// Auxiliary goes down — simulate a transient failure.
+	// Due to the kin-openapi global cache (#795) the reload below will use
+	// cached bytes and succeed rather than fail, so auxHealthy=false has no
+	// observable effect until #795 is fixed.
 	auxHealthy.Store(false)
 
 	// Force a TTL refresh.
 	validator.reloadAllSpecs(context.Background())
 
-	// Previous index must still be served — auxiliary actions must still work.
+	// Actions must still be available after a reload (regardless of whether
+	// the reload succeeded from cache or retained the old index on failure).
 	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"subscribe"},"message":{}}`)); err != nil {
 		t.Errorf("auxiliary action dropped after failed refresh — old index should have been retained: %v", err)
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -441,7 +442,7 @@ func TestValidate_EdgeCases(t *testing.T) {
 	}
 }
 
-// auxSpec mirrors the schemav2validator.AuxSpec type for test use.
+// testSpecAux is an OpenAPI 3.1 spec used as an auxiliary spec in tests; it defines the "subscribe" and "renew" actions.
 const testSpecAux = `openapi: 3.1.0
 info:
   title: Auxiliary API
@@ -574,7 +575,7 @@ func TestAuxiliary_ShadowPrimaryHardRejects(t *testing.T) {
 func TestAuxiliary_DirType(t *testing.T) {
 	dir := t.TempDir()
 
-	if err := os.WriteFile(dir+"/aux1.yaml", []byte(testSpecAux), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "aux1.yaml"), []byte(testSpecAux), 0644); err != nil {
 		t.Fatalf("failed to write aux1.yaml: %v", err)
 	}
 
@@ -599,7 +600,7 @@ paths:
                     action:
                       const: cancel
 `
-	if err := os.WriteFile(dir+"/aux2.yaml", []byte(spec2), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "aux2.yaml"), []byte(spec2), 0644); err != nil {
 		t.Fatalf("failed to write aux2.yaml: %v", err)
 	}
 
@@ -676,10 +677,12 @@ func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 	}))
 	defer primary.Close()
 
-	// Auxiliary starts healthy.
-	auxHealthy := true
+	// Auxiliary starts healthy. Use atomic.Bool to avoid a data race between
+	// the test goroutine (which sets the flag) and the httptest handler goroutine.
+	var auxHealthy atomic.Bool
+	auxHealthy.Store(true)
 	aux := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if auxHealthy {
+		if auxHealthy.Load() {
 			w.Write([]byte(testSpecAux))
 		} else {
 			http.Error(w, "unavailable", http.StatusServiceUnavailable)
@@ -705,7 +708,7 @@ func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 	}
 
 	// Auxiliary goes down — simulate a transient failure.
-	auxHealthy = false
+	auxHealthy.Store(false)
 
 	// Force a TTL refresh.
 	validator.reloadAllSpecs(context.Background())


### PR DESCRIPTION
## Summary

Closes #780

- Adds `auxiliary_types` / `auxiliary_locations` comma-separated config keys to `schemav2validator`, allowing operators to layer additional OpenAPI specs on top of the primary (signed) Beckn spec
- Primary spec is now optional — non-Beckn deployments can operate with auxiliary specs only
- Implements the previously-stubbed `dir` type: loads all top-level `*.yaml`/`*.yml`/`*.json` files in a directory as specs
- Hard-rejects at startup if any auxiliary action collides with the primary (auxiliary specs may only add, never shadow)
- On TTL refresh, merged index is rebuilt from scratch; previous valid index is retained on failure

## Config shape

```yaml
plugins:
  schemav2validator:
    type: url
    location: https://.../beckn.yaml          # primary — signed, injected by beckndefaults
    auxiliary_types: "file,url,dir"
    auxiliary_locations: "/etc/onix/energy.yaml,https://example.com/custom.yaml,/etc/onix/domain/"
```

## Test plan

- [ ] `TestAuxiliary_AddsNewActions` — primary + auxiliary actions all validate
- [ ] `TestAuxiliary_ShadowPrimaryHardRejects` — collision on startup returns error
- [ ] `TestAuxiliary_DirType` — all files in dir loaded, actions available
- [ ] `TestAuxiliary_NoPrimary_NonBeckn` — no primary, auxiliary carries full action set
- [ ] `TestAuxiliary_BadLocationSkipped` — bad auxiliary skipped, primary actions intact
- [ ] `TestProvider_AuxiliaryConfig` — config parsing: valid, mismatched lengths, empty entries
- [ ] All existing tests pass unmodified