### PR TITLE
fix(schemav2validator): bypass kin-openapi global URI cache for TTL reloads

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -315,8 +315,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 		return nil, fmt.Errorf("failed to parse schema URL %s: %w", schemaPath, parseErr)
 	}
 
-	loader := openapi3.NewLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := newFreshLoader()
 
 	var doc *openapi3.T
 	var err error
@@ -335,7 +334,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 		if ok {
 			log.Debugf(ctx, "Loading from memory: %s -> %s", schemaPath, relPath)
 
-			// $ref lookups: memory first, network fallback.
+			// $ref lookups: memory first, fresh-fetch fallback (bypasses global URIMapCache).
 			loader.ReadFromURIFunc = func(l *openapi3.Loader, refURL *url.URL) ([]byte, error) {
 				refRelPath := extractRelativeSchemaPath(refURL)
 				c.mu.RLock()
@@ -346,7 +345,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 					return data, nil
 				}
 				log.Debugf(ctx, "$ref not in memory, fetching from network: %s", refURL.String())
-				return openapi3.DefaultReadFromURI(l, refURL)
+				return freshReadFromURI(l, refURL)
 			}
 
 			doc, err = loader.LoadFromData(schemaBytes)

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -316,6 +316,7 @@ func (c *schemaCache) loadSchemaFromPath(ctx context.Context, schemaPath string,
 	}
 
 	loader := newFreshLoader()
+	loader.Context = ctx
 
 	var doc *openapi3.T
 	var err error

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -1014,7 +1014,7 @@ func TestLoadSchemaFromPath_TTLExpiry_FetchesFresh(t *testing.T) {
 	assert.Equal(t, "Schema v1", doc1.Info.Title)
 
 	// Wait for the LRU entry to expire, then switch the server to v2.
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	serveV2.Store(true)
 
 	// Re-load — LRU miss (expired), freshReadFromURI fetches from the server and gets v2.

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -2,9 +2,12 @@ package schemav2validator
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -989,4 +992,33 @@ components:
 	// rawSchemas empty, localSchema=true — local miss, falls back to @context file path
 	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, true)
 	assert.NoError(t, err)
+}
+
+func TestLoadSchemaFromPath_TTLExpiry_FetchesFresh(t *testing.T) {
+	var serveV2 atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveV2.Load() {
+			w.Write([]byte("openapi: 3.1.0\ninfo:\n  title: Schema v2\n  version: 2.0.0\n"))
+		} else {
+			w.Write([]byte("openapi: 3.1.0\ninfo:\n  title: Schema v1\n  version: 1.0.0\n"))
+		}
+	}))
+	defer server.Close()
+
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	// Load v1 with a 1ms TTL so the LRU entry expires almost immediately.
+	doc1, err := cache.loadSchemaFromPath(ctx, server.URL, 1*time.Millisecond, 30*time.Second, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "Schema v1", doc1.Info.Title)
+
+	// Wait for the LRU entry to expire, then switch the server to v2.
+	time.Sleep(5 * time.Millisecond)
+	serveV2.Store(true)
+
+	// Re-load — LRU miss (expired), freshReadFromURI fetches from the server and gets v2.
+	doc2, err := cache.loadSchemaFromPath(ctx, server.URL, 1*time.Hour, 30*time.Second, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "Schema v2", doc2.Info.Title, "expected v2 after TTL expiry — global URIMapCache not bypassed")
 }

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -303,6 +305,35 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context, failOnAuxError boo
 	return nil
 }
 
+// freshReadFromURI reads bytes directly from disk or network, bypassing the
+// kin-openapi package-level URIMapCache so TTL reloads always fetch current content.
+func freshReadFromURI(_ *openapi3.Loader, u *url.URL) ([]byte, error) {
+	switch u.Scheme {
+	case "http", "https":
+		resp, err := http.Get(u.String()) //nolint:noctx
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, u)
+		}
+		return io.ReadAll(resp.Body)
+	default: // "file" scheme or bare path
+		return os.ReadFile(u.Path)
+	}
+}
+
+// newFreshLoader returns a loader whose ReadFromURIFunc bypasses the global
+// URIMapCache. Use this everywhere instead of openapi3.NewLoader() so that
+// TTL-driven reloads always read the current file or remote content.
+func newFreshLoader() *openapi3.Loader {
+	l := openapi3.NewLoader()
+	l.IsExternalRefsAllowed = true
+	l.ReadFromURIFunc = freshReadFromURI
+	return l
+}
+
 // loadSingleSpec loads one OpenAPI document from the given type and location.
 // For type "dir", all top-level *.yaml and *.json files are loaded and their
 // action indexes are merged into a single cachedSpec.
@@ -311,8 +342,7 @@ func (v *schemav2Validator) loadSingleSpec(ctx context.Context, specType, locati
 		return v.loadSpecFromDir(ctx, location)
 	}
 
-	loader := openapi3.NewLoader()
-	loader.IsExternalRefsAllowed = true
+	loader := newFreshLoader()
 
 	var doc *openapi3.T
 	var err error

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -310,6 +310,11 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context, failOnAuxError boo
 // indefinitely; caller context deadlines further constrain it when set.
 var specHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
+// maxSpecBodyBytes caps how much of a spec response is read into memory.
+// No legitimate OpenAPI spec approaches this limit; it guards against
+// misconfigured proxies and adversarial servers sending arbitrarily large bodies.
+var maxSpecBodyBytes int64 = 32 * 1024 * 1024 // 32 MB
+
 // freshReadFromURI reads bytes directly from disk or network, bypassing the
 // kin-openapi package-level URIMapCache so TTL reloads always fetch current content.
 func freshReadFromURI(loader *openapi3.Loader, u *url.URL) ([]byte, error) {
@@ -331,7 +336,15 @@ func freshReadFromURI(loader *openapi3.Loader, u *url.URL) ([]byte, error) {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			return nil, fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, u)
 		}
-		return io.ReadAll(resp.Body)
+		limited := io.LimitReader(resp.Body, maxSpecBodyBytes+1)
+		data, err := io.ReadAll(limited)
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > maxSpecBodyBytes {
+			return nil, fmt.Errorf("spec response exceeds %d MB limit", maxSpecBodyBytes/(1024*1024))
+		}
+		return data, nil
 	default: // "file" scheme or bare path
 		return os.ReadFile(u.Path)
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -327,6 +327,11 @@ func freshReadFromURI(_ *openapi3.Loader, u *url.URL) ([]byte, error) {
 // newFreshLoader returns a loader whose ReadFromURIFunc bypasses the global
 // URIMapCache. Use this everywhere instead of openapi3.NewLoader() so that
 // TTL-driven reloads always read the current file or remote content.
+//
+// Note: setting ReadFromURIFunc causes kin-openapi to skip its own
+// IsExternalRefsAllowed guard (the custom function becomes the sole access
+// policy). IsExternalRefsAllowed=true is kept for documentation intent but
+// has no runtime effect once ReadFromURIFunc is non-nil.
 func newFreshLoader() *openapi3.Loader {
 	l := openapi3.NewLoader()
 	l.IsExternalRefsAllowed = true

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -305,12 +305,25 @@ func (v *schemav2Validator) loadAllSpecs(ctx context.Context, failOnAuxError boo
 	return nil
 }
 
+// specHTTPClient is used by freshReadFromURI for all remote spec fetches.
+// The 30 s timeout prevents a hanging server from stalling the reload goroutine
+// indefinitely; caller context deadlines further constrain it when set.
+var specHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // freshReadFromURI reads bytes directly from disk or network, bypassing the
 // kin-openapi package-level URIMapCache so TTL reloads always fetch current content.
-func freshReadFromURI(_ *openapi3.Loader, u *url.URL) ([]byte, error) {
+func freshReadFromURI(loader *openapi3.Loader, u *url.URL) ([]byte, error) {
 	switch u.Scheme {
 	case "http", "https":
-		resp, err := http.Get(u.String()) //nolint:noctx
+		ctx := context.Background()
+		if loader.Context != nil {
+			ctx = loader.Context
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := specHTTPClient.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -348,6 +361,7 @@ func (v *schemav2Validator) loadSingleSpec(ctx context.Context, specType, locati
 	}
 
 	loader := newFreshLoader()
+	loader.Context = ctx
 
 	var doc *openapi3.T
 	var err error

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -825,6 +825,36 @@ func TestTTLRefresh_PicksUpChangedURLSpec(t *testing.T) {
 	}
 }
 
+func TestTTLRefresh_PicksUpChangedDirSpec(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "spec.yaml")
+
+	if err := os.WriteFile(specFile, []byte(testSpec), 0644); err != nil {
+		t.Fatalf("failed to write initial spec: %v", err)
+	}
+
+	validator, _, err := New(context.Background(), &Config{Type: "dir", Location: dir, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
+		t.Fatalf("search action unavailable at startup: %v", err)
+	}
+
+	// Overwrite the existing file in-place — this is the case issue #795 highlighted
+	// as silently ignored before the fix.
+	if err := os.WriteFile(specFile, []byte(testSpecV2), 0644); err != nil {
+		t.Fatalf("failed to overwrite spec file: %v", err)
+	}
+
+	validator.reloadAllSpecs(context.Background())
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"confirm"},"message":{}}`)); err != nil {
+		t.Errorf("confirm action unavailable after TTL refresh — in-place file edit not picked up: %v", err)
+	}
+}
+
 func TestTTLRefresh_PicksUpChangedFileSpec(t *testing.T) {
 	f, err := os.CreateTemp("", "spec-*.yaml")
 	if err != nil {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -797,6 +797,23 @@ func TestAuxiliary_AllSpecsFail_HardRejects(t *testing.T) {
 	}
 }
 
+func TestFreshReadFromURI_BodyTooLarge(t *testing.T) {
+	old := maxSpecBodyBytes
+	maxSpecBodyBytes = 10
+	defer func() { maxSpecBodyBytes = old }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("this body is definitely more than ten bytes"))
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	_, err := freshReadFromURI(newFreshLoader(), u)
+	if err == nil {
+		t.Fatal("expected error for oversized response body, got nil")
+	}
+}
+
 func TestTTLRefresh_PicksUpChangedURLSpec(t *testing.T) {
 	var serveV2 atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -442,6 +442,32 @@ func TestValidate_EdgeCases(t *testing.T) {
 	}
 }
 
+// testSpecV2 is a replacement spec used in TTL-refresh tests; it exposes only the "confirm" action (distinct from testSpec).
+const testSpecV2 = `openapi: 3.1.0
+info:
+  title: Test API v2
+  version: 2.0.0
+paths:
+  /confirm:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [context, message]
+              properties:
+                context:
+                  type: object
+                  required: [action]
+                  properties:
+                    action:
+                      const: confirm
+                message:
+                  type: object
+`
+
 // testSpecAux is an OpenAPI 3.1 spec used as an auxiliary spec in tests; it defines the "subscribe" and "renew" actions.
 const testSpecAux = `openapi: 3.1.0
 info:
@@ -671,17 +697,9 @@ func TestAuxiliary_BadLocationSkipped(t *testing.T) {
 	}
 }
 
-// TestAuxiliary_RefreshRetainsIndexOnAuxFailure verifies that actions remain
-// available after a TTL refresh attempt.
-//
-// NOTE: this test does NOT exercise the failOnAuxError retain-old-index path.
-// kin-openapi's package-level URIMapCache (DefaultReadFromURI) caches raw bytes
-// keyed by URI for the entire process lifetime. Setting auxHealthy=false makes
-// the httptest server return a 503, but the reload never reaches the server —
-// kin-openapi returns the bytes it cached at startup, so the reload silently
-// succeeds from cache rather than failing. Once #795 is fixed (per-call
-// ReadFromURIFunc bypasses the global cache), this test will properly exercise
-// the retain-old-index path.
+// TestAuxiliary_RefreshRetainsIndexOnAuxFailure verifies that when an auxiliary
+// spec becomes unavailable during a TTL refresh, the old merged index is retained
+// so that all previously-valid actions remain available.
 func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(testSpec))
@@ -718,17 +736,13 @@ func TestAuxiliary_RefreshRetainsIndexOnAuxFailure(t *testing.T) {
 		t.Fatalf("auxiliary action unavailable at startup: %v", err)
 	}
 
-	// Auxiliary goes down — simulate a transient failure.
-	// Due to the kin-openapi global cache (#795) the reload below will use
-	// cached bytes and succeed rather than fail, so auxHealthy=false has no
-	// observable effect until #795 is fixed.
+	// Auxiliary goes down — the reload hits the server, gets a 503, and the old index is retained.
 	auxHealthy.Store(false)
 
 	// Force a TTL refresh.
 	validator.reloadAllSpecs(context.Background())
 
-	// Actions must still be available after a reload (regardless of whether
-	// the reload succeeded from cache or retained the old index on failure).
+	// Old index must be retained: both primary and auxiliary actions stay available.
 	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"subscribe"},"message":{}}`)); err != nil {
 		t.Errorf("auxiliary action dropped after failed refresh — old index should have been retained: %v", err)
 	}
@@ -780,6 +794,65 @@ func TestAuxiliary_AllSpecsFail_HardRejects(t *testing.T) {
 	}
 	if !contains(err.Error(), "no actions indexed") {
 		t.Errorf("New() error = %v, want it to mention 'no actions indexed'", err)
+	}
+}
+
+func TestTTLRefresh_PicksUpChangedURLSpec(t *testing.T) {
+	var serveV2 atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveV2.Load() {
+			w.Write([]byte(testSpecV2))
+		} else {
+			w.Write([]byte(testSpec))
+		}
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
+		t.Fatalf("search action unavailable at startup: %v", err)
+	}
+
+	serveV2.Store(true)
+	validator.reloadAllSpecs(context.Background())
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"confirm"},"message":{}}`)); err != nil {
+		t.Errorf("confirm action unavailable after TTL refresh — v2 spec not picked up: %v", err)
+	}
+}
+
+func TestTTLRefresh_PicksUpChangedFileSpec(t *testing.T) {
+	f, err := os.CreateTemp("", "spec-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(testSpec); err != nil {
+		t.Fatalf("failed to write v1 spec: %v", err)
+	}
+	f.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "file", Location: f.Name(), CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("New() unexpected error: %v", err)
+	}
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"search","domain":"retail"},"message":{}}`)); err != nil {
+		t.Fatalf("search action unavailable at startup: %v", err)
+	}
+
+	if err := os.WriteFile(f.Name(), []byte(testSpecV2), 0644); err != nil {
+		t.Fatalf("failed to overwrite spec file: %v", err)
+	}
+
+	validator.reloadAllSpecs(context.Background())
+
+	if err := validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"confirm"},"message":{}}`)); err != nil {
+		t.Errorf("confirm action unavailable after TTL refresh — v2 spec not picked up: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`kin-openapi` v0.137.0 wraps `DefaultReadFromURI` in a package-level `URIMapCache` that persists for the entire process lifetime. Every `openapi3.NewLoader()` call in `schemav2validator` reused this global cache, making TTL-driven reloads a silent no-op:

- **url**: remote spec fetched once at startup; HTTP request never repeated
- **file**: file read once at startup; disk never re-read
- **dir**: file additions/deletions picked up via `os.ReadDir`, but edits to existing files silently ignored
- **extended schema**: same bug — domain schema re-fetches after LRU TTL expiry still served stale bytes from the global cache

Operators who updated a spec file or redeployed a remote spec could not pick up the change without restarting the adapter, despite `cacheTTL` being configured.

## Fix

Introduced two package-level helpers in `schemav2validator`:

- `freshReadFromURI` — reads bytes directly from disk or network on every call, bypassing the `URIMapCache` entirely
- `newFreshLoader` — returns an `openapi3.Loader` with `ReadFromURIFunc` set to `freshReadFromURI`; used everywhere instead of `openapi3.NewLoader()`

Applied in two places:

| File | Change |
|---|---|
| `schemav2validator.go` | `loadSingleSpec` now uses `newFreshLoader()` — covers primary, auxiliary (`url`/`file`/`dir`) |
| `extended_schema.go` | `loadSchemaFromPath` uses `newFreshLoader()`; `$ref` fallback in localSchema path replaced `DefaultReadFromURI` with `freshReadFromURI` |

## Tests added

- `TestTTLRefresh_PicksUpChangedURLSpec` — serves v1 at startup, switches httptest server to v2, forces `reloadAllSpecs`, asserts v2 action is available
- `TestTTLRefresh_PicksUpChangedFileSpec` — same flow using a temp file overwritten with `os.WriteFile`
- `TestLoadSchemaFromPath_TTLExpiry_FetchesFresh` — loads a domain schema with a 1 ms TTL, waits for expiry, switches httptest server to v2, reloads, asserts v2 title is returned

`TestAuxiliary_RefreshRetainsIndexOnAuxFailure` updated to remove the `NOTE: … until
#795 is fixed` comment — the test now properly exercises the retain-old-index path (server returns 503, reload fails, stale index is retained).

## Notes

- Setting `ReadFromURIFunc` causes kin-openapi to skip its own `IsExternalRefsAllowed` guard (the custom function becomes the sole access policy). Since `freshReadFromURI` imposes no restrictions and we always set `IsExternalRefsAllowed = true`, behaviour is unchanged — but the flag is now a no-op and is kept only for documentation intent.
- `freshReadFromURI` uses `http.Get` (i.e. `http.DefaultClient`) with no explicit timeout, matching the library's own `ReadFromHTTP` behaviour. A per-request timeout for spec loading can be wired in as a separate improvement.

Closes #795
