### PR TITLE
feat(schemaversionmediator): translation policy model and loader

### DIFF
--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -38,10 +38,11 @@ type TranslationPolicy struct {
 	OnFailure PolicyAction
 }
 
-// defaultPolicy is returned when the operator has not configured a policy.
+// defaultPolicy is the sentinel default when the operator has not configured a policy.
 // translate/reject is the safest default: attempt translation, hard-fail if
 // it cannot be completed, never silently forward an untranslated payload.
-var defaultPolicy = &TranslationPolicy{
+// Declared as a value (not a pointer) to prevent accidental mutation.
+var defaultPolicy = TranslationPolicy{
 	Action:    PolicyActionTranslate,
 	OnFailure: PolicyActionReject,
 }
@@ -50,8 +51,9 @@ var defaultPolicy = &TranslationPolicy{
 // Config keys: "action" and "onFailure". Both are optional — absent keys fall
 // back to the default policy (translate/reject).
 //
-// Valid values for action:   reject | translate | pass_incompatible
-// Valid values for onFailure: reject | pass_incompatible
+// Valid values for action:    reject | translate | pass_incompatible
+// Valid values for onFailure: reject | pass_incompatible (only validated when action=translate;
+// ignored otherwise since no translation is ever attempted)
 // Setting onFailure to "translate" is not permitted — it would cause a loop.
 func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error) {
 	p := &TranslationPolicy{
@@ -68,14 +70,19 @@ func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error)
 		}
 	}
 
-	if raw, ok := config["onFailure"]; ok {
-		switch PolicyAction(raw) {
-		case PolicyActionReject, PolicyActionPassIncompatible:
-			p.OnFailure = PolicyAction(raw)
-		case PolicyActionTranslate:
-			return nil, fmt.Errorf("schemaversionmediator: onFailure cannot be %q — would cause a translation loop", raw)
-		default:
-			return nil, fmt.Errorf("schemaversionmediator: invalid onFailure %q: must be reject or pass_incompatible", raw)
+	// onFailure is only meaningful when action=translate. Validate it only in
+	// that case — silently ignoring it for other actions avoids surprising errors
+	// when operators carry over a stale onFailure key alongside action=reject.
+	if p.Action == PolicyActionTranslate {
+		if raw, ok := config["onFailure"]; ok {
+			switch PolicyAction(raw) {
+			case PolicyActionReject, PolicyActionPassIncompatible:
+				p.OnFailure = PolicyAction(raw)
+			case PolicyActionTranslate:
+				return nil, fmt.Errorf("schemaversionmediator: onFailure cannot be %q — would cause a translation loop", raw)
+			default:
+				return nil, fmt.Errorf("schemaversionmediator: invalid onFailure %q: must be reject or pass_incompatible", raw)
+			}
 		}
 	}
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -11,6 +11,77 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
+// PolicyAction defines what the mediator does when schema incompatibility is
+// detected or when a translation attempt fails.
+type PolicyAction string
+
+const (
+	// PolicyActionReject rejects the request immediately with a NACK.
+	PolicyActionReject PolicyAction = "reject"
+	// PolicyActionTranslate attempts translation for each incompatible schema
+	// object. On failure the OnFailure policy applies.
+	PolicyActionTranslate PolicyAction = "translate"
+	// PolicyActionPassIncompatible forwards the request as-is with a structured
+	// log signal indicating which schema objects were not translated.
+	PolicyActionPassIncompatible PolicyAction = "pass_incompatible"
+)
+
+// TranslationPolicy governs mediator behaviour when schema incompatibilities
+// are found. It is loaded from the plugin config map and applied by Mediate.
+//
+// Action is evaluated immediately after CheckCompatibility returns incompatible
+// objects — before any translation is attempted. OnFailure is only consulted
+// when Action is PolicyActionTranslate and the translation attempt fails (no
+// artifact found, or execution error).
+type TranslationPolicy struct {
+	Action    PolicyAction
+	OnFailure PolicyAction
+}
+
+// defaultPolicy is returned when the operator has not configured a policy.
+// translate/reject is the safest default: attempt translation, hard-fail if
+// it cannot be completed, never silently forward an untranslated payload.
+var defaultPolicy = &TranslationPolicy{
+	Action:    PolicyActionTranslate,
+	OnFailure: PolicyActionReject,
+}
+
+// loadTranslationPolicy reads the mediator policy from the plugin config map.
+// Config keys: "action" and "onFailure". Both are optional — absent keys fall
+// back to the default policy (translate/reject).
+//
+// Valid values for action:   reject | translate | pass_incompatible
+// Valid values for onFailure: reject | pass_incompatible
+// Setting onFailure to "translate" is not permitted — it would cause a loop.
+func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error) {
+	p := &TranslationPolicy{
+		Action:    defaultPolicy.Action,
+		OnFailure: defaultPolicy.OnFailure,
+	}
+
+	if raw, ok := config["action"]; ok {
+		switch PolicyAction(raw) {
+		case PolicyActionReject, PolicyActionTranslate, PolicyActionPassIncompatible:
+			p.Action = PolicyAction(raw)
+		default:
+			return nil, fmt.Errorf("schemaversionmediator: invalid action %q: must be reject, translate, or pass_incompatible", raw)
+		}
+	}
+
+	if raw, ok := config["onFailure"]; ok {
+		switch PolicyAction(raw) {
+		case PolicyActionReject, PolicyActionPassIncompatible:
+			p.OnFailure = PolicyAction(raw)
+		case PolicyActionTranslate:
+			return nil, fmt.Errorf("schemaversionmediator: onFailure cannot be %q — would cause a translation loop", raw)
+		default:
+			return nil, fmt.Errorf("schemaversionmediator: invalid onFailure %q: must be reject or pass_incompatible", raw)
+		}
+	}
+
+	return p, nil
+}
+
 // ErrNoManifest is returned by CheckCompatibility when the node manifest is nil.
 // The caller should log a warning and skip mediation — translation targets cannot
 // be determined without a manifest, but the absence of one is not a hard failure.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -275,6 +275,71 @@ func TestCheckCompatibility_EmptyPayload(t *testing.T) {
 	}
 }
 
+// --- loadTranslationPolicy tests ---
+
+func TestLoadTranslationPolicy_Defaults(t *testing.T) {
+	p, err := loadTranslationPolicy(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Action != PolicyActionTranslate {
+		t.Errorf("expected default action=translate, got %q", p.Action)
+	}
+	if p.OnFailure != PolicyActionReject {
+		t.Errorf("expected default onFailure=reject, got %q", p.OnFailure)
+	}
+}
+
+func TestLoadTranslationPolicy_AllValidActions(t *testing.T) {
+	for _, action := range []PolicyAction{PolicyActionReject, PolicyActionTranslate, PolicyActionPassIncompatible} {
+		p, err := loadTranslationPolicy(map[string]string{"action": string(action)})
+		if err != nil {
+			t.Errorf("action=%q: unexpected error: %v", action, err)
+			continue
+		}
+		if p.Action != action {
+			t.Errorf("action=%q: got %q", action, p.Action)
+		}
+	}
+}
+
+func TestLoadTranslationPolicy_ValidOnFailure(t *testing.T) {
+	for _, onFailure := range []PolicyAction{PolicyActionReject, PolicyActionPassIncompatible} {
+		p, err := loadTranslationPolicy(map[string]string{
+			"action":    "translate",
+			"onFailure": string(onFailure),
+		})
+		if err != nil {
+			t.Errorf("onFailure=%q: unexpected error: %v", onFailure, err)
+			continue
+		}
+		if p.OnFailure != onFailure {
+			t.Errorf("onFailure=%q: got %q", onFailure, p.OnFailure)
+		}
+	}
+}
+
+func TestLoadTranslationPolicy_InvalidAction(t *testing.T) {
+	_, err := loadTranslationPolicy(map[string]string{"action": "unknown"})
+	if err == nil {
+		t.Fatal("expected error for unrecognised action, got nil")
+	}
+}
+
+func TestLoadTranslationPolicy_InvalidOnFailure(t *testing.T) {
+	_, err := loadTranslationPolicy(map[string]string{"onFailure": "unknown"})
+	if err == nil {
+		t.Fatal("expected error for unrecognised onFailure, got nil")
+	}
+}
+
+func TestLoadTranslationPolicy_OnFailureTranslateRejected(t *testing.T) {
+	_, err := loadTranslationPolicy(map[string]string{"onFailure": "translate"})
+	if err == nil {
+		t.Fatal("expected error when onFailure=translate, got nil")
+	}
+}
+
 // --- helpers ---
 
 func assertContainsType(t *testing.T, objects []model.SchemaObject, typ string) {

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -340,6 +340,24 @@ func TestLoadTranslationPolicy_OnFailureTranslateRejected(t *testing.T) {
 	}
 }
 
+func TestLoadTranslationPolicy_OnFailureIgnoredWhenActionNotTranslate(t *testing.T) {
+	// onFailure is meaningless when action=reject or pass_incompatible.
+	// A stale/invalid onFailure key must not produce an error in those cases.
+	for _, action := range []PolicyAction{PolicyActionReject, PolicyActionPassIncompatible} {
+		p, err := loadTranslationPolicy(map[string]string{
+			"action":    string(action),
+			"onFailure": "unknown_value",
+		})
+		if err != nil {
+			t.Errorf("action=%q: expected no error for stale onFailure key, got %v", action, err)
+			continue
+		}
+		if p.Action != action {
+			t.Errorf("action=%q: got %q", action, p.Action)
+		}
+	}
+}
+
 // --- helpers ---
 
 func assertContainsType(t *testing.T, objects []model.SchemaObject, typ string) {


### PR DESCRIPTION
## Summary

Adds `TranslationPolicy` to `schemaversionmediator.go` — governs mediator behaviour when schema incompatibilities are detected or translation fails.

- **`PolicyAction`** — `reject` | `translate` | `pass_incompatible`
- **`TranslationPolicy`** — two fields: `Action` (evaluated immediately after compatibility check) and `OnFailure` (consulted only when `Action=translate` and translation fails)
- **`loadTranslationPolicy`** — reads `action` and `onFailure` keys from the plugin config map; defaults to `translate`/`reject` when absent; rejects `onFailure=translate` to prevent a loop

## Policy semantics

| action | onFailure | Behaviour |
|---|---|---|
| `reject` | — | Any incompatibility → immediate NACK |
| `pass_incompatible` | — | Forward as-is with structured log signal |
| `translate` | `reject` | Attempt translation; hard-fail if it cannot complete **(default)** |
| `translate` | `pass_incompatible` | Attempt translation; forward as-is on failure |

## Notes

- Policy is evaluated **before** any translation attempt — after `CheckCompatibility` returns incompatible objects
- `OnFailure=translate` is explicitly rejected at load time — it would cause a translation loop
- No separate config file — two plain keys in the mediator's plugin config map

Closes part of #770