### PR TITLE
feat(schemaversionmediator): payload walker and compatibility check

### DIFF
--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -1,0 +1,103 @@
+// Package schemaversionmediator implements the SchemaVersionMediator plugin.
+// It walks inbound Beckn payloads, checks schema object compatibility against
+// the local node manifest, and dispatches translation for incompatible objects.
+package schemaversionmediator
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+)
+
+// TranslationNeeded describes a single schema object from the payload that
+// the local node cannot handle as-is and requires translation.
+//
+// From is the schema object as declared in the inbound payload.
+// To is the schema object the local node supports for the same Type.
+// To is nil when the Type is entirely absent from the local node manifest —
+// an unknown schema whose handling is governed by the data-loss policy.
+type TranslationNeeded struct {
+	From model.SchemaObject
+	To   *model.SchemaObject
+}
+
+// WalkPayload recursively traverses a JSON payload and returns all schema
+// objects declared via JSON-LD "@context" and "@type" fields. The walk is
+// depth-first and collects every qualifying node regardless of nesting level.
+// The payload is not modified.
+func WalkPayload(payload []byte) ([]model.SchemaObject, error) {
+	var root any
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: walk payload: %w", err)
+	}
+	var results []model.SchemaObject
+	walkNode(root, &results)
+	return results, nil
+}
+
+// walkNode is the recursive descent worker for WalkPayload.
+func walkNode(node any, results *[]model.SchemaObject) {
+	switch v := node.(type) {
+	case map[string]any:
+		if contextURL, ok := stringField(v, "@context"); ok {
+			if typ, ok := stringField(v, "@type"); ok {
+				*results = append(*results, model.SchemaObject{
+					ContextURL: contextURL,
+					Type:       typ,
+				})
+			}
+		}
+		for _, child := range v {
+			walkNode(child, results)
+		}
+	case []any:
+		for _, item := range v {
+			walkNode(item, results)
+		}
+	}
+}
+
+// stringField returns the string value of key in m, reporting whether it was
+// present and non-empty.
+func stringField(m map[string]any, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok && s != ""
+}
+
+// CheckCompatibility compares extracted schema objects against the local node
+// manifest and returns those that require translation. An empty result means
+// the payload is fully compatible and the mediator can short-circuit.
+//
+// For each extracted SchemaObject:
+//   - Exact match in manifest → compatible, omitted from result.
+//   - Same Type, different ContextURL → TranslationNeeded with To set to the
+//     locally supported SchemaObject (version the node expects).
+//   - Type absent from manifest entirely → TranslationNeeded with To nil;
+//     handling is delegated to the data-loss policy enforcer.
+func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeManifest) []TranslationNeeded {
+	supported := make(map[string]model.SchemaObject, len(manifest.Schema.SchemaObjects))
+	for _, obj := range manifest.Schema.SchemaObjects {
+		supported[obj.Type] = obj
+	}
+
+	var needs []TranslationNeeded
+	for _, from := range extracted {
+		local, known := supported[from.Type]
+		switch {
+		case !known:
+			// Type entirely absent from the local manifest — unknown schema.
+			needs = append(needs, TranslationNeeded{From: from})
+		case local.ContextURL != from.ContextURL:
+			// Same type, different version — translation required.
+			to := local
+			needs = append(needs, TranslationNeeded{From: from, To: &to})
+		}
+		// Exact match: compatible — no entry added.
+	}
+	return needs
+}

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -5,10 +5,16 @@ package schemaversionmediator
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
+
+// ErrNoManifest is returned by CheckCompatibility when the node manifest is nil.
+// The caller should log a warning and skip mediation — translation targets cannot
+// be determined without a manifest, but the absence of one is not a hard failure.
+var ErrNoManifest = errors.New("schemaversionmediator: node manifest unavailable, skipping mediation")
 
 // TranslationNeeded describes a single schema object from the payload that
 // the local node cannot handle as-is and requires translation.
@@ -24,7 +30,9 @@ type TranslationNeeded struct {
 
 // WalkPayload recursively traverses a JSON payload and returns all schema
 // objects declared via JSON-LD "@context" and "@type" fields. The walk is
-// depth-first and collects every qualifying node regardless of nesting level.
+// depth-first and collects every qualifying node regardless of nesting level,
+// including both a parent node and its nested children when both carry
+// "@context"/"@type" declarations — each is an independent schema contract.
 // The payload is not modified.
 func WalkPayload(payload []byte) ([]model.SchemaObject, error) {
 	var root any
@@ -37,6 +45,9 @@ func WalkPayload(payload []byte) ([]model.SchemaObject, error) {
 }
 
 // walkNode is the recursive descent worker for WalkPayload.
+// When a map node carries both "@context" and "@type" it is collected, then
+// the walk continues into its children — a parent and its nested children may
+// each declare independent schema objects and both are valid collection targets.
 func walkNode(node any, results *[]model.SchemaObject) {
 	switch v := node.(type) {
 	case map[string]any:
@@ -48,7 +59,12 @@ func walkNode(node any, results *[]model.SchemaObject) {
 				})
 			}
 		}
-		for _, child := range v {
+		for key, child := range v {
+			// Skip the JSON-LD marker fields themselves — they are strings and
+			// descending into them is a no-op, but skipping makes intent explicit.
+			if key == "@context" || key == "@type" {
+				continue
+			}
 			walkNode(child, results)
 		}
 	case []any:
@@ -73,13 +89,20 @@ func stringField(m map[string]any, key string) (string, bool) {
 // manifest and returns those that require translation. An empty result means
 // the payload is fully compatible and the mediator can short-circuit.
 //
+// Returns ErrNoManifest if manifest is nil — the caller should log a warning
+// and skip mediation rather than treating this as a hard failure.
+//
 // For each extracted SchemaObject:
 //   - Exact match in manifest → compatible, omitted from result.
 //   - Same Type, different ContextURL → TranslationNeeded with To set to the
 //     locally supported SchemaObject (version the node expects).
 //   - Type absent from manifest entirely → TranslationNeeded with To nil;
 //     handling is delegated to the data-loss policy enforcer.
-func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeManifest) []TranslationNeeded {
+func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeManifest) ([]TranslationNeeded, error) {
+	if manifest == nil {
+		return nil, ErrNoManifest
+	}
+
 	supported := make(map[string]model.SchemaObject, len(manifest.Schema.SchemaObjects))
 	for _, obj := range manifest.Schema.SchemaObjects {
 		supported[obj.Type] = obj
@@ -99,5 +122,5 @@ func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeMani
 		}
 		// Exact match: compatible — no entry added.
 	}
-	return needs
+	return needs, nil
 }

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -1,0 +1,220 @@
+package schemaversionmediator
+
+import (
+	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+)
+
+// --- WalkPayload tests ---
+
+func TestWalkPayload_SingleObject(t *testing.T) {
+	payload := []byte(`{
+		"@context": "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld",
+		"@type": "Order"
+	}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 schema object, got %d", len(got))
+	}
+	if got[0].ContextURL != "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld" {
+		t.Errorf("unexpected ContextURL: %s", got[0].ContextURL)
+	}
+	if got[0].Type != "Order" {
+		t.Errorf("unexpected Type: %s", got[0].Type)
+	}
+}
+
+func TestWalkPayload_NestedObjects(t *testing.T) {
+	payload := []byte(`{
+		"message": {
+			"@context": "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld",
+			"@type": "Order",
+			"item": {
+				"@context": "https://schema.beckn.io/retail/schema/1.1.0/item.jsonld",
+				"@type": "Item"
+			}
+		}
+	}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 schema objects, got %d", len(got))
+	}
+}
+
+func TestWalkPayload_ArrayOfObjects(t *testing.T) {
+	payload := []byte(`{
+		"items": [
+			{
+				"@context": "https://schema.beckn.io/retail/schema/1.1.0/item.jsonld",
+				"@type": "Item"
+			},
+			{
+				"@context": "https://schema.beckn.io/retail/schema/1.1.0/item.jsonld",
+				"@type": "Item"
+			}
+		]
+	}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 schema objects, got %d", len(got))
+	}
+}
+
+func TestWalkPayload_NoSchemaObjects(t *testing.T) {
+	payload := []byte(`{"context": {"domain": "retail"}, "message": {}}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 schema objects, got %d", len(got))
+	}
+}
+
+func TestWalkPayload_MissingType(t *testing.T) {
+	// @context present but no @type — should not be collected
+	payload := []byte(`{"@context": "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld"}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 schema objects, got %d", len(got))
+	}
+}
+
+func TestWalkPayload_InvalidJSON(t *testing.T) {
+	_, err := WalkPayload([]byte(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+// --- CheckCompatibility tests ---
+
+func manifest(objects ...model.SchemaObject) *model.NodeManifest {
+	return &model.NodeManifest{
+		Schema: model.NodeManifestSchema{SchemaObjects: objects},
+	}
+}
+
+func schemaObj(contextURL, typ string) model.SchemaObject {
+	return model.SchemaObject{ContextURL: contextURL, Type: typ}
+}
+
+func TestCheckCompatibility_AllCompatible(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	}
+	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
+
+	needs := CheckCompatibility(extracted, m)
+	if len(needs) != 0 {
+		t.Fatalf("expected no translation needed, got %d", len(needs))
+	}
+}
+
+func TestCheckCompatibility_VersionMismatch(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/order.jsonld", "Order"),
+	}
+	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
+
+	needs := CheckCompatibility(extracted, m)
+	if len(needs) != 1 {
+		t.Fatalf("expected 1 translation needed, got %d", len(needs))
+	}
+	if needs[0].From.ContextURL != "https://schema.beckn.io/retail/schema/1.0.0/order.jsonld" {
+		t.Errorf("unexpected From.ContextURL: %s", needs[0].From.ContextURL)
+	}
+	if needs[0].To == nil {
+		t.Fatal("expected To to be set for version mismatch")
+	}
+	if needs[0].To.ContextURL != "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld" {
+		t.Errorf("unexpected To.ContextURL: %s", needs[0].To.ContextURL)
+	}
+}
+
+func TestCheckCompatibility_UnknownType(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"),
+	}
+	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
+
+	needs := CheckCompatibility(extracted, m)
+	if len(needs) != 1 {
+		t.Fatalf("expected 1 translation needed, got %d", len(needs))
+	}
+	if needs[0].To != nil {
+		t.Error("expected To to be nil for unknown type")
+	}
+}
+
+func TestCheckCompatibility_MixedOutcomes(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),   // compatible
+		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/item.jsonld", "Item"),     // version mismatch
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"),   // unknown type
+	}
+	m := manifest(
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/item.jsonld", "Item"),
+	)
+
+	needs := CheckCompatibility(extracted, m)
+	if len(needs) != 2 {
+		t.Fatalf("expected 2 translation needs, got %d", len(needs))
+	}
+
+	// Item: version mismatch — To must be set
+	itemNeed := needs[0]
+	if itemNeed.From.Type != "Item" {
+		t.Errorf("expected Item mismatch first, got %s", itemNeed.From.Type)
+	}
+	if itemNeed.To == nil {
+		t.Error("expected To to be set for Item version mismatch")
+	}
+
+	// Quote: unknown type — To must be nil
+	quoteNeed := needs[1]
+	if quoteNeed.From.Type != "Quote" {
+		t.Errorf("expected Quote unknown type second, got %s", quoteNeed.From.Type)
+	}
+	if quoteNeed.To != nil {
+		t.Error("expected To to be nil for unknown Quote type")
+	}
+}
+
+func TestCheckCompatibility_EmptyManifest(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	}
+	m := manifest() // no schema objects
+
+	needs := CheckCompatibility(extracted, m)
+	if len(needs) != 1 {
+		t.Fatalf("expected 1 translation needed, got %d", len(needs))
+	}
+	if needs[0].To != nil {
+		t.Error("expected To to be nil when manifest is empty")
+	}
+}
+
+func TestCheckCompatibility_EmptyPayload(t *testing.T) {
+	needs := CheckCompatibility([]model.SchemaObject{}, manifest(
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	))
+	if len(needs) != 0 {
+		t.Fatalf("expected no translation needed for empty payload, got %d", len(needs))
+	}
+}

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -1,6 +1,7 @@
 package schemaversionmediator
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
@@ -46,6 +47,31 @@ func TestWalkPayload_NestedObjects(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected 2 schema objects, got %d", len(got))
 	}
+	assertContainsType(t, got, "Order")
+	assertContainsType(t, got, "Item")
+}
+
+// TestWalkPayload_ParentAndChildBothCollected confirms that when a parent node
+// and a nested child node each carry independent "@context"/"@type" declarations,
+// both are collected — they represent distinct schema contracts.
+func TestWalkPayload_ParentAndChildBothCollected(t *testing.T) {
+	payload := []byte(`{
+		"@context": "https://schema.beckn.io/retail/schema/1.1.0/order.jsonld",
+		"@type": "Order",
+		"fulfillment": {
+			"@context": "https://schema.beckn.io/retail/schema/1.1.0/fulfillment.jsonld",
+			"@type": "Fulfillment"
+		}
+	}`)
+	got, err := WalkPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 schema objects (parent + child), got %d", len(got))
+	}
+	assertContainsType(t, got, "Order")
+	assertContainsType(t, got, "Fulfillment")
 }
 
 func TestWalkPayload_ArrayOfObjects(t *testing.T) {
@@ -112,13 +138,29 @@ func schemaObj(contextURL, typ string) model.SchemaObject {
 	return model.SchemaObject{ContextURL: contextURL, Type: typ}
 }
 
+func TestCheckCompatibility_NilManifest(t *testing.T) {
+	extracted := []model.SchemaObject{
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	}
+	needs, err := CheckCompatibility(extracted, nil)
+	if !errors.Is(err, ErrNoManifest) {
+		t.Fatalf("expected ErrNoManifest, got %v", err)
+	}
+	if needs != nil {
+		t.Errorf("expected nil needs when manifest is absent, got %v", needs)
+	}
+}
+
 func TestCheckCompatibility_AllCompatible(t *testing.T) {
 	extracted := []model.SchemaObject{
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
-	needs := CheckCompatibility(extracted, m)
+	needs, err := CheckCompatibility(extracted, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 0 {
 		t.Fatalf("expected no translation needed, got %d", len(needs))
 	}
@@ -130,7 +172,10 @@ func TestCheckCompatibility_VersionMismatch(t *testing.T) {
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
-	needs := CheckCompatibility(extracted, m)
+	needs, err := CheckCompatibility(extracted, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 1 {
 		t.Fatalf("expected 1 translation needed, got %d", len(needs))
 	}
@@ -151,7 +196,10 @@ func TestCheckCompatibility_UnknownType(t *testing.T) {
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
-	needs := CheckCompatibility(extracted, m)
+	needs, err := CheckCompatibility(extracted, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 1 {
 		t.Fatalf("expected 1 translation needed, got %d", len(needs))
 	}
@@ -162,33 +210,35 @@ func TestCheckCompatibility_UnknownType(t *testing.T) {
 
 func TestCheckCompatibility_MixedOutcomes(t *testing.T) {
 	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),   // compatible
-		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/item.jsonld", "Item"),     // version mismatch
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"),   // unknown type
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),  // compatible
+		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/item.jsonld", "Item"),    // version mismatch
+		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"), // unknown type
 	}
 	m := manifest(
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/item.jsonld", "Item"),
 	)
 
-	needs := CheckCompatibility(extracted, m)
+	needs, err := CheckCompatibility(extracted, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 2 {
 		t.Fatalf("expected 2 translation needs, got %d", len(needs))
 	}
 
-	// Item: version mismatch — To must be set
-	itemNeed := needs[0]
-	if itemNeed.From.Type != "Item" {
-		t.Errorf("expected Item mismatch first, got %s", itemNeed.From.Type)
+	// Assert by type rather than by index — order is an implementation detail.
+	itemNeed := findNeedByType(needs, "Item")
+	if itemNeed == nil {
+		t.Fatal("expected TranslationNeeded entry for Item")
 	}
 	if itemNeed.To == nil {
 		t.Error("expected To to be set for Item version mismatch")
 	}
 
-	// Quote: unknown type — To must be nil
-	quoteNeed := needs[1]
-	if quoteNeed.From.Type != "Quote" {
-		t.Errorf("expected Quote unknown type second, got %s", quoteNeed.From.Type)
+	quoteNeed := findNeedByType(needs, "Quote")
+	if quoteNeed == nil {
+		t.Fatal("expected TranslationNeeded entry for Quote")
 	}
 	if quoteNeed.To != nil {
 		t.Error("expected To to be nil for unknown Quote type")
@@ -201,7 +251,10 @@ func TestCheckCompatibility_EmptyManifest(t *testing.T) {
 	}
 	m := manifest() // no schema objects
 
-	needs := CheckCompatibility(extracted, m)
+	needs, err := CheckCompatibility(extracted, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 1 {
 		t.Fatalf("expected 1 translation needed, got %d", len(needs))
 	}
@@ -211,10 +264,34 @@ func TestCheckCompatibility_EmptyManifest(t *testing.T) {
 }
 
 func TestCheckCompatibility_EmptyPayload(t *testing.T) {
-	needs := CheckCompatibility([]model.SchemaObject{}, manifest(
+	needs, err := CheckCompatibility([]model.SchemaObject{}, manifest(
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
 	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(needs) != 0 {
 		t.Fatalf("expected no translation needed for empty payload, got %d", len(needs))
 	}
+}
+
+// --- helpers ---
+
+func assertContainsType(t *testing.T, objects []model.SchemaObject, typ string) {
+	t.Helper()
+	for _, o := range objects {
+		if o.Type == typ {
+			return
+		}
+	}
+	t.Errorf("expected schema object with Type=%q not found in %v", typ, objects)
+}
+
+func findNeedByType(needs []TranslationNeeded, typ string) *TranslationNeeded {
+	for i := range needs {
+		if needs[i].From.Type == typ {
+			return &needs[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- `WalkPayload` — depth-first recursive descent over a Beckn JSON payload, collecting all nodes that declare both `@context` and `@type` JSON-LD fields as `[]model.SchemaObject`
- `CheckCompatibility` — compares extracted schema objects against the local `NodeManifest` and returns `[]TranslationNeeded` for objects requiring translation
- `TranslationNeeded` — internal type carrying `From` (payload version) and `To *SchemaObject` (local supported version); `To` is nil when the type is entirely absent from the manifest

## Compatibility outcomes

| Case | Result |
|---|---|
| Exact match (ContextURL + Type) | Omitted — compatible |
| Same Type, different ContextURL | `TranslationNeeded{From, To: &localObj}` — fetch artifact and translate |
| Type absent from manifest | `TranslationNeeded{From, To: nil}` — delegated to data-loss policy enforcer |

Empty result → payload fully compatible, mediator short-circuits.

## Test coverage

12 tests covering: single object, nested objects, arrays, no schema objects, missing `@type`, invalid JSON, all compatible, version mismatch, unknown type, mixed outcomes, empty manifest, empty payload.

## Notes

- `TranslationNeeded` is intentionally package-internal — nothing outside the mediator plugin needs this type
- No changes to `pkg/model/` or `pkg/plugin/definition/` — `model.SchemaObject` and `model.NodeManifest` from #769 are the right shapes as-is

Closes part of #770