### PR TITLE
fix(signvalidator): split timestamp check into distinct expiry/not-ye…

### DIFF
--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -41,20 +41,8 @@ func (v *validator) Validate(ctx context.Context, body []byte, header string, pu
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	currentTime := time.Now().Unix()
-	if createdTimestamp > currentTime {
-		return model.NewSignValidationErr(fmt.Errorf("signature not yet valid: created=%s, server_time=%s, delta=%ds",
-			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
-			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
-			createdTimestamp-currentTime,
-		))
-	}
-	if currentTime > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("signature expired: expires=%s, server_time=%s, expired_by=%ds",
-			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
-			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
-			currentTime-expiredTimestamp,
-		))
+	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp); err != nil {
+		return err
 	}
 
 	createdTime := time.Unix(createdTimestamp, 0)
@@ -132,20 +120,8 @@ func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHe
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	currentTime := time.Now().Unix()
-	if createdTimestamp > currentTime {
-		return model.NewSignValidationErr(fmt.Errorf("AckSignature not yet valid: created=%s, server_time=%s, delta=%ds",
-			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
-			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
-			createdTimestamp-currentTime,
-		))
-	}
-	if currentTime > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("AckSignature expired: expires=%s, server_time=%s, expired_by=%ds",
-			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
-			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
-			currentTime-expiredTimestamp,
-		))
+	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp); err != nil {
+		return err
 	}
 
 	signingString := hashAck(ackBody, createdTimestamp, expiredTimestamp, outboundAuthSignature)
@@ -159,6 +135,31 @@ func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHe
 		return model.NewSignValidationErr(fmt.Errorf("AckSignature verification failed"))
 	}
 
+	return nil
+}
+
+// checkTimestampWindow validates that the current server time falls within
+// [created, expires]. prefix ("signature" or "AckSignature") is used in the
+// error message to distinguish the two callers in logs.
+func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int64) error {
+	now := time.Now().UTC()
+	current := now.Unix()
+	if createdTimestamp > current {
+		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, delta=%ds",
+			prefix,
+			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
+			now.Format(time.RFC3339),
+			createdTimestamp-current,
+		))
+	}
+	if current > expiredTimestamp {
+		return model.NewSignValidationErr(fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
+			prefix,
+			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
+			now.Format(time.RFC3339),
+			current-expiredTimestamp,
+		))
+	}
 	return nil
 }
 

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -42,8 +42,19 @@ func (v *validator) Validate(ctx context.Context, body []byte, header string, pu
 	}
 
 	currentTime := time.Now().Unix()
-	if createdTimestamp > currentTime || currentTime > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("signature is expired or not yet valid"))
+	if createdTimestamp > currentTime {
+		return model.NewSignValidationErr(fmt.Errorf("signature not yet valid: created=%s, server_time=%s, delta=%ds",
+			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
+			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
+			createdTimestamp-currentTime,
+		))
+	}
+	if currentTime > expiredTimestamp {
+		return model.NewSignValidationErr(fmt.Errorf("signature expired: expires=%s, server_time=%s, expired_by=%ds",
+			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
+			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
+			currentTime-expiredTimestamp,
+		))
 	}
 
 	createdTime := time.Unix(createdTimestamp, 0)
@@ -122,8 +133,19 @@ func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHe
 	}
 
 	currentTime := time.Now().Unix()
-	if createdTimestamp > currentTime || currentTime > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("AckSignature is expired or not yet valid"))
+	if createdTimestamp > currentTime {
+		return model.NewSignValidationErr(fmt.Errorf("AckSignature not yet valid: created=%s, server_time=%s, delta=%ds",
+			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
+			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
+			createdTimestamp-currentTime,
+		))
+	}
+	if currentTime > expiredTimestamp {
+		return model.NewSignValidationErr(fmt.Errorf("AckSignature expired: expires=%s, server_time=%s, expired_by=%ds",
+			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
+			time.Unix(currentTime, 0).UTC().Format(time.RFC3339),
+			currentTime-expiredTimestamp,
+		))
 	}
 
 	signingString := hashAck(ackBody, createdTimestamp, expiredTimestamp, outboundAuthSignature)

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -72,10 +73,11 @@ func TestVerifyFailure(t *testing.T) {
 	_, wrongPublicKeyBase64 := generateTestKeyPair()
 
 	tests := []struct {
-		name   string
-		body   []byte
-		header string
-		pubKey string
+		name        string
+		body        []byte
+		header      string
+		pubKey      string
+		errContains string
 	}{
 		{
 			name:   "Missing Authorization Header",
@@ -119,7 +121,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix()-7200, 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()-3600, 10) +
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix()-7200, time.Now().Unix()-3600) + `"`,
-			pubKey: publicKeyBase64,
+			pubKey:      publicKeyBase64,
+			errContains: "expired_by=",
 		},
 		{
 			name: "Invalid Public Key",
@@ -152,6 +155,9 @@ func TestVerifyFailure(t *testing.T) {
 
 			if err == nil {
 				t.Fatal("Expected an error but got none")
+			}
+			if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("Expected error to contain %q, got: %v", tt.errContains, err)
 			}
 			if close != nil {
 				if err := close(); err != nil {


### PR DESCRIPTION

When signature timestamp validation fails the error now includes the relevant timestamps (RFC3339), the server's current time, and the delta in seconds — making clock-skew vs stale-signature failures immediately distinguishable in logs without manual calculation.

Closes #801
Ref: Networks-for-Humanity/fabric-support#58