### PR TITLE
fix(schemav2validator): strengthen domain allowlist validation

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -488,7 +488,11 @@ func isAllowedDomain(schemaURL string, allowedDomains []string) bool {
 		return false // unparseable or no host (file://, bare path) → deny
 	}
 	for _, domain := range allowedDomains {
-		if strings.Contains(u.Host, domain) {
+		domain = strings.TrimSpace(domain)
+		if domain == "" {
+			continue
+		}
+		if u.Host == domain || strings.HasSuffix(u.Host, "."+domain) {
 			return true
 		}
 	}

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -481,10 +481,14 @@ func findSchemaByType(ctx context.Context, doc *openapi3.T, typeName string) (*o
 // isAllowedDomain checks if the URL domain is in the whitelist.
 func isAllowedDomain(schemaURL string, allowedDomains []string) bool {
 	if len(allowedDomains) == 0 {
-		return true // No whitelist = all allowed
+		return true // No whitelist = all allowed (local dev mode)
+	}
+	u, err := url.Parse(schemaURL)
+	if err != nil || u.Host == "" {
+		return false // unparseable or no host (file://, bare path) → deny
 	}
 	for _, domain := range allowedDomains {
-		if strings.Contains(schemaURL, domain) {
+		if strings.Contains(u.Host, domain) {
 			return true
 		}
 	}
@@ -516,6 +520,15 @@ func (c *schemaCache) validateReferencedObject(
 	}
 
 	if doc == nil {
+		if len(allowedDomains) > 0 {
+			// Allowlist is configured → restrict to http/https only.
+			// Rejects file://, gopher://, etc. regardless of fragment content.
+			u, err := url.Parse(obj.Context)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				log.Warnf(ctx, "Invalid or disallowed scheme in @context: %s", obj.Context)
+				return fmt.Errorf("invalid scheme in @context: %s", obj.Context)
+			}
+		}
 		if !isAllowedDomain(obj.Context, allowedDomains) {
 			log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
 			return fmt.Errorf("domain not allowed: %s", obj.Context)

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -478,15 +478,9 @@ func findSchemaByType(ctx context.Context, doc *openapi3.T, typeName string) (*o
 	return nil, fmt.Errorf("no schema found for @type: %s", typeName)
 }
 
-// isAllowedDomain checks if the URL domain is in the whitelist.
-func isAllowedDomain(schemaURL string, allowedDomains []string) bool {
-	if len(allowedDomains) == 0 {
-		return true // No whitelist = all allowed (local dev mode)
-	}
-	u, err := url.Parse(schemaURL)
-	if err != nil || u.Host == "" {
-		return false // unparseable or no host (file://, bare path) → deny
-	}
+// isAllowedDomain checks if the host of an already-parsed URL is in the allowlist.
+// Callers must guard with len(allowedDomains) > 0 before calling; an empty list returns false.
+func isAllowedDomain(u *url.URL, allowedDomains []string) bool {
 	for _, domain := range allowedDomains {
 		domain = strings.TrimSpace(domain)
 		if domain == "" {
@@ -525,17 +519,17 @@ func (c *schemaCache) validateReferencedObject(
 
 	if doc == nil {
 		if len(allowedDomains) > 0 {
-			// Allowlist is configured → restrict to http/https only.
-			// Rejects file://, gopher://, etc. regardless of fragment content.
+			// Allowlist is configured → restrict to http/https only and check host.
+			// Parsing once covers both the scheme check and the domain check.
 			u, err := url.Parse(obj.Context)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				log.Warnf(ctx, "Invalid or disallowed scheme in @context: %s", obj.Context)
 				return fmt.Errorf("invalid scheme in @context: %s", obj.Context)
 			}
-		}
-		if !isAllowedDomain(obj.Context, allowedDomains) {
-			log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
-			return fmt.Errorf("domain not allowed: %s", obj.Context)
+			if !isAllowedDomain(u, allowedDomains) {
+				log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
+				return fmt.Errorf("domain not allowed: %s", obj.Context)
+			}
 		}
 		schemaPath := transformContextToSchemaURL(obj.Context)
 		log.Debugf(ctx, "Transformed %s -> %s (localSchema=%v)", obj.Context, schemaPath, localSchema)

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -479,8 +479,11 @@ func findSchemaByType(ctx context.Context, doc *openapi3.T, typeName string) (*o
 }
 
 // isAllowedDomain checks if the host of an already-parsed URL is in the allowlist.
-// Callers must guard with len(allowedDomains) > 0 before calling; an empty list returns false.
+// An empty allowlist returns true (no restriction configured).
 func isAllowedDomain(u *url.URL, allowedDomains []string) bool {
+	if len(allowedDomains) == 0 {
+		return true
+	}
 	for _, domain := range allowedDomains {
 		domain = strings.TrimSpace(domain)
 		if domain == "" {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -1123,6 +1123,48 @@ components:
 	assert.NoError(t, err)
 }
 
+func TestValidateReferencedObject_AllowlistedHttpsURLPasses(t *testing.T) {
+	schemaContent := `openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object
+      additionalProperties: false
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": TestType
+      properties:
+        field1:
+          type: string
+      required:
+        - field1`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(schemaContent))
+	}))
+	defer server.Close()
+
+	// Extract just the host (e.g. "127.0.0.1:PORT") and add it to the allowlist.
+	serverURL, _ := url.Parse(server.URL)
+	allowedDomains := []string{serverURL.Host}
+
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: server.URL + "/schema/context.jsonld",
+		Type:    "TestType",
+		Data:    map[string]interface{}{"field1": "value1"},
+	}
+
+	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
+	assert.NoError(t, err, "valid http URL with allowlisted host should pass")
+}
+
 func TestLoadSchemaFromPath_TTLExpiry_FetchesFresh(t *testing.T) {
 	var serveV2 atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -415,6 +415,24 @@ func TestIsAllowedDomain(t *testing.T) {
 			allowedDomains: []string{"githubusercontent.com"},
 			want:           true,
 		},
+		{
+			name:           "fragment injection bypass attempt",
+			schemaURL:      "file:///dev/zero#raw.githubusercontent.com",
+			allowedDomains: []string{"raw.githubusercontent.com"},
+			want:           false,
+		},
+		{
+			name:           "file scheme with no host is denied when allowlist set",
+			schemaURL:      "file:///etc/passwd",
+			allowedDomains: []string{"raw.githubusercontent.com"},
+			want:           false,
+		},
+		{
+			name:           "file scheme allowed when no allowlist",
+			schemaURL:      "file:///local/schema.yaml",
+			allowedDomains: []string{},
+			want:           true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -675,6 +693,42 @@ func TestValidateReferencedObject_DomainNotAllowed(t *testing.T) {
 	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "domain not allowed")
+}
+
+func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		context string
+	}{
+		{
+			name:    "file scheme with fragment bypass",
+			context: "file:///dev/zero#raw.githubusercontent.com",
+		},
+		{
+			name:    "file scheme local path",
+			context: "file:///etc/passwd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchemaCache(10)
+			ctx := context.Background()
+
+			obj := referencedObject{
+				Path:    "message.test",
+				Context: tt.context,
+				Type:    "Dos",
+				Data:    map[string]interface{}{},
+			}
+
+			allowedDomains := []string{"raw.githubusercontent.com"}
+
+			err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid scheme in @context")
+		})
+	}
 }
 
 func TestValidateExtendedSchemas_NoObjects(t *testing.T) {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -445,6 +445,12 @@ func TestIsAllowedDomain(t *testing.T) {
 			allowedDomains: []string{"raw.githubusercontent.com"},
 			want:           false,
 		},
+		{
+			name:           "empty allowlist allows any domain",
+			schemaURL:      "https://any.domain.example.com/schema.yaml",
+			allowedDomains: []string{},
+			want:           true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -386,18 +386,6 @@ func TestIsAllowedDomain(t *testing.T) {
 		want           bool
 	}{
 		{
-			name:           "empty whitelist - all allowed",
-			schemaURL:      "https://example.com/schema.yaml",
-			allowedDomains: []string{},
-			want:           true,
-		},
-		{
-			name:           "nil whitelist - all allowed",
-			schemaURL:      "https://example.com/schema.yaml",
-			allowedDomains: nil,
-			want:           true,
-		},
-		{
 			name:           "domain in whitelist",
 			schemaURL:      "https://raw.githubusercontent.com/beckn/schema.yaml",
 			allowedDomains: []string{"raw.githubusercontent.com", "schemas.beckn.org"},
@@ -452,22 +440,18 @@ func TestIsAllowedDomain(t *testing.T) {
 			want:           false,
 		},
 		{
-			name:           "file scheme with no host is denied when allowlist set",
+			name:           "no host (file://) does not match even with non-empty allowlist",
 			schemaURL:      "file:///etc/passwd",
 			allowedDomains: []string{"raw.githubusercontent.com"},
 			want:           false,
-		},
-		{
-			name:           "file scheme allowed when no allowlist",
-			schemaURL:      "file:///local/schema.yaml",
-			allowedDomains: []string{},
-			want:           true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isAllowedDomain(tt.schemaURL, tt.allowedDomains)
+			u, err := url.Parse(tt.schemaURL)
+			assert.NoError(t, err)
+			got := isAllowedDomain(u, tt.allowedDomains)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -738,6 +722,11 @@ func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testi
 			name:    "file scheme local path",
 			context: "file:///etc/passwd",
 		},
+		{
+			// host IS in allowlist — scheme check must fire before domain check
+			name:    "gopher scheme with allowlisted host",
+			context: "gopher://raw.githubusercontent.com/schema.yaml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -757,6 +746,62 @@ func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testi
 			err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid scheme in @context")
+		})
+	}
+}
+
+func TestValidateReferencedObject_EmptyAllowlistSkipsDomainCheck(t *testing.T) {
+	schemaContent := `openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object
+      additionalProperties: false
+      x-jsonld:
+        "@context": ./context.jsonld
+        "@type": TestType
+      properties:
+        field1:
+          type: string
+      required:
+        - field1`
+
+	tests := []struct {
+		name          string
+		allowedDomains []string
+	}{
+		{name: "file scheme allowed when no allowlist (nil)", allowedDomains: nil},
+		{name: "file scheme allowed when no allowlist (empty)", allowedDomains: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "test-schema-*.yaml")
+			assert.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+			tmpFile.Write([]byte(schemaContent))
+			tmpFile.Close()
+
+			cache := newSchemaCache(10)
+			ctx := context.Background()
+
+			// Use file:// scheme — would be rejected by scheme check if allowlist were set.
+			obj := referencedObject{
+				Path:    "message.test",
+				Context: "file://" + tmpFile.Name(),
+				Type:    "TestType",
+				Data:    map[string]interface{}{"field1": "value1"},
+			}
+
+			err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, tt.allowedDomains, false)
+			// No domain or scheme error — allowlist check was skipped entirely.
+			if err != nil {
+				assert.NotContains(t, err.Error(), "domain not allowed")
+				assert.NotContains(t, err.Error(), "invalid scheme in @context")
+			}
 		})
 	}
 }

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -410,9 +410,39 @@ func TestIsAllowedDomain(t *testing.T) {
 			want:           false,
 		},
 		{
-			name:           "partial domain match",
+			name:           "exact domain match",
+			schemaURL:      "https://raw.githubusercontent.com/beckn/schema.yaml",
+			allowedDomains: []string{"raw.githubusercontent.com"},
+			want:           true,
+		},
+		{
+			name:           "legitimate subdomain passes",
 			schemaURL:      "https://raw.githubusercontent.com/beckn/schema.yaml",
 			allowedDomains: []string{"githubusercontent.com"},
+			want:           true,
+		},
+		{
+			name:           "prefix bypass blocked - evil-beckn.io vs beckn.io",
+			schemaURL:      "https://evil-beckn.io/schema.yaml",
+			allowedDomains: []string{"beckn.io"},
+			want:           false,
+		},
+		{
+			name:           "suffix bypass blocked - beckn.io.evil.com vs beckn.io",
+			schemaURL:      "https://beckn.io.evil.com/schema.yaml",
+			allowedDomains: []string{"beckn.io"},
+			want:           false,
+		},
+		{
+			name:           "substring bypass blocked - notraw.githubusercontent.com vs raw.githubusercontent.com",
+			schemaURL:      "https://notraw.githubusercontent.com/schema.yaml",
+			allowedDomains: []string{"raw.githubusercontent.com"},
+			want:           false,
+		},
+		{
+			name:           "allowlist entry with leading/trailing spaces",
+			schemaURL:      "https://raw.githubusercontent.com/beckn/schema.yaml",
+			allowedDomains: []string{"  raw.githubusercontent.com  "},
 			want:           true,
 		},
 		{


### PR DESCRIPTION
### Summary

Improves the robustness of domain allowlist enforcement in `isAllowedDomain` and `validateReferencedObject` to ensure only intended domains and URL schemes are accepted when an allowlist is configured.

### Changes

- Refactored `isAllowedDomain` to accept a pre-parsed `*url.URL` and match against `u.Host` using exact and subdomain-anchored matching instead of raw string matching
- Added scheme enforcement (`http`/`https` only) in `validateReferencedObject` when an allowlist is active
- URL is now parsed once and reused for both the scheme check and the domain check, removing a redundant parse
- Both checks are gated on `len(allowedDomains) > 0`, preserving unrestricted behaviour when no allowlist is configured
- Added `strings.TrimSpace` and empty-entry skip on allowlist entries to handle accidental whitespace in config values

### Tests added

- Host-level domain matching: exact match, subdomain, and invalid host cases
- Scheme validation when allowlist is active (including a case where the host would otherwise pass the domain check)
- Allowlist entry whitespace trimming
- Empty/nil allowlist skips all checks (regression)
- Valid `http://` URL with allowlisted host passes end-to-end (regression)