### PR TITLE
fix: cache registry lookup results to prevent repeated network calls

### DIFF
--- a/cmd/adapter/main_test.go
+++ b/cmd/adapter/main_test.go
@@ -80,7 +80,7 @@ func (m *MockPluginManager) Registry(ctx context.Context, cache definition.Cache
 }
 
 // KeyManager returns a mock implementation of the KeyManager interface.
-func (m *MockPluginManager) KeyManager(ctx context.Context, cache definition.Cache, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
+func (m *MockPluginManager) KeyManager(ctx context.Context, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
 	return nil, nil
 }
 

--- a/cmd/adapter/main_test.go
+++ b/cmd/adapter/main_test.go
@@ -75,7 +75,7 @@ func (m *MockPluginManager) Cache(ctx context.Context, cfg *plugin.Config) (defi
 }
 
 // Registry returns a mock implementation of the RegistryLookup interface.
-func (m *MockPluginManager) Registry(ctx context.Context, cfg *plugin.Config) (definition.RegistryLookup, error) {
+func (m *MockPluginManager) Registry(ctx context.Context, cache definition.Cache, cfg *plugin.Config) (definition.RegistryLookup, error) {
 	return nil, nil
 }
 

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -23,7 +23,7 @@ type PluginManager interface {
 	PolicyChecker(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *plugin.Config) (definition.PolicyChecker, error)
 	Cache(ctx context.Context, cfg *plugin.Config) (definition.Cache, error)
 	Registry(ctx context.Context, cache definition.Cache, cfg *plugin.Config) (definition.RegistryLookup, error)
-	KeyManager(ctx context.Context, cache definition.Cache, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error)
+	KeyManager(ctx context.Context, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error)
 	ManifestLoader(ctx context.Context, cache definition.Cache, lookup definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.ManifestLoader, error)
 	TransportWrapper(ctx context.Context, cfg *plugin.Config) (definition.TransportWrapper, error)
 	SchemaValidator(ctx context.Context, cfg *plugin.Config) (definition.SchemaValidator, error)

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -22,7 +22,7 @@ type PluginManager interface {
 	Step(ctx context.Context, cfg *plugin.Config) (definition.Step, error)
 	PolicyChecker(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *plugin.Config) (definition.PolicyChecker, error)
 	Cache(ctx context.Context, cfg *plugin.Config) (definition.Cache, error)
-	Registry(ctx context.Context, cfg *plugin.Config) (definition.RegistryLookup, error)
+	Registry(ctx context.Context, cache definition.Cache, cfg *plugin.Config) (definition.RegistryLookup, error)
 	KeyManager(ctx context.Context, cache definition.Cache, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error)
 	ManifestLoader(ctx context.Context, cache definition.Cache, lookup definition.RegistryMetadataLookup, cfg *plugin.Config) (definition.ManifestLoader, error)
 	TransportWrapper(ctx context.Context, cfg *plugin.Config) (definition.TransportWrapper, error)

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -391,19 +391,16 @@ func loadPlugin[T any](ctx context.Context, name string, cfg *plugin.Config, mgr
 	return plugin, nil
 }
 
-// loadKeyManager loads the KeyManager plugin using the provided PluginManager, cache, and registry.
-func loadKeyManager(ctx context.Context, mgr PluginManager, cache definition.Cache, registry definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
+// loadKeyManager loads the KeyManager plugin using the provided PluginManager and registry.
+func loadKeyManager(ctx context.Context, mgr PluginManager, registry definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
 	if cfg == nil {
 		log.Debug(ctx, "Skipping KeyManager plugin: not configured")
 		return nil, nil
 	}
-	if cache == nil {
-		return nil, fmt.Errorf("failed to load KeyManager plugin (%s): Cache plugin not configured", cfg.ID)
-	}
 	if registry == nil {
 		return nil, fmt.Errorf("failed to load KeyManager plugin (%s): Registry plugin not configured", cfg.ID)
 	}
-	km, err := mgr.KeyManager(ctx, cache, registry, cfg)
+	km, err := mgr.KeyManager(ctx, registry, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load KeyManager plugin (%s): %w", cfg.ID, err)
 	}
@@ -495,7 +492,7 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 	}); err != nil {
 		return err
 	}
-	if h.km, err = loadKeyManager(ctx, mgr, h.cache, h.registry, cfg.KeyManager); err != nil {
+	if h.km, err = loadKeyManager(ctx, mgr, h.registry, cfg.KeyManager); err != nil {
 		return err
 	}
 	if h.manifestLoader, err = loadManifestLoader(ctx, mgr, h.cache, h.registry, cfg.ManifestLoader); err != nil {

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -490,7 +490,9 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 	if h.cache, err = loadPlugin(ctx, "Cache", cfg.Cache, mgr.Cache); err != nil {
 		return err
 	}
-	if h.registry, err = loadPlugin(ctx, "Registry", cfg.Registry, mgr.Registry); err != nil {
+	if h.registry, err = loadPlugin(ctx, "Registry", cfg.Registry, func(ctx context.Context, cfg *plugin.Config) (definition.RegistryLookup, error) {
+		return mgr.Registry(ctx, h.cache, cfg)
+	}); err != nil {
 		return err
 	}
 	if h.km, err = loadKeyManager(ctx, mgr, h.cache, h.registry, cfg.KeyManager); err != nil {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -146,7 +146,7 @@ func (noopPluginManager) Cache(context.Context, *plugin.Config) (definition.Cach
 func (noopPluginManager) Registry(context.Context, definition.Cache, *plugin.Config) (definition.RegistryLookup, error) {
 	return nil, nil
 }
-func (noopPluginManager) KeyManager(context.Context, definition.Cache, definition.RegistryLookup, *plugin.Config) (definition.KeyManager, error) {
+func (noopPluginManager) KeyManager(context.Context, definition.RegistryLookup, *plugin.Config) (definition.KeyManager, error) {
 	return nil, nil
 }
 func (noopPluginManager) ManifestLoader(context.Context, definition.Cache, definition.RegistryMetadataLookup, *plugin.Config) (definition.ManifestLoader, error) {

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -143,7 +143,7 @@ func (noopPluginManager) PolicyChecker(context.Context, definition.ManifestLoade
 func (noopPluginManager) Cache(context.Context, *plugin.Config) (definition.Cache, error) {
 	return nil, nil
 }
-func (noopPluginManager) Registry(context.Context, *plugin.Config) (definition.RegistryLookup, error) {
+func (noopPluginManager) Registry(context.Context, definition.Cache, *plugin.Config) (definition.RegistryLookup, error) {
 	return nil, nil
 }
 func (noopPluginManager) KeyManager(context.Context, definition.Cache, definition.RegistryLookup, *plugin.Config) (definition.KeyManager, error) {

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -62,7 +62,7 @@ func (m *mockPluginManager) Cache(ctx context.Context, cfg *plugin.Config) (defi
 }
 
 // Registry returns a mock registry lookup implementation.
-func (m *mockPluginManager) Registry(ctx context.Context, cfg *plugin.Config) (definition.RegistryLookup, error) {
+func (m *mockPluginManager) Registry(ctx context.Context, cache definition.Cache, cfg *plugin.Config) (definition.RegistryLookup, error) {
 	return nil, nil
 }
 

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -67,7 +67,7 @@ func (m *mockPluginManager) Registry(ctx context.Context, cache definition.Cache
 }
 
 // KeyManager returns a mock key manager implementation.
-func (m *mockPluginManager) KeyManager(ctx context.Context, cache definition.Cache, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
+func (m *mockPluginManager) KeyManager(ctx context.Context, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error) {
 	return nil, nil
 }
 

--- a/pkg/plugin/definition/keymanager.go
+++ b/pkg/plugin/definition/keymanager.go
@@ -17,5 +17,5 @@ type KeyManager interface {
 
 // KeyManagerProvider initializes a new signer instance.
 type KeyManagerProvider interface {
-	New(context.Context, Cache, RegistryLookup, map[string]string) (KeyManager, func() error, error)
+	New(context.Context, RegistryLookup, map[string]string) (KeyManager, func() error, error)
 }

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -18,5 +18,5 @@ type RegistryMetadataLookup interface {
 
 // RegistryLookupProvider initializes a new registry lookup instance.
 type RegistryLookupProvider interface {
-	New(context.Context, map[string]string) (RegistryLookup, func() error, error)
+	New(context.Context, Cache, map[string]string) (RegistryLookup, func() error, error)
 }

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin.go
@@ -15,12 +15,22 @@ import (
 
 // dediRegistryProvider implements the RegistryLookupProvider interface for the DeDi registry plugin.
 type dediRegistryProvider struct {
-	newFunc func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error)
+	newFunc func(ctx context.Context, cache definition.Cache, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error)
 }
 
 func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregistry.Config, error) {
 	dediConfig := &dediregistry.Config{
 		URL: config["url"],
+	}
+
+	// Parse cacheTTL if provided.
+	if cacheTTLStr, exists := config["cacheTTL"]; exists && cacheTTLStr != "" {
+		cacheTTL, err := time.ParseDuration(cacheTTLStr)
+		if err != nil {
+			log.Warnf(context.Background(), "Invalid cacheTTL value '%s', using default", cacheTTLStr)
+		} else {
+			dediConfig.CacheTTL = cacheTTL
+		}
 	}
 
 	// Parse timeout if provided.
@@ -80,7 +90,7 @@ func (d dediRegistryProvider) parseConfig(config map[string]string) (*dediregist
 }
 
 // New creates a new DeDi registry plugin instance.
-func (d dediRegistryProvider) New(ctx context.Context, config map[string]string) (definition.RegistryLookup, func() error, error) {
+func (d dediRegistryProvider) New(ctx context.Context, cache definition.Cache, config map[string]string) (definition.RegistryLookup, func() error, error) {
 	if ctx == nil {
 		return nil, nil, errors.New("context cannot be nil")
 	}
@@ -99,7 +109,7 @@ func (d dediRegistryProvider) New(ctx context.Context, config map[string]string)
 
 	log.Debugf(ctx, "DeDi Registry config mapped: %+v", dediConfig)
 
-	dediClient, closer, err := d.newFunc(ctx, dediConfig)
+	dediClient, closer, err := d.newFunc(ctx, cache, dediConfig)
 	if err != nil {
 		log.Errorf(ctx, err, "Failed to create DeDi registry instance")
 		return nil, nil, err

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -148,6 +148,38 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 	}
 }
 
+// TestDediRegistryProvider_ParseConfig_CacheTTL verifies that cacheTTL is parsed correctly
+// and that an invalid value warns but does not return an error (warn-and-ignore semantics).
+func TestDediRegistryProvider_ParseConfig_CacheTTL(t *testing.T) {
+	provider := dediRegistryProvider{}
+
+	t.Run("valid cacheTTL is parsed and set", func(t *testing.T) {
+		cfg, err := provider.parseConfig(map[string]string{
+			"url":      "https://test.com/dedi",
+			"cacheTTL": "15m",
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.CacheTTL != 15*time.Minute {
+			t.Errorf("expected CacheTTL 15m, got %v", cfg.CacheTTL)
+		}
+	})
+
+	t.Run("invalid cacheTTL warns and leaves CacheTTL zero", func(t *testing.T) {
+		cfg, err := provider.parseConfig(map[string]string{
+			"url":      "https://test.com/dedi",
+			"cacheTTL": "not-a-duration",
+		})
+		if err != nil {
+			t.Fatalf("expected no error (warn-and-ignore), got %v", err)
+		}
+		if cfg.CacheTTL != 0 {
+			t.Errorf("expected CacheTTL 0 (will use defaultCacheTTL), got %v", cfg.CacheTTL)
+		}
+	})
+}
+
 func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
 

--- a/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/dediregistry/cmd/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/dediregistry"
 )
 
@@ -150,7 +151,7 @@ func TestDediRegistryProvider_ParseConfig_InvalidConfig(t *testing.T) {
 func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
 	provider := dediRegistryProvider{}
 
-	_, _, err := provider.New(context.Background(), map[string]string{
+	_, _, err := provider.New(context.Background(), nil, map[string]string{
 		"url":       "https://test.com/dedi",
 		"retry_max": "abc",
 	})
@@ -165,7 +166,7 @@ func TestDediRegistryProvider_New_InvalidRetryConfig(t *testing.T) {
 func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
 	var captured *dediregistry.Config
 	provider := dediRegistryProvider{
-		newFunc: func(ctx context.Context, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error) {
+		newFunc: func(ctx context.Context, cache definition.Cache, cfg *dediregistry.Config) (*dediregistry.DeDiRegistryClient, func() error, error) {
 			captured = cfg
 			return new(dediregistry.DeDiRegistryClient), func() error { return nil }, nil
 		},
@@ -179,7 +180,7 @@ func TestDediRegistryProvider_New_ForwardsRetryConfig(t *testing.T) {
 		"retry_wait_max": "2s",
 	}
 
-	_, closer, err := provider.New(context.Background(), config)
+	_, closer, err := provider.New(context.Background(), nil, config)
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -212,7 +213,7 @@ func TestDediRegistryProvider_New(t *testing.T) {
 		"timeout": "30",
 	}
 
-	dediRegistry, closer, err := provider.New(ctx, config)
+	dediRegistry, closer, err := provider.New(ctx, nil, config)
 	if err != nil {
 		t.Errorf("New() error = %v", err)
 		return
@@ -252,7 +253,7 @@ func TestDediRegistryProvider_New_InvalidConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := provider.New(ctx, tt.config)
+			_, _, err := provider.New(ctx, nil, tt.config)
 			if err == nil {
 				t.Errorf("New() with %s should return error", tt.name)
 			}
@@ -264,7 +265,7 @@ func TestDediRegistryProvider_New_InvalidTimeout(t *testing.T) {
 	// Invalid timeout is now a hard error, not a warn-and-continue fallback.
 	provider := dediRegistryProvider{newFunc: dediregistry.New}
 
-	_, _, err := provider.New(context.Background(), map[string]string{
+	_, _, err := provider.New(context.Background(), nil, map[string]string{
 		"url":     "https://test.com/dedi",
 		"timeout": "invalid",
 	})
@@ -342,7 +343,7 @@ func TestDediRegistryProvider_New_DeprecatedAllowedParentNamespacesErrorsWithout
 		"allowedParentNamespaces": "commerce-network.org",
 	}
 
-	_, _, err := provider.New(ctx, config)
+	_, _, err := provider.New(ctx, nil, config)
 	if err == nil {
 		t.Fatal("expected New() to error when only allowedParentNamespaces is configured")
 	}
@@ -355,7 +356,7 @@ func TestDediRegistryProvider_New_NilContext(t *testing.T) {
 		"url": "https://test.com/dedi",
 	}
 
-	_, _, err := provider.New(nil, config)
+	_, _, err := provider.New(nil, nil, config)
 	if err == nil {
 		t.Error("New() with nil context should return error")
 	}

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -11,7 +11,10 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"github.com/hashicorp/go-retryablehttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const defaultCacheTTL = 5 * time.Minute
@@ -158,9 +161,13 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 	}
 
 	cacheKey := fmt.Sprintf("lookup_%s_%s", subscriberID, keyID)
+	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
 
 	if c.cache != nil {
-		if cached, err := c.cache.Get(ctx, cacheKey); err == nil {
+		cacheCtx, cacheSpan := tracer.Start(ctx, "cache lookup")
+		cached, err := c.cache.Get(cacheCtx, cacheKey)
+		cacheSpan.End()
+		if err == nil {
 			var results []model.Subscription
 			if err := json.Unmarshal([]byte(cached), &results); err == nil {
 				log.Debugf(ctx, "DeDi registry lookup cache hit for key: %s", cacheKey)
@@ -171,7 +178,9 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 
 	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL, subscriberID, dediAllRegistriesWildcard, keyID)
 
-	data, err := c.fetchDeDiData(ctx, lookupURL, "record lookup")
+	httpCtx, httpSpan := tracer.Start(ctx, "http lookup")
+	defer httpSpan.End()
+	data, err := c.fetchDeDiData(httpCtx, lookupURL, "record lookup")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+const defaultCacheTTL = 5 * time.Minute
 
 // dediAllRegistriesWildcard is the wildcard constant required by the DeDi registry service
 // to search across all cached registries in Beckn One. This value must not be configured externally.
@@ -20,6 +23,7 @@ const dediAllRegistriesWildcard = "subscribers.beckn.one"
 // Config holds configuration parameters for the DeDi registry client.
 type Config struct {
 	URL               string        `yaml:"url" json:"url"`
+	CacheTTL          time.Duration `yaml:"cacheTTL" json:"cacheTTL"`
 	AllowedNetworkIDs []string      `yaml:"allowedNetworkIDs" json:"allowedNetworkIDs"`
 	Timeout           int           `yaml:"timeout" json:"timeout"`
 	RetryMax          int           `yaml:"retry_max" json:"retry_max"`
@@ -29,8 +33,10 @@ type Config struct {
 
 // DeDiRegistryClient encapsulates the logic for calling the DeDi registry endpoints.
 type DeDiRegistryClient struct {
-	config *Config
-	client *retryablehttp.Client
+	config   *Config
+	client   *retryablehttp.Client
+	cache    definition.Cache
+	cacheTTL time.Duration
 }
 
 // validate checks if the provided DeDi registry configuration is valid.
@@ -45,7 +51,7 @@ func validate(cfg *Config) error {
 }
 
 // New creates a new instance of DeDiRegistryClient.
-func New(ctx context.Context, cfg *Config) (*DeDiRegistryClient, func() error, error) {
+func New(ctx context.Context, cache definition.Cache, cfg *Config) (*DeDiRegistryClient, func() error, error) {
 	log.Debugf(ctx, "Initializing DeDi Registry client with config: %+v", cfg)
 
 	if err := validate(cfg); err != nil {
@@ -70,9 +76,16 @@ func New(ctx context.Context, cfg *Config) (*DeDiRegistryClient, func() error, e
 		retryClient.RetryWaitMax = cfg.RetryWaitMax
 	}
 
+	ttl := cfg.CacheTTL
+	if ttl <= 0 {
+		ttl = defaultCacheTTL
+	}
+
 	client := &DeDiRegistryClient{
-		config: cfg,
-		client: retryClient,
+		config:   cfg,
+		client:   retryClient,
+		cache:    cache,
+		cacheTTL: ttl,
 	}
 
 	// Cleanup function
@@ -130,6 +143,8 @@ func (c *DeDiRegistryClient) fetchDeDiData(ctx context.Context, url, operation s
 }
 
 // Lookup implements RegistryLookup interface - calls the DeDi wrapper lookup endpoint and returns Subscription.
+// Results are cached using the subscriber ID and key ID as the cache key.
+// On a cache hit the network call is skipped entirely.
 func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription) ([]model.Subscription, error) {
 	// Extract subscriber ID and key ID from request (both come from Authorization header parsing)
 	subscriberID := req.SubscriberID
@@ -140,6 +155,18 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 	}
 	if keyID == "" {
 		return nil, fmt.Errorf("key_id is required for DeDi lookup")
+	}
+
+	cacheKey := fmt.Sprintf("lookup_%s_%s", subscriberID, keyID)
+
+	if c.cache != nil {
+		if cached, err := c.cache.Get(ctx, cacheKey); err == nil {
+			var results []model.Subscription
+			if err := json.Unmarshal([]byte(cached), &results); err == nil {
+				log.Debugf(ctx, "DeDi registry lookup cache hit for key: %s", cacheKey)
+				return results, nil
+			}
+		}
 	}
 
 	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL, subscriberID, dediAllRegistriesWildcard, keyID)
@@ -199,8 +226,22 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 		Updated:          parseTime(updatedAt),
 	}
 
+	results := []model.Subscription{subscription}
 	log.Debugf(ctx, "DeDi lookup successful, found subscription for subscriber: %s", detailsSubscriberID)
-	return []model.Subscription{subscription}, nil
+
+	if c.cache != nil {
+		ttl := c.cacheTTL
+		if ttlSec, ok := data["ttl"].(float64); ok && ttlSec > 0 {
+			ttl = time.Duration(ttlSec) * time.Second
+		}
+		if encoded, err := json.Marshal(results); err == nil {
+			if err := c.cache.Set(ctx, cacheKey, string(encoded), ttl); err != nil {
+				log.Warnf(ctx, "Failed to cache DeDi registry lookup result for key %s: %v", cacheKey, err)
+			}
+		}
+	}
+
+	return results, nil
 }
 
 // LookupRegistry fetches registry-level metadata for the given DeDi registry path.

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -166,21 +166,22 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 	if c.cache != nil {
 		cacheCtx, cacheSpan := tracer.Start(ctx, "cache lookup")
 		cached, err := c.cache.Get(cacheCtx, cacheKey)
-		cacheSpan.End()
 		if err == nil {
 			var results []model.Subscription
 			if err := json.Unmarshal([]byte(cached), &results); err == nil {
 				log.Debugf(ctx, "DeDi registry lookup cache hit for key: %s", cacheKey)
+				cacheSpan.End()
 				return results, nil
 			}
 		}
+		cacheSpan.End()
 	}
 
 	lookupURL := fmt.Sprintf("%s/lookup/%s/%s/%s", c.config.URL, subscriberID, dediAllRegistriesWildcard, keyID)
 
 	httpCtx, httpSpan := tracer.Start(ctx, "http lookup")
-	defer httpSpan.End()
 	data, err := c.fetchDeDiData(httpCtx, lookupURL, "record lookup")
+	httpSpan.End()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -3,6 +3,7 @@ package dediregistry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -11,6 +12,29 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
+
+type mockCache struct {
+	getFunc func(ctx context.Context, key string) (string, error)
+	setKey  string
+	setVal  string
+	setTTL  time.Duration
+	setErr  error
+}
+
+func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, key)
+	}
+	return "", errors.New("cache miss")
+}
+func (m *mockCache) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	m.setKey = key
+	m.setVal = value
+	m.setTTL = ttl
+	return m.setErr
+}
+func (m *mockCache) Delete(ctx context.Context, key string) error { return nil }
+func (m *mockCache) Clear(ctx context.Context) error              { return nil }
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
@@ -676,6 +700,149 @@ func TestLookupRegistry(t *testing.T) {
 
 		if _, err := client.LookupRegistry(ctx, "nfo.example.org", "mobility-network"); err == nil {
 			t.Error("expected error for 404 response, got nil")
+		}
+	})
+}
+
+func dediLookupResponse(ttl float64) map[string]interface{} {
+	resp := map[string]interface{}{
+		"message": "ok",
+		"data": map[string]interface{}{
+			"details": map[string]interface{}{
+				"url":                "http://sub.example.com",
+				"type":               "BAP",
+				"domain":             "retail",
+				"subscriber_id":      "sub.example.com",
+				"signing_public_key": "test-signing-key",
+				"encr_public_key":    "test-encr-key",
+			},
+			"network_memberships": []string{"commerce.org/prod"},
+			"created_at":          "2025-01-01T00:00:00Z",
+			"updated_at":          "2025-01-01T00:00:00Z",
+		},
+	}
+	if ttl > 0 {
+		resp["data"].(map[string]interface{})["ttl"] = ttl
+	}
+	return resp
+}
+
+func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
+	ctx := context.Background()
+	sub := &model.Subscription{
+		Subscriber: model.Subscriber{SubscriberID: "sub.example.com"},
+		KeyID:      "key-1",
+	}
+	expectedCacheKey := "lookup_sub.example.com_key-1"
+
+	t.Run("cache hit skips HTTP call", func(t *testing.T) {
+		cached := []model.Subscription{{SigningPublicKey: "cached-key"}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		httpCalled := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(ctx, sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if httpCalled {
+			t.Error("expected HTTP call to be skipped on cache hit")
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "cached-key" {
+			t.Errorf("expected cached result, got %+v", results)
+		}
+	})
+
+	t.Run("cache miss writes to cache using ttl from response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dediLookupResponse(600))
+		}))
+		defer server.Close()
+
+		cache := &mockCache{}
+		client, closer, err := New(ctx, cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(ctx, sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "test-signing-key" {
+			t.Errorf("unexpected result: %+v", results)
+		}
+		if cache.setKey != expectedCacheKey {
+			t.Errorf("expected cache key %q, got %q", expectedCacheKey, cache.setKey)
+		}
+		if cache.setTTL != 600*time.Second {
+			t.Errorf("expected TTL 600s from response, got %v", cache.setTTL)
+		}
+	})
+
+	t.Run("nil cache — no cache operations", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dediLookupResponse(600))
+		}))
+		defer server.Close()
+
+		client, closer, err := New(ctx, nil, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(ctx, sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "test-signing-key" {
+			t.Errorf("unexpected result: %+v", results)
+		}
+	})
+
+	t.Run("cache set error does not fail lookup", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dediLookupResponse(600))
+		}))
+		defer server.Close()
+
+		cache := &mockCache{setErr: errors.New("redis down")}
+		client, closer, err := New(ctx, cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(ctx, sub)
+		if err != nil {
+			t.Fatalf("Lookup() must not fail when cache.Set errors, got: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "test-signing-key" {
+			t.Errorf("unexpected result: %+v", results)
 		}
 	})
 }

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -845,4 +845,32 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 			t.Errorf("unexpected result: %+v", results)
 		}
 	})
+
+	t.Run("corrupt cache value falls through to HTTP", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(dediLookupResponse(0))
+		}))
+		defer server.Close()
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return "this is not valid json{{{{", nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(ctx, sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "test-signing-key" {
+			t.Errorf("expected HTTP result after corrupt cache, got %+v", results)
+		}
+	})
 }

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 		Timeout: 30,
 	}
 
-	client, closer, err := New(ctx, validConfig)
+	client, closer, err := New(ctx, nil, validConfig)
 	if err != nil {
 		t.Errorf("New() error = %v", err)
 		return
@@ -84,7 +84,7 @@ func TestNew(t *testing.T) {
 			RetryWaitMin: 100 * time.Millisecond,
 			RetryWaitMax: 1 * time.Second,
 		}
-		client, _, err := New(ctx, cfg)
+		client, _, err := New(ctx, nil, cfg)
 		if err != nil {
 			t.Fatalf("expected no error, but got: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestLookup(t *testing.T) {
 			Timeout:      30,
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -233,7 +233,7 @@ func TestLookup(t *testing.T) {
 			AllowedNetworkIDs: []string{"commerce-network.org/prod"},
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -276,7 +276,7 @@ func TestLookup(t *testing.T) {
 			AllowedNetworkIDs: []string{"commerce-network/subscriber-references"},
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -323,7 +323,7 @@ func TestLookup(t *testing.T) {
 			AllowedNetworkIDs: []string{"commerce-network.org/prod"},
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -347,7 +347,7 @@ func TestLookup(t *testing.T) {
 			URL:          "https://test.com/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -374,7 +374,7 @@ func TestLookup(t *testing.T) {
 			URL:          "https://test.com/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -407,7 +407,7 @@ func TestLookup(t *testing.T) {
 			URL:          server.URL + "/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -444,7 +444,7 @@ func TestLookup(t *testing.T) {
 			URL:          server.URL + "/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -474,7 +474,7 @@ func TestLookup(t *testing.T) {
 			URL:          server.URL + "/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -507,7 +507,7 @@ func TestLookup(t *testing.T) {
 			URL:          server.URL + "/dedi",
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -532,7 +532,7 @@ func TestLookup(t *testing.T) {
 			Timeout:      1,
 		}
 
-		client, closer, err := New(ctx, config)
+		client, closer, err := New(ctx, nil, config)
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
 		}
@@ -579,7 +579,7 @@ func TestLookupRegistry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(ctx, &Config{
+		client, closer, err := New(ctx, nil, &Config{
 			URL:          server.URL + "/dedi",
 		})
 		if err != nil {
@@ -614,7 +614,7 @@ func TestLookupRegistry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(ctx, &Config{
+		client, closer, err := New(ctx, nil, &Config{
 			URL:          server.URL,
 		})
 		if err != nil {
@@ -642,7 +642,7 @@ func TestLookupRegistry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(ctx, &Config{
+		client, closer, err := New(ctx, nil, &Config{
 			URL:          server.URL,
 		})
 		if err != nil {
@@ -666,7 +666,7 @@ func TestLookupRegistry(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(ctx, &Config{
+		client, closer, err := New(ctx, nil, &Config{
 			URL:          server.URL + "/dedi",
 		})
 		if err != nil {

--- a/pkg/plugin/implementation/keymanager/cmd/plugin.go
+++ b/pkg/plugin/implementation/keymanager/cmd/plugin.go
@@ -14,14 +14,14 @@ type keyManagerProvider struct{}
 // newKeyManagerFunc is a function type that creates a new KeyManager instance.
 var newKeyManagerFunc = keymanager.New
 
-// New creates and initializes a new KeyManager instance using the provided cache, registry lookup, and configuration.
-func (k *keyManagerProvider) New(ctx context.Context, cache definition.Cache, registry definition.RegistryLookup, cfg map[string]string) (definition.KeyManager, func() error, error) {
+// New creates and initializes a new KeyManager instance using the provided registry lookup and configuration.
+func (k *keyManagerProvider) New(ctx context.Context, registry definition.RegistryLookup, cfg map[string]string) (definition.KeyManager, func() error, error) {
 	config := &keymanager.Config{
 		VaultAddr: cfg["vaultAddr"],
 		KVVersion: cfg["kvVersion"],
 	}
 	log.Debugf(ctx, "Keymanager config mapped: %+v", cfg)
-	km, cleanup, err := newKeyManagerFunc(ctx, cache, registry, config)
+	km, cleanup, err := newKeyManagerFunc(ctx, registry, config)
 	if err != nil {
 		log.Error(ctx, err, "Failed to initialize KeyManager")
 		return nil, nil, err

--- a/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
@@ -40,22 +40,6 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 	}, nil
 }
 
-type mockCache struct{}
-
-func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
-	return "", nil
-}
-func (m *mockCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
-	return nil
-}
-func (m *mockCache) Clear(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockCache) Delete(ctx context.Context, key string) error {
-	return nil
-}
-
 func TestNewSuccess(t *testing.T) {
 	// Setup dummy implementations and variables
 	ctx := context.Background()

--- a/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
@@ -59,7 +59,6 @@ func (m *mockCache) Delete(ctx context.Context, key string) error {
 func TestNewSuccess(t *testing.T) {
 	// Setup dummy implementations and variables
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 	cfg := map[string]string{
 		"vaultAddr": "http://dummy-vault",
@@ -72,14 +71,14 @@ func TestNewSuccess(t *testing.T) {
 		return nil
 	}
 
-	newKeyManagerFunc = func(ctx context.Context, cache definition.Cache, registry definition.RegistryLookup, cfg *keymanager.Config) (*keymanager.KeyMgr, func() error, error) {
+	newKeyManagerFunc = func(ctx context.Context, registry definition.RegistryLookup, cfg *keymanager.Config) (*keymanager.KeyMgr, func() error, error) {
 		// return a mock struct pointer of *keymanager.KeyMgr or a stub instance
 		return &keymanager.KeyMgr{}, fakeCleanup, nil
 	}
 
 	// Create provider and call New
 	provider := &keyManagerProvider{}
-	km, cleanup, err := provider.New(ctx, cache, registry, cfg)
+	km, cleanup, err := provider.New(ctx, registry, cfg)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -102,19 +101,18 @@ func TestNewSuccess(t *testing.T) {
 func TestNewFailure(t *testing.T) {
 	// Setup dummy variables
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 	cfg := map[string]string{
 		"vaultAddr": "http://dummy-vault",
 		"kvVersion": "2",
 	}
 
-	newKeyManagerFunc = func(ctx context.Context, cache definition.Cache, registry definition.RegistryLookup, cfg *keymanager.Config) (*keymanager.KeyMgr, func() error, error) {
+	newKeyManagerFunc = func(ctx context.Context, registry definition.RegistryLookup, cfg *keymanager.Config) (*keymanager.KeyMgr, func() error, error) {
 		return nil, nil, fmt.Errorf("some error")
 	}
 
 	provider := &keyManagerProvider{}
-	km, cleanup, err := provider.New(ctx, cache, registry, cfg)
+	km, cleanup, err := provider.New(ctx, registry, cfg)
 	if err == nil {
 		t.Fatal("Expected error, got nil")
 	}

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -29,7 +28,6 @@ type Config struct {
 type KeyMgr struct {
 	VaultClient *vault.Client
 	Registry    definition.RegistryLookup
-	Cache       definition.Cache
 	KvVersion   string
 	SecretPath  string
 }
@@ -49,9 +47,6 @@ var (
 
 	// ErrSubscriberNotFound indicates that no subscriber was found with the provided credentials.
 	ErrSubscriberNotFound = errors.New("no subscriber found with given credentials")
-
-	// ErrNilCache indicates that the cache implementation is nil.
-	ErrNilCache = errors.New("cache implementation cannot be nil")
 
 	// ErrNilRegistryLookup indicates that the registry lookup implementation is nil.
 	ErrNilRegistryLookup = errors.New("registry lookup implementation cannot be nil")
@@ -77,17 +72,12 @@ func ValidateCfg(cfg *Config) error {
 var getVaultClient = GetVaultClient
 
 // New creates a new KeyMgr instance with the provided configuration, cache, and registry lookup.
-func New(ctx context.Context, cache definition.Cache, registryLookup definition.RegistryLookup, cfg *Config) (*KeyMgr, func() error, error) {
+func New(ctx context.Context, registryLookup definition.RegistryLookup, cfg *Config) (*KeyMgr, func() error, error) {
 	log.Info(ctx, "Initializing KeyManager plugin")
 	// Validate configuration.
 	if err := ValidateCfg(cfg); err != nil {
 		log.Error(ctx, err, "Invalid configuration for KeyManager")
 		return nil, nil, err
-	}
-	// Check if cache implementation is provided.
-	if cache == nil {
-		log.Error(ctx, ErrNilCache, "Cache is nil in KeyManager initialization")
-		return nil, nil, ErrNilCache
 	}
 
 	// Check if registry lookup implementation is provided.
@@ -110,7 +100,6 @@ func New(ctx context.Context, cache definition.Cache, registryLookup definition.
 	km := &KeyMgr{
 		VaultClient: vaultClient,
 		Registry:    registryLookup,
-		Cache:       cache,
 		KvVersion:   cfg.KVVersion,
 	}
 
@@ -118,7 +107,6 @@ func New(ctx context.Context, cache definition.Cache, registryLookup definition.
 	cleanup := func() error {
 		log.Info(ctx, "Cleaning up KeyManager resources")
 		km.VaultClient = nil
-		km.Cache = nil
 		km.Registry = nil
 		return nil
 	}
@@ -288,14 +276,6 @@ func (km *KeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyset, erro
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
 func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
-	cacheKey := fmt.Sprintf("%s_%s", subscriberID, uniqueKeyID)
-	cachedData, err := km.Cache.Get(ctx, cacheKey)
-	if err == nil {
-		var keys model.Keyset
-		if err := json.Unmarshal([]byte(cachedData), &keys); err == nil {
-			return keys.SigningPublic, keys.EncrPublic, nil
-		}
-	}
 	subscribers, err := km.Registry.Lookup(ctx, &model.Subscription{
 		Subscriber: model.Subscriber{
 			SubscriberID: subscriberID,

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -71,7 +71,7 @@ func ValidateCfg(cfg *Config) error {
 // This is exported for testing purposes.
 var getVaultClient = GetVaultClient
 
-// New creates a new KeyMgr instance with the provided configuration, cache, and registry lookup.
+// New creates a new KeyMgr instance with the provided configuration and registry lookup.
 func New(ctx context.Context, registryLookup definition.RegistryLookup, cfg *Config) (*KeyMgr, func() error, error) {
 	log.Info(ctx, "Initializing KeyManager plugin")
 	// Validate configuration.

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -50,23 +50,6 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 	}, nil
 }
 
-type mockCache struct {
-	GetFunc func(ctx context.Context, key string) (string, error)
-}
-
-func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
-	return "", nil
-}
-func (m *mockCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
-	return nil
-}
-func (m *mockCache) Clear(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockCache) Delete(ctx context.Context, key string) error {
-	return nil
-}
 
 func TestValidateCfgSuccess(t *testing.T) {
 	tests := []struct {
@@ -378,7 +361,6 @@ func TestNewSuccess(t *testing.T) {
 	tests := []struct {
 		name            string
 		cfg             *Config
-		cache           definition.Cache
 		registry        definition.RegistryLookup
 		mockVaultStatus int
 		mockVaultBody   string
@@ -389,7 +371,6 @@ func TestNewSuccess(t *testing.T) {
 				VaultAddr: "http://dummy",
 				KVVersion: "v2",
 			},
-			cache:           &mockCache{},
 			registry:        &mockRegistryLookup{},
 			mockVaultStatus: http.StatusOK,
 			mockVaultBody:   `{}`,
@@ -416,7 +397,7 @@ func TestNewSuccess(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			km, cleanup, err := New(ctx, tt.cache, tt.registry, tt.cfg)
+			km, cleanup, err := New(ctx, tt.registry, tt.cfg)
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -436,29 +417,16 @@ func TestNewFailure(t *testing.T) {
 	tests := []struct {
 		name            string
 		cfg             *Config
-		cache           definition.Cache
 		registry        definition.RegistryLookup
 		mockVaultStatus int
 		mockVaultBody   string
 	}{
-		{
-			name: "nil cache",
-			cfg: &Config{
-				VaultAddr: "http://dummy",
-				KVVersion: "v2",
-			},
-			cache:           nil,
-			registry:        &mockRegistryLookup{},
-			mockVaultStatus: http.StatusOK,
-			mockVaultBody:   `{}`,
-		},
 		{
 			name: "nil registry",
 			cfg: &Config{
 				VaultAddr: "http://dummy",
 				KVVersion: "v2",
 			},
-			cache:           &mockCache{},
 			registry:        nil,
 			mockVaultStatus: http.StatusOK,
 			mockVaultBody:   `{}`,
@@ -469,7 +437,6 @@ func TestNewFailure(t *testing.T) {
 				VaultAddr: "",   // Invalid
 				KVVersion: "v3", // Unsupported
 			},
-			cache:           &mockCache{},
 			registry:        &mockRegistryLookup{},
 			mockVaultStatus: http.StatusOK,
 			mockVaultBody:   `{}`,
@@ -480,7 +447,6 @@ func TestNewFailure(t *testing.T) {
 				VaultAddr: "http://dummy",
 				KVVersion: "v2",
 			},
-			cache:           &mockCache{},
 			registry:        &mockRegistryLookup{},
 			mockVaultStatus: http.StatusOK,
 			mockVaultBody:   `{}`,
@@ -512,7 +478,7 @@ func TestNewFailure(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			km, cleanup, err := New(ctx, tt.cache, tt.registry, tt.cfg)
+			km, cleanup, err := New(ctx, tt.registry, tt.cfg)
 
 			if err == nil {
 				t.Error("expected error, got nil")
@@ -993,35 +959,21 @@ func TestValidateParamsFailure(t *testing.T) {
 func TestLookupNPKeysSuccess(t *testing.T) {
 	tests := []struct {
 		name               string
-		cacheGetFunc       func(ctx context.Context, key string) (string, error)
 		registryLookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
 		expectedSigningPub string
 		expectedEncrPub    string
 	}{
 		{
-			name: "Cache hit with valid keys",
-			cacheGetFunc: func(ctx context.Context, key string) (string, error) {
-				return `{"SigningPublic":"mock-signing-public-key","EncrPublic":"mock-encryption-public-key"}`, nil
-			},
-			registryLookupFunc: nil,
-			expectedSigningPub: "mock-signing-public-key",
-			expectedEncrPub:    "mock-encryption-public-key",
-		},
-		{
-			name: "Cache miss and registry success",
-			cacheGetFunc: func(ctx context.Context, key string) (string, error) {
-
-				return "", nil
-			},
+			name: "registry lookup success",
 			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 				return []model.Subscription{
 					{
 						Subscriber: model.Subscriber{
 							SubscriberID: sub.SubscriberID,
 						},
-						KeyID:            sub.KeyID,
+						KeyID:           sub.KeyID,
 						SigningPublicKey: "mock-signing-public-key",
-						EncrPublicKey:    "mock-encryption-public-key",
+						EncrPublicKey:   "mock-encryption-public-key",
 					},
 				}, nil
 			},
@@ -1032,25 +984,16 @@ func TestLookupNPKeysSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up the KeyMgr with mocks
 			km := &KeyMgr{
-				Cache: &mockCache{
-					GetFunc: tt.cacheGetFunc,
-				},
 				Registry: &mockRegistry{
 					LookupFunc: tt.registryLookupFunc,
 				},
 			}
 
-			// Call the method
 			signingPublic, encrPublic, err := km.LookupNPKeys(context.Background(), "sub-id", "key-id")
-
-			// Validate no errors in success cases
 			if err != nil {
 				t.Fatalf("LookupNPKeys() unexpected error: %v", err)
 			}
-
-			// Validate returned public keys
 			if signingPublic != tt.expectedSigningPub {
 				t.Errorf("SigningPublic = %v, want %v", signingPublic, tt.expectedSigningPub)
 			}
@@ -1064,25 +1007,18 @@ func TestLookupNPKeysSuccess(t *testing.T) {
 func TestLookupNPKeysFailure(t *testing.T) {
 	tests := []struct {
 		name               string
-		cacheGetFunc       func(ctx context.Context, key string) (string, error)
 		registryLookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
 		expectedError      string
 	}{
 		{
-			name: "Cache miss and registry failure",
-			cacheGetFunc: func(ctx context.Context, key string) (string, error) {
-				return "", nil
-			},
+			name: "registry failure",
 			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 				return nil, fmt.Errorf("registry down")
 			},
 			expectedError: "registry down",
 		},
 		{
-			name: "Cache miss and registry returns no subscriber",
-			cacheGetFunc: func(ctx context.Context, key string) (string, error) {
-				return "", nil
-			},
+			name: "registry returns no subscriber",
 			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
 				return nil, nil
 			},
@@ -1092,11 +1028,7 @@ func TestLookupNPKeysFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up the KeyMgr with mocks
 			km := &KeyMgr{
-				Cache: &mockCache{
-					GetFunc: tt.cacheGetFunc,
-				},
 				Registry: &mockRegistry{
 					LookupFunc: tt.registryLookupFunc,
 				},
@@ -1105,7 +1037,6 @@ func TestLookupNPKeysFailure(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected an error but got none")
 			}
-
 			if !strings.Contains(err.Error(), tt.expectedError) {
 				t.Errorf("expected error to contain %v, got %v", tt.expectedError, err.Error())
 			}

--- a/pkg/plugin/implementation/registry/cmd/plugin.go
+++ b/pkg/plugin/implementation/registry/cmd/plugin.go
@@ -24,6 +24,16 @@ func (r registryProvider) parseConfig(config map[string]string) (*registry.Confi
 		URL: config["url"],
 	}
 
+	// Parse cacheTTL
+	if cacheTTLStr, exists := config["cacheTTL"]; exists && cacheTTLStr != "" {
+		cacheTTL, err := time.ParseDuration(cacheTTLStr)
+		if err != nil {
+			log.Warnf(context.Background(), "Invalid cacheTTL value '%s', using default", cacheTTLStr)
+		} else {
+			registryConfig.CacheTTL = cacheTTL
+		}
+	}
+
 	// Parse retry_max
 	if retryMaxStr, exists := config["retry_max"]; exists && retryMaxStr != "" {
 		retryMax, err := strconv.Atoi(retryMaxStr)
@@ -55,7 +65,7 @@ func (r registryProvider) parseConfig(config map[string]string) (*registry.Confi
 }
 
 // New creates a new registry plugin instance.
-func (r registryProvider) New(ctx context.Context, config map[string]string) (definition.RegistryLookup, func() error, error) {
+func (r registryProvider) New(ctx context.Context, cache definition.Cache, config map[string]string) (definition.RegistryLookup, func() error, error) {
 	if ctx == nil {
 		return nil, nil, errors.New("context cannot be nil")
 	}
@@ -69,7 +79,7 @@ func (r registryProvider) New(ctx context.Context, config map[string]string) (de
 
 	log.Debugf(ctx, "Registry config mapped: %+v", registryConfig)
 
-	registryClient, closer, err := newRegistryFunc(ctx, registryConfig)
+	registryClient, closer, err := newRegistryFunc(ctx, cache, registryConfig)
 	if err != nil {
 		log.Errorf(ctx, err, "Failed to create registry instance")
 		return nil, nil, err

--- a/pkg/plugin/implementation/registry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/registry/cmd/plugin_test.go
@@ -121,6 +121,49 @@ func TestRegistryProvider_ParseConfig(t *testing.T) {
 	}
 }
 
+// TestRegistryProvider_ParseConfig_CacheTTL verifies that cacheTTL is parsed correctly
+// and that an invalid value warns but does not return an error (warn-and-ignore semantics).
+func TestRegistryProvider_ParseConfig_CacheTTL(t *testing.T) {
+	t.Parallel()
+	provider := registryProvider{}
+
+	t.Run("valid cacheTTL is parsed and set", func(t *testing.T) {
+		cfg, err := provider.parseConfig(map[string]string{
+			"url":      "http://test.com",
+			"cacheTTL": "10m",
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.CacheTTL != 10*time.Minute {
+			t.Errorf("expected CacheTTL 10m, got %v", cfg.CacheTTL)
+		}
+	})
+
+	t.Run("invalid cacheTTL warns and leaves CacheTTL zero", func(t *testing.T) {
+		cfg, err := provider.parseConfig(map[string]string{
+			"url":      "http://test.com",
+			"cacheTTL": "not-a-duration",
+		})
+		if err != nil {
+			t.Fatalf("expected no error (warn-and-ignore), got %v", err)
+		}
+		if cfg.CacheTTL != 0 {
+			t.Errorf("expected CacheTTL 0 (will use defaultCacheTTL), got %v", cfg.CacheTTL)
+		}
+	})
+
+	t.Run("absent cacheTTL leaves CacheTTL zero", func(t *testing.T) {
+		cfg, err := provider.parseConfig(map[string]string{"url": "http://test.com"})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.CacheTTL != 0 {
+			t.Errorf("expected CacheTTL 0, got %v", cfg.CacheTTL)
+		}
+	})
+}
+
 // TestRegistryProvider_New tests the plugin's main constructor.
 func TestRegistryProvider_New(t *testing.T) {
 	t.Parallel()

--- a/pkg/plugin/implementation/registry/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/registry/cmd/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/registry"
 )
 
@@ -132,7 +133,7 @@ func TestRegistryProvider_New(t *testing.T) {
 	})
 
 	t.Run("should return error if context is nil", func(t *testing.T) {
-		_, _, err := provider.New(nil, map[string]string{})
+		_, _, err := provider.New(nil, nil, map[string]string{})
 		if err == nil {
 			t.Fatal("expected an error for nil context but got none")
 		}
@@ -143,7 +144,7 @@ func TestRegistryProvider_New(t *testing.T) {
 
 	t.Run("should return error if config parsing fails", func(t *testing.T) {
 		config := map[string]string{"retry_max": "invalid"}
-		_, _, err := provider.New(context.Background(), config)
+		_, _, err := provider.New(context.Background(), nil, config)
 		if err == nil {
 			t.Fatal("expected an error for bad config but got none")
 		}
@@ -152,12 +153,12 @@ func TestRegistryProvider_New(t *testing.T) {
 	t.Run("should return error if registry.New fails", func(t *testing.T) {
 		// Mock the newRegistryFunc to return an error
 		expectedErr := errors.New("registry creation failed")
-		newRegistryFunc = func(ctx context.Context, cfg *registry.Config) (*registry.RegistryClient, func() error, error) {
+		newRegistryFunc = func(ctx context.Context, cache definition.Cache, cfg *registry.Config) (*registry.RegistryClient, func() error, error) {
 			return nil, nil, expectedErr
 		}
 
 		config := map[string]string{"url": "http://test.com"}
-		_, _, err := provider.New(context.Background(), config)
+		_, _, err := provider.New(context.Background(), nil, config)
 		if err == nil {
 			t.Fatal("expected an error from registry.New but got none")
 		}
@@ -169,13 +170,13 @@ func TestRegistryProvider_New(t *testing.T) {
 	t.Run("should succeed and return a valid instance", func(t *testing.T) {
 		// Mock the newRegistryFunc for a successful case
 		mockCloser := func() error { fmt.Println("closed"); return nil }
-		newRegistryFunc = func(ctx context.Context, cfg *registry.Config) (*registry.RegistryClient, func() error, error) {
-			// Return a non-nil client of th correct concrete type
+		newRegistryFunc = func(ctx context.Context, cache definition.Cache, cfg *registry.Config) (*registry.RegistryClient, func() error, error) {
+			// Return a non-nil client of the correct concrete type
 			return new(registry.RegistryClient), mockCloser, nil
 		}
 
 		config := map[string]string{"url": "http://test.com"}
-		instance, closer, err := provider.New(context.Background(), config)
+		instance, closer, err := provider.New(context.Background(), nil, config)
 		if err != nil {
 			t.Fatalf("expected no error, but got: %v", err)
 		}

--- a/pkg/plugin/implementation/registry/registry.go
+++ b/pkg/plugin/implementation/registry/registry.go
@@ -12,7 +12,10 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"github.com/hashicorp/go-retryablehttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const defaultCacheTTL = 5 * time.Minute
@@ -129,9 +132,13 @@ func (c *RegistryClient) Subscribe(ctx context.Context, subscription *model.Subs
 // On a cache hit the network call is skipped entirely.
 func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscription) ([]model.Subscription, error) {
 	cacheKey := fmt.Sprintf("lookup_%s_%s", subscription.SubscriberID, subscription.KeyID)
+	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
 
 	if c.cache != nil {
-		if cached, err := c.cache.Get(ctx, cacheKey); err == nil {
+		cacheCtx, cacheSpan := tracer.Start(ctx, "cache lookup")
+		cached, err := c.cache.Get(cacheCtx, cacheKey)
+		cacheSpan.End()
+		if err == nil {
 			var results []model.Subscription
 			if err := json.Unmarshal([]byte(cached), &results); err == nil {
 				log.Debugf(ctx, "Registry lookup cache hit for key: %s", cacheKey)
@@ -152,7 +159,10 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(ctx)
+
+	httpCtx, httpSpan := tracer.Start(ctx, "http lookup")
+	defer httpSpan.End()
+	req = req.WithContext(httpCtx)
 
 	log.Debugf(ctx, "Making lookup request to: %s", lookupURL)
 	resp, err := c.client.Do(req)

--- a/pkg/plugin/implementation/registry/registry.go
+++ b/pkg/plugin/implementation/registry/registry.go
@@ -11,12 +11,16 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+const defaultCacheTTL = 5 * time.Minute
 
 // Config holds configuration parameters for the registry client.
 type Config struct {
 	URL          string        `yaml:"url" json:"url"`
+	CacheTTL     time.Duration `yaml:"cacheTTL" json:"cacheTTL"`
 	RetryMax     int           `yaml:"retry_max" json:"retry_max"`
 	RetryWaitMin time.Duration `yaml:"retry_wait_min" json:"retry_wait_min"`
 	RetryWaitMax time.Duration `yaml:"retry_wait_max" json:"retry_wait_max"`
@@ -24,8 +28,10 @@ type Config struct {
 
 // RegistryClient encapsulates the logic for calling the registry endpoints.
 type RegistryClient struct {
-	config *Config
-	client *retryablehttp.Client
+	config   *Config
+	client   *retryablehttp.Client
+	cache    definition.Cache
+	cacheTTL time.Duration
 }
 
 // validate checks if the provided registry configuration is valid.
@@ -40,7 +46,7 @@ func validate(cfg *Config) error {
 }
 
 // New creates a new instance of RegistryClient.
-func New(ctx context.Context, cfg *Config) (*RegistryClient, func() error, error) {
+func New(ctx context.Context, cache definition.Cache, cfg *Config) (*RegistryClient, func() error, error) {
 	log.Debugf(ctx, "Initializing Registry client with config: %+v", cfg)
 
 	if err := validate(cfg); err != nil {
@@ -60,9 +66,16 @@ func New(ctx context.Context, cfg *Config) (*RegistryClient, func() error, error
 		rc.RetryWaitMax = cfg.RetryWaitMax
 	}
 
+	ttl := cfg.CacheTTL
+	if ttl <= 0 {
+		ttl = defaultCacheTTL
+	}
+
 	client := &RegistryClient{
-		config: cfg,
-		client: rc,
+		config:   cfg,
+		client:   rc,
+		cache:    cache,
+		cacheTTL: ttl,
 	}
 
 	// Cleanup function
@@ -112,7 +125,21 @@ func (c *RegistryClient) Subscribe(ctx context.Context, subscription *model.Subs
 }
 
 // Lookup calls the /lookup endpoint with retry and returns a slice of Subscription.
+// Results are cached using the subscriber ID and key ID as the cache key.
+// On a cache hit the network call is skipped entirely.
 func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscription) ([]model.Subscription, error) {
+	cacheKey := fmt.Sprintf("lookup_%s_%s", subscription.SubscriberID, subscription.KeyID)
+
+	if c.cache != nil {
+		if cached, err := c.cache.Get(ctx, cacheKey); err == nil {
+			var results []model.Subscription
+			if err := json.Unmarshal([]byte(cached), &results); err == nil {
+				log.Debugf(ctx, "Registry lookup cache hit for key: %s", cacheKey)
+				return results, nil
+			}
+		}
+	}
+
 	lookupURL := fmt.Sprintf("%s/lookup", c.config.URL)
 
 	jsonData, err := json.Marshal(subscription)
@@ -146,11 +173,25 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 	}
 
 	var results []model.Subscription
-	err = json.Unmarshal(body, &results)
-	if err != nil {
+	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
 	log.Debugf(ctx, "Lookup request successful, found %d subscriptions", len(results))
+
+	if c.cache != nil && len(results) > 0 {
+		ttl := c.cacheTTL
+		if !results[0].ValidUntil.IsZero() {
+			if d := time.Until(results[0].ValidUntil); d > 0 {
+				ttl = d
+			}
+		}
+		if data, err := json.Marshal(results); err == nil {
+			if err := c.cache.Set(ctx, cacheKey, string(data), ttl); err != nil {
+				log.Warnf(ctx, "Failed to cache registry lookup result for key %s: %v", cacheKey, err)
+			}
+		}
+	}
+
 	return results, nil
 }

--- a/pkg/plugin/implementation/registry/registry.go
+++ b/pkg/plugin/implementation/registry/registry.go
@@ -137,14 +137,15 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 	if c.cache != nil {
 		cacheCtx, cacheSpan := tracer.Start(ctx, "cache lookup")
 		cached, err := c.cache.Get(cacheCtx, cacheKey)
-		cacheSpan.End()
 		if err == nil {
 			var results []model.Subscription
 			if err := json.Unmarshal([]byte(cached), &results); err == nil {
 				log.Debugf(ctx, "Registry lookup cache hit for key: %s", cacheKey)
+				cacheSpan.End()
 				return results, nil
 			}
 		}
+		cacheSpan.End()
 	}
 
 	lookupURL := fmt.Sprintf("%s/lookup", c.config.URL)
@@ -161,26 +162,29 @@ func (c *RegistryClient) Lookup(ctx context.Context, subscription *model.Subscri
 	req.Header.Set("Content-Type", "application/json")
 
 	httpCtx, httpSpan := tracer.Start(ctx, "http lookup")
-	defer httpSpan.End()
 	req = req.WithContext(httpCtx)
 
 	log.Debugf(ctx, "Making lookup request to: %s", lookupURL)
 	resp, err := c.client.Do(req)
 	if err != nil {
+		httpSpan.End()
 		return nil, fmt.Errorf("failed to send lookup request with retry: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		httpSpan.End()
 		log.Errorf(ctx, nil, "Lookup request failed with status: %s, response: %s", resp.Status, string(body))
 		return nil, fmt.Errorf("lookup request failed with status: %s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		httpSpan.End()
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	httpSpan.End()
 
 	var results []model.Subscription
 	if err := json.Unmarshal(body, &results); err != nil {

--- a/pkg/plugin/implementation/registry/registry_test.go
+++ b/pkg/plugin/implementation/registry/registry_test.go
@@ -313,6 +313,91 @@ func TestRegistryClient_Lookup_Cache(t *testing.T) {
 		}
 	})
 
+	t.Run("corrupt cache value falls through to HTTP", func(t *testing.T) {
+		resp := []model.Subscription{{SigningPublicKey: "fresh-key"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return "this is not valid json{{{{", nil
+			},
+		}
+		client, closer, err := New(context.Background(), cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "fresh-key" {
+			t.Errorf("expected HTTP result after corrupt cache, got %+v", results)
+		}
+	})
+
+	t.Run("cache set error does not fail lookup", func(t *testing.T) {
+		resp := []model.Subscription{{SigningPublicKey: "registry-key"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{setErr: errors.New("redis down")}
+		client, closer, err := New(context.Background(), cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() must not fail when cache.Set errors, got: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "registry-key" {
+			t.Errorf("unexpected result: %+v", results)
+		}
+	})
+
+	t.Run("zero ValidUntil uses default cache TTL", func(t *testing.T) {
+		resp := []model.Subscription{{
+			SigningPublicKey: "registry-key",
+			// ValidUntil is zero — no expiry in the response
+		}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{}
+		client, closer, err := New(context.Background(), cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		_, err = client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if cache.setTTL != defaultCacheTTL {
+			t.Errorf("expected default TTL %v, got %v", defaultCacheTTL, cache.setTTL)
+		}
+	})
+
 	t.Run("nil cache behaves as before — no cache operations", func(t *testing.T) {
 		resp := []model.Subscription{{SigningPublicKey: "direct-key"}}
 

--- a/pkg/plugin/implementation/registry/registry_test.go
+++ b/pkg/plugin/implementation/registry/registry_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,30 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
+
+// mockCache is a test double for definition.Cache.
+type mockCache struct {
+	getFunc func(ctx context.Context, key string) (string, error)
+	setKey  string
+	setVal  string
+	setTTL  time.Duration
+	setErr  error
+}
+
+func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, key)
+	}
+	return "", errors.New("cache miss")
+}
+func (m *mockCache) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	m.setKey = key
+	m.setVal = value
+	m.setTTL = ttl
+	return m.setErr
+}
+func (m *mockCache) Delete(ctx context.Context, key string) error { return nil }
+func (m *mockCache) Clear(ctx context.Context) error              { return nil }
 
 // TestValidate ensures the config validation logic works correctly.
 func TestValidate(t *testing.T) {
@@ -61,7 +86,7 @@ func TestNew(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should fail with invalid config", func(t *testing.T) {
-		_, _, err := New(context.Background(), &Config{URL: ""})
+		_, _, err := New(context.Background(), nil, &Config{URL: ""})
 		if err == nil {
 			t.Fatal("expected an error for invalid config but got none")
 		}
@@ -69,7 +94,7 @@ func TestNew(t *testing.T) {
 
 	t.Run("should succeed with valid config and set defaults", func(t *testing.T) {
 		cfg := &Config{URL: "http://test.com"}
-		client, closer, err := New(context.Background(), cfg)
+		client, closer, err := New(context.Background(), nil, cfg)
 		if err != nil {
 			t.Fatalf("expected no error, but got: %v", err)
 		}
@@ -92,7 +117,7 @@ func TestNew(t *testing.T) {
 			RetryWaitMin: 100 * time.Millisecond,
 			RetryWaitMax: 1 * time.Second,
 		}
-		client, _, err := New(context.Background(), cfg)
+		client, _, err := New(context.Background(), nil, cfg)
 		if err != nil {
 			t.Fatalf("expected no error, but got: %v", err)
 		}
@@ -145,7 +170,7 @@ func TestRegistryClient_Lookup(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(context.Background(), &Config{URL: server.URL})
+		client, closer, err := New(context.Background(), nil, &Config{URL: server.URL})
 		if err != nil {
 			t.Fatalf("failed to create client: %v", err)
 		}
@@ -171,7 +196,7 @@ func TestRegistryClient_Lookup(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(context.Background(), &Config{URL: server.URL})
+		client, closer, err := New(context.Background(), nil, &Config{URL: server.URL})
 		if err != nil {
 			t.Fatalf("failed to create client: %v", err)
 		}
@@ -190,7 +215,7 @@ func TestRegistryClient_Lookup(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, closer, err := New(context.Background(), &Config{URL: server.URL, RetryMax: 1})
+		client, closer, err := New(context.Background(), nil, &Config{URL: server.URL, RetryMax: 1})
 		if err != nil {
 			t.Fatalf("failed to create client: %v", err)
 		}
@@ -199,6 +224,117 @@ func TestRegistryClient_Lookup(t *testing.T) {
 		_, err = client.Lookup(context.Background(), &model.Subscription{})
 		if err == nil {
 			t.Fatal("expected an unmarshaling error but got none")
+		}
+	})
+}
+
+// TestRegistryClient_Lookup_Cache tests the caching behaviour of the Lookup method.
+func TestRegistryClient_Lookup_Cache(t *testing.T) {
+	t.Parallel()
+
+	sub := &model.Subscription{
+		Subscriber: model.Subscriber{SubscriberID: "test-np"},
+		KeyID:      "key-1",
+	}
+	expectedCacheKey := "lookup_test-np_key-1"
+
+	t.Run("cache hit skips HTTP call", func(t *testing.T) {
+		cached := []model.Subscription{{SigningPublicKey: "cached-key"}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		httpCalled := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(context.Background(), cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if httpCalled {
+			t.Error("expected HTTP call to be skipped on cache hit")
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "cached-key" {
+			t.Errorf("expected cached result, got %+v", results)
+		}
+	})
+
+	t.Run("cache miss calls HTTP and writes to cache", func(t *testing.T) {
+		validUntil := time.Now().Add(10 * time.Minute)
+		resp := []model.Subscription{{
+			Subscriber:      model.Subscriber{SubscriberID: "test-np"},
+			KeyID:           "key-1",
+			SigningPublicKey: "registry-key",
+			ValidUntil:      validUntil,
+		}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		cache := &mockCache{}
+		client, closer, err := New(context.Background(), cache, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "registry-key" {
+			t.Errorf("unexpected result: %+v", results)
+		}
+		if cache.setKey != expectedCacheKey {
+			t.Errorf("expected cache key %q, got %q", expectedCacheKey, cache.setKey)
+		}
+		if cache.setVal == "" {
+			t.Error("expected non-empty value written to cache")
+		}
+		if cache.setTTL <= 0 {
+			t.Errorf("expected positive TTL, got %v", cache.setTTL)
+		}
+	})
+
+	t.Run("nil cache behaves as before — no cache operations", func(t *testing.T) {
+		resp := []model.Subscription{{SigningPublicKey: "direct-key"}}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client, closer, err := New(context.Background(), nil, &Config{URL: server.URL})
+		if err != nil {
+			t.Fatalf("failed to create client: %v", err)
+		}
+		defer closer()
+
+		results, err := client.Lookup(context.Background(), sub)
+		if err != nil {
+			t.Fatalf("Lookup() unexpected error: %v", err)
+		}
+		if len(results) != 1 || results[0].SigningPublicKey != "direct-key" {
+			t.Errorf("unexpected result: %+v", results)
 		}
 	})
 }

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
@@ -14,8 +14,8 @@ type simpleKeyManagerProvider struct{}
 // newSimpleKeyManagerFunc is a function type that creates a new SimpleKeyManager instance.
 var newSimpleKeyManagerFunc = simplekeymanager.New
 
-// New creates and initializes a new SimpleKeyManager instance using the provided cache, registry lookup, and configuration.
-func (k *simpleKeyManagerProvider) New(ctx context.Context, cache definition.Cache, registry definition.RegistryLookup, cfg map[string]string) (definition.KeyManager, func() error, error) {
+// New creates and initializes a new SimpleKeyManager instance using the provided registry lookup and configuration.
+func (k *simpleKeyManagerProvider) New(ctx context.Context, registry definition.RegistryLookup, cfg map[string]string) (definition.KeyManager, func() error, error) {
 	subscriberID := cfg["subscriberId"]
 	if subscriberID == "" {
 		if np := cfg["networkParticipant"]; np != "" {
@@ -40,7 +40,7 @@ func (k *simpleKeyManagerProvider) New(ctx context.Context, cache definition.Cac
 		config.EncrPrivateKey != "",
 		config.EncrPublicKey != "")
 
-	km, cleanup, err := newSimpleKeyManagerFunc(ctx, cache, registry, config)
+	km, cleanup, err := newSimpleKeyManagerFunc(ctx, registry, config)
 	if err != nil {
 		log.Error(ctx, err, "Failed to initialize SimpleKeyManager")
 		return nil, nil, err

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
@@ -3,30 +3,10 @@ package main
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/simplekeymanager"
 )
-
-// Mock implementations for testing
-type mockCache struct{}
-
-func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
-	return "", nil
-}
-
-func (m *mockCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
-	return nil
-}
-
-func (m *mockCache) Clear(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockCache) Delete(ctx context.Context, key string) error {
-	return nil
-}
 
 type mockRegistry struct{}
 
@@ -37,7 +17,6 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 func TestSimpleKeyManagerProvider_New(t *testing.T) {
 	provider := &simpleKeyManagerProvider{}
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 
 	tests := []struct {
@@ -53,19 +32,19 @@ func TestSimpleKeyManagerProvider_New(t *testing.T) {
 		{
 			name: "valid config with keys",
 			config: map[string]string{
-				"subscriberId": "bap-one",
-				"keyId":        "test-key",
-				"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
-				"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
-				"encrPublicKey":      "dGVzdC1lbmNyLXB1YmxpYw==",
+				"subscriberId":     "bap-one",
+				"keyId":            "test-key",
+				"signingPrivateKey": "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+				"signingPublicKey":  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+				"encrPrivateKey":    "dGVzdC1lbmNyLXByaXZhdGU=",
+				"encrPublicKey":     "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
 		{
 			name: "invalid config - partial keys",
 			config: map[string]string{
-				"keyId":             "test-key",
+				"keyId":            "test-key",
 				"signingPrivateKey": "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				// Missing other required keys
 			},
@@ -82,7 +61,7 @@ func TestSimpleKeyManagerProvider_New(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			km, cleanup, err := provider.New(ctx, cache, registry, tt.config)
+			km, cleanup, err := provider.New(ctx, registry, tt.config)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("simpleKeyManagerProvider.New() error = %v, wantErr %v", err, tt.wantErr)
@@ -97,7 +76,6 @@ func TestSimpleKeyManagerProvider_New(t *testing.T) {
 					t.Error("simpleKeyManagerProvider.New() returned nil cleanup function")
 				}
 				if cleanup != nil {
-					// Test that cleanup doesn't panic
 					err := cleanup()
 					if err != nil {
 						t.Errorf("cleanup() error = %v", err)
@@ -120,43 +98,28 @@ func TestSimpleKeyManagerProvider_NewWithNilDependencies(t *testing.T) {
 	ctx := context.Background()
 	config := map[string]string{}
 
-	// Test with nil cache
-	_, _, err := provider.New(ctx, nil, &mockRegistry{}, config)
-	if err == nil {
-		t.Error("simpleKeyManagerProvider.New() should fail with nil cache")
-	}
-
 	// Test with nil registry
-	_, _, err = provider.New(ctx, &mockCache{}, nil, config)
+	_, _, err := provider.New(ctx, nil, config)
 	if err == nil {
 		t.Error("simpleKeyManagerProvider.New() should fail with nil registry")
-	}
-
-	// Test with both nil
-	_, _, err = provider.New(ctx, nil, nil, config)
-	if err == nil {
-		t.Error("simpleKeyManagerProvider.New() should fail with nil dependencies")
 	}
 }
 
 func TestConfigMapping(t *testing.T) {
 	provider := &simpleKeyManagerProvider{}
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 
 	configMap := map[string]string{
-		"subscriberId": "mapped-np",
-		"keyId":        "mapped-key-id",
-		"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
-		"signingPublicKey":   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-		"encrPrivateKey":     "dGVzdC1lbmNyLXByaXZhdGU=",
-		"encrPublicKey":      "dGVzdC1lbmNyLXB1YmxpYw==",
+		"subscriberId":     "mapped-np",
+		"keyId":            "mapped-key-id",
+		"signingPrivateKey": "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+		"signingPublicKey":  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+		"encrPrivateKey":    "dGVzdC1lbmNyLXByaXZhdGU=",
+		"encrPublicKey":     "dGVzdC1lbmNyLXB1YmxpYw==",
 	}
 
-	// We can't directly test the config mapping without exposing internals,
-	// but we can test that the mapping doesn't cause errors
-	_, cleanup, err := provider.New(ctx, cache, registry, configMap)
+	_, cleanup, err := provider.New(ctx, registry, configMap)
 	if err != nil {
 		t.Errorf("Config mapping failed: %v", err)
 		return
@@ -170,11 +133,10 @@ func TestConfigMapping(t *testing.T) {
 func TestDeprecatedNetworkParticipantKey(t *testing.T) {
 	provider := &simpleKeyManagerProvider{}
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 
 	// Config using the deprecated networkParticipant key should still work.
-	_, cleanup, err := provider.New(ctx, cache, registry, map[string]string{
+	_, cleanup, err := provider.New(ctx, registry, map[string]string{
 		"networkParticipant": "bap-one",
 		"keyId":              "test-key",
 		"signingPrivateKey":  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
@@ -190,7 +152,7 @@ func TestDeprecatedNetworkParticipantKey(t *testing.T) {
 	}
 
 	// subscriberId takes precedence over deprecated networkParticipant when both are present.
-	_, cleanup, err = provider.New(ctx, cache, registry, map[string]string{
+	_, cleanup, err = provider.New(ctx, registry, map[string]string{
 		"subscriberId":       "bap-primary",
 		"networkParticipant": "bap-ignored",
 		"keyId":              "test-key",
@@ -207,18 +169,12 @@ func TestDeprecatedNetworkParticipantKey(t *testing.T) {
 	}
 }
 
-// Test that the provider implements the correct interface
-// This is a compile-time check to ensure interface compliance
 func TestProviderInterface(t *testing.T) {
 	provider := &simpleKeyManagerProvider{}
 	ctx := context.Background()
 
-	// This should compile if the interface is implemented correctly
-	_, _, err := provider.New(ctx, &mockCache{}, &mockRegistry{}, map[string]string{})
-
-	// We expect an error here because of missing dependencies, but the call should compile
+	_, _, err := provider.New(ctx, &mockRegistry{}, map[string]string{})
 	if err == nil {
-		// This might succeed with mocks, which is fine
 		t.Log("Provider.New() succeeded with mock dependencies")
 	} else {
 		t.Logf("Provider.New() failed as expected: %v", err)
@@ -226,19 +182,15 @@ func TestProviderInterface(t *testing.T) {
 }
 
 func TestNewSimpleKeyManagerFunc(t *testing.T) {
-	// Test that the function variable is set
 	if newSimpleKeyManagerFunc == nil {
 		t.Error("newSimpleKeyManagerFunc is nil")
 	}
 
-	// Test that it points to the correct function
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 	cfg := &simplekeymanager.Config{}
 
-	// This should call the actual New function
-	_, cleanup, err := newSimpleKeyManagerFunc(ctx, cache, registry, cfg)
+	_, cleanup, err := newSimpleKeyManagerFunc(ctx, registry, cfg)
 
 	if err != nil {
 		t.Logf("newSimpleKeyManagerFunc failed as expected with mocks: %v", err)

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -34,7 +33,6 @@ type Config struct {
 // SimpleKeyMgr provides methods for managing cryptographic keys using configuration.
 type SimpleKeyMgr struct {
 	Registry definition.RegistryLookup
-	Cache    definition.Cache
 	keysets  map[string]*model.Keyset // In-memory storage for keysets
 }
 
@@ -53,9 +51,6 @@ var (
 
 	// ErrSubscriberNotFound indicates that no subscriber was found with the provided credentials.
 	ErrSubscriberNotFound = errors.New("no subscriber found with given credentials")
-
-	// ErrNilCache indicates that the cache implementation is nil.
-	ErrNilCache = errors.New("cache implementation cannot be nil")
 
 	// ErrNilRegistryLookup indicates that the registry lookup implementation is nil.
 	ErrNilRegistryLookup = errors.New("registry lookup implementation cannot be nil")
@@ -108,20 +103,14 @@ var (
 	uuidGenFunc       = uuid.NewRandom
 )
 
-// New creates a new SimpleKeyMgr instance with the provided configuration, cache, and registry lookup.
-func New(ctx context.Context, cache definition.Cache, registryLookup definition.RegistryLookup, cfg *Config) (*SimpleKeyMgr, func() error, error) {
+// New creates a new SimpleKeyMgr instance with the provided registry lookup and configuration.
+func New(ctx context.Context, registryLookup definition.RegistryLookup, cfg *Config) (*SimpleKeyMgr, func() error, error) {
 	log.Info(ctx, "Initializing SimpleKeyManager plugin")
 
 	// Validate configuration.
 	if err := ValidateCfg(cfg); err != nil {
 		log.Error(ctx, err, "Invalid configuration for SimpleKeyManager")
 		return nil, nil, err
-	}
-
-	// Check if cache implementation is provided.
-	if cache == nil {
-		log.Error(ctx, ErrNilCache, "Cache is nil in SimpleKeyManager initialization")
-		return nil, nil, ErrNilCache
 	}
 
 	// Check if registry lookup implementation is provided.
@@ -135,7 +124,6 @@ func New(ctx context.Context, cache definition.Cache, registryLookup definition.
 	// Create SimpleKeyManager instance.
 	skm := &SimpleKeyMgr{
 		Registry: registryLookup,
-		Cache:    cache,
 		keysets:  make(map[string]*model.Keyset),
 	}
 
@@ -148,7 +136,6 @@ func New(ctx context.Context, cache definition.Cache, registryLookup definition.
 	// Cleanup function to release SimpleKeyManager resources.
 	cleanup := func() error {
 		log.Info(ctx, "Cleaning up SimpleKeyManager resources")
-		skm.Cache = nil
 		skm.Registry = nil
 		skm.keysets = nil
 		return nil
@@ -249,24 +236,7 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 	}
 
 	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
-	cacheKey := fmt.Sprintf("%s_%s", subscriberID, uniqueKeyID)
-	var cachedData string
 
-	{
-		spanCtx, span := tracer.Start(ctx, "redis lookup")
-		defer span.End()
-		var err error
-		cachedData, err = skm.Cache.Get(spanCtx, cacheKey)
-		if err == nil {
-			var keys model.Keyset
-			if err := json.Unmarshal([]byte(cachedData), &keys); err == nil {
-				log.Debugf(ctx, "Found cached keys for subscriber: %s, uniqueKeyID: %s", subscriberID, uniqueKeyID)
-				return keys.SigningPublic, keys.EncrPublic, nil
-			}
-		}
-	}
-
-	log.Debugf(ctx, "Cache miss, looking up registry for subscriber: %s, uniqueKeyID: %s", subscriberID, uniqueKeyID)
 	var subscribers []model.Subscription
 	{
 		spanCtx, span := tracer.Start(ctx, "registry lookup")

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -4,30 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
-	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Mock implementations for testing
-type mockCache struct{}
-
-func (m *mockCache) Get(ctx context.Context, key string) (string, error) {
-	return "", nil
-}
-
-func (m *mockCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
-	return nil
-}
-
-func (m *mockCache) Clear(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockCache) Delete(ctx context.Context, key string) error {
-	return nil
-}
-
 type mockRegistry struct{}
 
 func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
@@ -94,7 +75,6 @@ func TestValidateCfg(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	ctx := context.Background()
-	cache := &mockCache{}
 	registry := &mockRegistry{}
 
 	tests := []struct {
@@ -115,12 +95,12 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config with keys",
 			cfg: &Config{
-				SubscriberID: "test-np",
-				KeyID:        "test-key",
-				SigningPrivateKey:  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
-				SigningPublicKey:   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				EncrPrivateKey:     "dGVzdC1lbmNyLXByaXZhdGU=",
-				EncrPublicKey:      "dGVzdC1lbmNyLXB1YmxpYw==",
+				SubscriberID:     "test-np",
+				KeyID:            "test-key",
+				SigningPrivateKey: "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+				SigningPublicKey:  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+				EncrPrivateKey:   "dGVzdC1lbmNyLXByaXZhdGU=",
+				EncrPublicKey:    "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
@@ -128,7 +108,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			skm, cleanup, err := New(ctx, cache, registry, tt.cfg)
+			skm, cleanup, err := New(ctx, registry, tt.cfg)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
@@ -154,14 +134,8 @@ func TestNewWithNilDependencies(t *testing.T) {
 	ctx := context.Background()
 	cfg := &Config{}
 
-	// Test nil cache
-	_, _, err := New(ctx, nil, &mockRegistry{}, cfg)
-	if err == nil {
-		t.Error("New() should fail with nil cache")
-	}
-
 	// Test nil registry
-	_, _, err = New(ctx, &mockCache{}, nil, cfg)
+	_, _, err := New(ctx, nil, cfg)
 	if err == nil {
 		t.Error("New() should fail with nil registry")
 	}
@@ -329,7 +303,6 @@ func TestDeleteKeyset(t *testing.T) {
 
 func TestLookupNPKeys(t *testing.T) {
 	skm := &SimpleKeyMgr{
-		Cache:    &mockCache{},
 		Registry: &mockRegistry{},
 	}
 	ctx := context.Background()

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -384,7 +384,7 @@ func (m *Manager) SignValidator(ctx context.Context, cfg *Config) (definition.Si
 
 // KeyManager returns a KeyManager instance based on the provided configuration.
 // It reuses the loaded provider.
-func (m *Manager) KeyManager(ctx context.Context, cache definition.Cache, rClient definition.RegistryLookup, cfg *Config) (definition.KeyManager, error) {
+func (m *Manager) KeyManager(ctx context.Context, rClient definition.RegistryLookup, cfg *Config) (definition.KeyManager, error) {
 
 	kmp, err := provider[definition.KeyManagerProvider](m.plugins, cfg.ID)
 	if err != nil {
@@ -406,7 +406,7 @@ func (m *Manager) KeyManager(ctx context.Context, cache definition.Cache, rClien
 
 // SimpleKeyManager returns a KeyManager instance based on the provided configuration.
 // It reuses the loaded provider.
-func (m *Manager) SimpleKeyManager(ctx context.Context, cache definition.Cache, rClient definition.RegistryLookup, cfg *Config) (definition.KeyManager, error) {
+func (m *Manager) SimpleKeyManager(ctx context.Context, rClient definition.RegistryLookup, cfg *Config) (definition.KeyManager, error) {
 
 	kmp, err := provider[definition.KeyManagerProvider](m.plugins, cfg.ID)
 	if err != nil {

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -390,7 +390,7 @@ func (m *Manager) KeyManager(ctx context.Context, cache definition.Cache, rClien
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
 	}
-	km, closer, err := kmp.New(ctx, cache, rClient, cfg.Config)
+	km, closer, err := kmp.New(ctx, rClient, cfg.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +404,7 @@ func (m *Manager) KeyManager(ctx context.Context, cache definition.Cache, rClien
 	return km, nil
 }
 
-// KeyManager returns a KeyManager instance based on the provided configuration.
+// SimpleKeyManager returns a KeyManager instance based on the provided configuration.
 // It reuses the loaded provider.
 func (m *Manager) SimpleKeyManager(ctx context.Context, cache definition.Cache, rClient definition.RegistryLookup, cfg *Config) (definition.KeyManager, error) {
 
@@ -412,7 +412,7 @@ func (m *Manager) SimpleKeyManager(ctx context.Context, cache definition.Cache, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
 	}
-	km, closer, err := kmp.New(ctx, cache, rClient, cfg.Config)
+	km, closer, err := kmp.New(ctx, rClient, cfg.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -469,12 +469,12 @@ func (m *Manager) ManifestLoader(ctx context.Context, cache definition.Cache, lo
 
 // Registry returns a RegistryLookup instance based on the provided configuration.
 // It registers a cleanup function for resource management.
-func (m *Manager) Registry(ctx context.Context, cfg *Config) (definition.RegistryLookup, error) {
+func (m *Manager) Registry(ctx context.Context, cache definition.Cache, cfg *Config) (definition.RegistryLookup, error) {
 	rp, err := provider[definition.RegistryLookupProvider](m.plugins, cfg.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
 	}
-	registry, closer, err := rp.New(ctx, cfg.Config)
+	registry, closer, err := rp.New(ctx, cache, cfg.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -490,12 +490,12 @@ func (m *Manager) Registry(ctx context.Context, cfg *Config) (definition.Registr
 
 // DeDiRegistry returns a RegistryLookup instance based on the provided configuration.
 // It reuses the loaded provider.
-func (m *Manager) DeDiRegistry(ctx context.Context, cfg *Config) (definition.RegistryLookup, error) {
+func (m *Manager) DeDiRegistry(ctx context.Context, cache definition.Cache, cfg *Config) (definition.RegistryLookup, error) {
 	rp, err := provider[definition.RegistryLookupProvider](m.plugins, cfg.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
 	}
-	registry, closer, err := rp.New(ctx, cfg.Config)
+	registry, closer, err := rp.New(ctx, cache, cfg.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -1468,12 +1468,11 @@ func TestKeyManagerSuccess(t *testing.T) {
 				closers: []func(){},
 			}
 
-			// Create mock cache and registry lookup.
-			mockCache := &mockCache{}
+			// Create mock registry lookup.
 			mockRegistry := &mockRegistryLookup{}
 
 			// Call KeyManager.
-			keyManager, err := m.KeyManager(context.Background(), mockCache, mockRegistry, tt.cfg)
+			keyManager, err := m.KeyManager(context.Background(), mockRegistry, tt.cfg)
 
 			// Check success case.
 			if err != nil {
@@ -1541,12 +1540,11 @@ func TestKeyManagerFailure(t *testing.T) {
 				}
 			}
 
-			// Create mock cache and registry lookup.
-			mockCache := &mockCache{}
+			// Create mock registry lookup.
 			mockRegistry := &mockRegistryLookup{}
 
 			// Call KeyManager.
-			keyManager, err := m.KeyManager(context.Background(), mockCache, mockRegistry, tt.cfg)
+			keyManager, err := m.KeyManager(context.Background(), mockRegistry, tt.cfg)
 
 			// Check error.
 			if err == nil {

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -248,7 +248,7 @@ type mockKeyManagerProvider struct {
 	errFunc    func() error
 }
 
-func (m *mockKeyManagerProvider) New(ctx context.Context, cache definition.Cache, lookup definition.RegistryLookup, config map[string]string) (definition.KeyManager, func() error, error) {
+func (m *mockKeyManagerProvider) New(ctx context.Context, lookup definition.RegistryLookup, config map[string]string) (definition.KeyManager, func() error, error) {
 	if m.err != nil {
 		return nil, nil, m.err
 	}


### PR DESCRIPTION
## Summary

Fixes #774

Registry lookup results were never written back to cache after a successful network call, causing `LookupNPKeys` to make live HTTP requests to the registry on every inbound request — twice per request (once in `validateSignStep`, once in `validateAckSign`).

## What changed

Moved cache responsibility from the key manager layer down to the registry layer, where the network call actually lives.

- `RegistryClient.Lookup` and `DeDiRegistryClient.Lookup` now accept a `definition.Cache` at construction time, read from it before making an HTTP call, and write results back after a successful response
- `KeyMgr` and `SimpleKeyMgr` no longer own a `Cache` field or contain cache logic — they delegate entirely to the registry
- `RegistryLookupProvider.New` gains a `Cache` parameter; `KeyManagerProvider.New` loses it
- TTL is resolved from the response where available (`ValidUntil` for registry, `ttl` field for DeDi), falling back to a configured `cacheTTL` or a default of 5 minutes
- OTel spans added to both registry clients: `"cache lookup"` (covers `Get` + `Unmarshal`) and `"http lookup"` (covers the HTTP call only)

## Behaviour

- Cache hit → HTTP call skipped entirely
- Cache miss → result fetched and written back; `cache.Set` failure is non-fatal (warns and returns result)
- Corrupt cached value → falls through to HTTP
- `nil` cache → behaves as before, no cache operations

## Test plan

- [ ] `TestRegistryClient_Lookup_Cache` — cache hit, miss, corrupt value, set error, nil cache, TTL variants
- [ ] `TestDeDiRegistryClient_Lookup_Cache` — same coverage for DeDi client
- [ ] All 46 test packages pass
- [ ] Local testing to ensure registry API calls are not being made repeatedly for same NP.