### PR TITLE
feat(definition): SchemaVersionMediator and Translator plugin interfaces

### DIFF
--- a/pkg/plugin/definition/schemaversionmediator.go
+++ b/pkg/plugin/definition/schemaversionmediator.go
@@ -1,0 +1,25 @@
+package definition
+
+import (
+	"context"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+)
+
+// SchemaVersionMediator mediates schema version differences in a Beckn payload.
+// It walks the payload, checks compatibility against the node manifest, fetches
+// translation artifacts, dispatches to the appropriate translator, and enforces
+// the configured data-loss policy.
+//
+// Mediate is direction-agnostic: both the receiver handler (inbound) and the
+// caller handler (outbound) invoke it via their respective StepContext.
+type SchemaVersionMediator interface {
+	Mediate(ctx *model.StepContext) error
+}
+
+// SchemaVersionMediatorProvider initializes a SchemaVersionMediator with its
+// dependencies. loader is injected so the mediator can fetch the node manifest
+// for the network at runtime without owning the fetch/cache lifecycle.
+type SchemaVersionMediatorProvider interface {
+	New(ctx context.Context, loader ManifestLoader, config map[string]string) (SchemaVersionMediator, func() error, error)
+}

--- a/pkg/plugin/definition/translator.go
+++ b/pkg/plugin/definition/translator.go
@@ -1,0 +1,23 @@
+package definition
+
+import "context"
+
+// Translator executes a single translation pass over a payload fragment using
+// a fetched translation artifact. Implementations are stateless — all state
+// required for translation is carried in the artifact bytes themselves.
+//
+// artifact is the raw bytes of the translation artifact fetched from
+// schema.beckn.io (e.g. a JSONata expression). payload is the payload fragment
+// to be translated. The translated fragment is returned as a new byte slice.
+//
+// The mediator selects the Translator implementation by matching the artifact's
+// Content-Type, allowing a single mediation pass to dispatch different fragments
+// to different translators (e.g. JSONata for one schema delta, SHACL for another).
+type Translator interface {
+	Translate(ctx context.Context, artifact []byte, payload []byte) ([]byte, error)
+}
+
+// TranslatorProvider initializes a Translator instance with its configuration.
+type TranslatorProvider interface {
+	New(ctx context.Context, config map[string]string) (Translator, func() error, error)
+}


### PR DESCRIPTION
## Summary

- Adds `SchemaVersionMediator` interface and `SchemaVersionMediatorProvider` in `pkg/plugin/definition/schemaversionmediator.go`
- Adds `Translator` interface and `TranslatorProvider` in `pkg/plugin/definition/translator.go`

## Design decisions

- `Mediate(ctx *model.StepContext) error` is direction-agnostic — both the receiver handler (inbound) and caller handler (outbound) invoke the same method via their respective `StepContext`. Direction-specific guards (cold-start, nil-body) are implementation concerns, not interface concerns.
- `ManifestLoader` is injected into `SchemaVersionMediatorProvider.New` — the mediator does not own the manifest fetch/cache lifecycle.
- `Translator` is stateless (`Translate(ctx, artifact, payload)`). The mediator selects the implementation by artifact `Content-Type`, enabling a single mediation pass to dispatch different payload fragments to different translators (e.g. JSONata for one schema delta, SHACL for another).
- `CompatibilityCheck` is intentionally not a separate interface — it is an internal concern of the mediator implementation with no standalone plugin utility.

## Dependencies

Closes part of #770
Requires #769 (ManifestLoader interface) — already available in `definition/manifestloader.go`

## Test plan

- [ ] `go build ./pkg/plugin/definition/...` passes (verified locally)
- [ ] Implementation branches (walker, mediation loop) will add unit tests against these interfaces