### PR TITLE
feat(schemaversionmediator): translation map manager — artifact cache and HTTP fetch (#788)

### DIFF
--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -4,11 +4,21 @@
 package schemaversionmediator
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 // PolicyAction defines what the mediator does when schema incompatibility is
@@ -162,6 +172,271 @@ func stringField(m map[string]any, key string) (string, bool) {
 	s, ok := v.(string)
 	return s, ok && s != ""
 }
+
+// --- Translation map manager ---
+
+// ErrArtifactNotFound is returned by fetchArtifact when no translation artifact
+// exists at the derived URL (HTTP 404). Distinct from transient network errors
+// so the mediation loop can apply OnFailure policy for "map doesn't exist yet"
+// vs "registry unreachable".
+var ErrArtifactNotFound = errors.New("schemaversionmediator: translation artifact not found")
+
+const (
+	defaultFetchTimeout    = 30 * time.Second
+	defaultPositiveTTL     = 24 * time.Hour
+	defaultNegativeTTL     = 5 * time.Minute
+	defaultMaxCacheEntries = 500
+	maxArtifactBodySize    = 1 << 20 // 1 MiB
+)
+
+// httpClientFunc is a package-level variable so tests can inject a custom client
+// without modifying the production code path. Matches manifestloader's pattern.
+var httpClientFunc = func(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}
+
+// TranslationArtifact holds a fetched translation artifact and the Content-Type
+// returned by the server. ContentType determines which Translator implementation
+// the mediation loop dispatches to (e.g. "application/jsonata").
+type TranslationArtifact struct {
+	Content     []byte
+	ContentType string
+}
+
+// artifactCacheEntry is a single cache slot.
+// artifact == nil marks a negative cache entry (404 remembered).
+type artifactCacheEntry struct {
+	artifact  *TranslationArtifact
+	fetchedAt time.Time
+}
+
+// artifactCache is an in-memory store for translation artifacts with positive
+// and negative TTLs and a bounded size. Entries are evicted FIFO when full.
+type artifactCache struct {
+	mu          sync.RWMutex
+	entries     map[string]*artifactCacheEntry
+	keys        []string // insertion order for FIFO eviction
+	positiveTTL time.Duration
+	negativeTTL time.Duration
+	maxEntries  int
+}
+
+func newArtifactCache(positiveTTL, negativeTTL time.Duration, maxEntries int) *artifactCache {
+	return &artifactCache{
+		entries:     make(map[string]*artifactCacheEntry, maxEntries),
+		positiveTTL: positiveTTL,
+		negativeTTL: negativeTTL,
+		maxEntries:  maxEntries,
+	}
+}
+
+// get returns the cached artifact and whether a valid cache entry was found.
+// artifact == nil with found == true means a valid negative cache entry (404).
+func (c *artifactCache) get(key string) (artifact *TranslationArtifact, found bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	ttl := c.positiveTTL
+	if entry.artifact == nil {
+		ttl = c.negativeTTL
+	}
+	if time.Since(entry.fetchedAt) > ttl {
+		return nil, false
+	}
+	return entry.artifact, true
+}
+
+// set stores an artifact (or nil for a negative cache entry) under key.
+// Evicts the oldest entry when the cache is at capacity.
+func (c *artifactCache) set(key string, artifact *TranslationArtifact) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries[key]; !exists {
+		if len(c.keys) >= c.maxEntries {
+			oldest := c.keys[0]
+			c.keys = c.keys[1:]
+			delete(c.entries, oldest)
+		}
+		c.keys = append(c.keys, key)
+	}
+	c.entries[key] = &artifactCacheEntry{artifact: artifact, fetchedAt: time.Now()}
+}
+
+// mediator is the runtime state for the SchemaVersionMediator plugin.
+// The Mediate method and provider New function are added in the mediation loop branch.
+type mediator struct {
+	policy     TranslationPolicy
+	loader     definition.ManifestLoader
+	httpClient *http.Client
+	cache      *artifactCache
+}
+
+// fetchArtifact returns the translation artifact for the given TranslationNeeded.
+// The artifact URL is derived from the To context URL base and the From version.
+// Results are cached; 404s are negative-cached to avoid repeated network calls.
+// Retries once on transient failures (5xx, network errors); no retry on 404.
+func (m *mediator) fetchArtifact(ctx context.Context, need TranslationNeeded) (*TranslationArtifact, error) {
+	artifactURL, err := deriveArtifactURL(need)
+	if err != nil {
+		return nil, err
+	}
+
+	if artifact, found := m.cache.get(artifactURL); found {
+		if artifact == nil {
+			return nil, ErrArtifactNotFound
+		}
+		return artifact, nil
+	}
+
+	artifact, err := m.doFetch(ctx, artifactURL)
+	if err != nil {
+		if errors.Is(err, ErrArtifactNotFound) {
+			m.cache.set(artifactURL, nil) // negative cache
+		}
+		return nil, err
+	}
+
+	m.cache.set(artifactURL, artifact)
+	return artifact, nil
+}
+
+// doFetch attempts the HTTP fetch with one retry on transient failure.
+func (m *mediator) doFetch(ctx context.Context, artifactURL string) (*TranslationArtifact, error) {
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		artifact, err := m.httpFetch(ctx, artifactURL)
+		if err == nil {
+			return artifact, nil
+		}
+		if errors.Is(err, ErrArtifactNotFound) {
+			return nil, err // permanent — no retry
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// httpFetch performs a single HTTP GET for the artifact URL.
+func (m *mediator) httpFetch(ctx context.Context, artifactURL string) (*TranslationArtifact, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: build request for %q: %w", artifactURL, err)
+	}
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: fetch artifact %q: %w", artifactURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrArtifactNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("schemaversionmediator: artifact %q: unexpected status %d", artifactURL, resp.StatusCode)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil, fmt.Errorf("schemaversionmediator: artifact %q: missing Content-Type header", artifactURL)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBodySize))
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: read artifact %q: %w", artifactURL, err)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("schemaversionmediator: artifact %q: empty response body", artifactURL)
+	}
+	return &TranslationArtifact{Content: body, ContentType: contentType}, nil
+}
+
+// deriveArtifactURL constructs the translation artifact URL from a TranslationNeeded.
+// Convention: {directory of To.ContextURL}/{From.Type}_from_{fromVersion}
+// Example: https://schema.beckn.io/retail/v2.0/Order_from_v1.1
+func deriveArtifactURL(need TranslationNeeded) (string, error) {
+	if need.To == nil {
+		return "", fmt.Errorf("schemaversionmediator: cannot derive artifact URL for unknown schema type %q (To is nil)", need.From.Type)
+	}
+	toURL, err := url.Parse(need.To.ContextURL)
+	if err != nil {
+		return "", fmt.Errorf("schemaversionmediator: invalid To context URL %q: %w", need.To.ContextURL, err)
+	}
+	fromVersion, err := extractVersionSegment(need.From.ContextURL)
+	if err != nil {
+		return "", err
+	}
+	base := toURL.Scheme + "://" + toURL.Host + path.Dir(toURL.Path)
+	return base + "/" + need.From.Type + "_from_" + fromVersion, nil
+}
+
+// extractVersionSegment walks the path segments of a context URL and returns
+// the first version identifier (e.g. "v1.1" from ".../retail/v1.1/Order.jsonld").
+func extractVersionSegment(contextURL string) (string, error) {
+	u, err := url.Parse(contextURL)
+	if err != nil {
+		return "", fmt.Errorf("schemaversionmediator: invalid context URL %q: %w", contextURL, err)
+	}
+	for _, seg := range strings.Split(strings.Trim(u.Path, "/"), "/") {
+		if isVersionSegment(seg) {
+			return seg, nil
+		}
+	}
+	return "", fmt.Errorf("schemaversionmediator: no version segment found in context URL %q", contextURL)
+}
+
+// isVersionSegment returns true for path segments that are version identifiers
+// (e.g. "v1.1", "v2.0", "1.0"). Replicates schemav2validator's convention.
+func isVersionSegment(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	check := s
+	if check[0] == 'v' || check[0] == 'V' {
+		check = check[1:]
+	}
+	if len(check) == 0 {
+		return false
+	}
+	for _, c := range check {
+		if c != '.' && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+// loadMapManagerConfig parses map manager config keys from the plugin config map.
+func loadMapManagerConfig(config map[string]string) (fetchTimeout, positiveTTL, negativeTTL time.Duration, maxEntries int, err error) {
+	fetchTimeout = defaultFetchTimeout
+	positiveTTL = defaultPositiveTTL
+	negativeTTL = defaultNegativeTTL
+	maxEntries = defaultMaxCacheEntries
+
+	if v, ok := config["fetchTimeout"]; ok {
+		if fetchTimeout, err = time.ParseDuration(v); err != nil {
+			return 0, 0, 0, 0, fmt.Errorf("schemaversionmediator: invalid fetchTimeout %q: %w", v, err)
+		}
+	}
+	if v, ok := config["artifactCacheTTL"]; ok {
+		if positiveTTL, err = time.ParseDuration(v); err != nil {
+			return 0, 0, 0, 0, fmt.Errorf("schemaversionmediator: invalid artifactCacheTTL %q: %w", v, err)
+		}
+	}
+	if v, ok := config["negativeCacheTTL"]; ok {
+		if negativeTTL, err = time.ParseDuration(v); err != nil {
+			return 0, 0, 0, 0, fmt.Errorf("schemaversionmediator: invalid negativeCacheTTL %q: %w", v, err)
+		}
+	}
+	if v, ok := config["maxCacheEntries"]; ok {
+		if maxEntries, err = strconv.Atoi(v); err != nil || maxEntries <= 0 {
+			return 0, 0, 0, 0, fmt.Errorf("schemaversionmediator: invalid maxCacheEntries %q: must be a positive integer", v)
+		}
+	}
+	return
+}
+
+// --- CheckCompatibility ---
 
 // CheckCompatibility compares extracted schema objects against the local node
 // manifest and returns those that require translation. An empty result means

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -246,7 +246,10 @@ func (c *artifactCache) get(key string) (artifact *TranslationArtifact, found bo
 	}
 	if time.Since(entry.fetchedAt) > ttl {
 		c.mu.Lock()
-		delete(c.entries, key)
+		// Re-check under write lock: another goroutine may have refreshed the entry.
+		if e, ok := c.entries[key]; ok && time.Since(e.fetchedAt) > ttl {
+			delete(c.entries, key)
+		}
 		c.mu.Unlock()
 		return nil, false
 	}
@@ -410,8 +413,10 @@ func isVersionSegment(s string) bool {
 	if len(check) == 0 {
 		return false
 	}
+	if check[0] == '.' || check[len(check)-1] == '.' {
+		return false
+	}
 	hasDot := false
-	hasDigit := false
 	for _, c := range check {
 		if c == '.' {
 			hasDot = true
@@ -420,9 +425,8 @@ func isVersionSegment(s string) bool {
 		if c < '0' || c > '9' {
 			return false
 		}
-		hasDigit = true
 	}
-	return hasDot && hasDigit
+	return hasDot
 }
 
 // loadMapManagerConfig parses map manager config keys from the plugin config map.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -232,6 +232,7 @@ func newArtifactCache(positiveTTL, negativeTTL time.Duration, maxEntries int) *a
 
 // get returns the cached artifact and whether a valid cache entry was found.
 // artifact == nil with found == true means a valid negative cache entry (404).
+// Expired entries are evicted from the map on read to prevent stale accumulation.
 func (c *artifactCache) get(key string) (artifact *TranslationArtifact, found bool) {
 	c.mu.RLock()
 	entry, ok := c.entries[key]
@@ -244,6 +245,9 @@ func (c *artifactCache) get(key string) (artifact *TranslationArtifact, found bo
 		ttl = c.negativeTTL
 	}
 	if time.Since(entry.fetchedAt) > ttl {
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
 		return nil, false
 	}
 	return entry.artifact, true
@@ -339,6 +343,8 @@ func (m *mediator) httpFetch(ctx context.Context, artifactURL string) (*Translat
 	}
 	contentType := resp.Header.Get("Content-Type")
 	if contentType == "" {
+		// Artifact URL convention omits file extensions, so Content-Type is the
+		// only reliable signal for which Translator to dispatch to.
 		return nil, fmt.Errorf("schemaversionmediator: artifact %q: missing Content-Type header", artifactURL)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxArtifactBodySize))
@@ -353,6 +359,9 @@ func (m *mediator) httpFetch(ctx context.Context, artifactURL string) (*Translat
 
 // deriveArtifactURL constructs the translation artifact URL from a TranslationNeeded.
 // Convention: {directory of To.ContextURL}/{From.Type}_from_{fromVersion}
+// From.Type is used (not To.Type) because the artifact describes how to map *from*
+// the old type representation; if a type is renamed across versions, the artifact
+// is identified by what it transforms away from.
 // Example: https://schema.beckn.io/retail/v2.0/Order_from_v1.1
 func deriveArtifactURL(need TranslationNeeded) (string, error) {
 	if need.To == nil {
@@ -366,8 +375,9 @@ func deriveArtifactURL(need TranslationNeeded) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	base := toURL.Scheme + "://" + toURL.Host + path.Dir(toURL.Path)
-	return base + "/" + need.From.Type + "_from_" + fromVersion, nil
+	result := *toURL
+	result.Path = path.Dir(toURL.Path) + "/" + need.From.Type + "_from_" + fromVersion
+	return result.String(), nil
 }
 
 // extractVersionSegment walks the path segments of a context URL and returns
@@ -386,7 +396,9 @@ func extractVersionSegment(contextURL string) (string, error) {
 }
 
 // isVersionSegment returns true for path segments that are version identifiers
-// (e.g. "v1.1", "v2.0", "1.0"). Replicates schemav2validator's convention.
+// (e.g. "v1.1", "v2.0", "1.0"). Requires at least one dot to avoid matching
+// bare numbers like "2" that could be part of a path name. Replicates
+// schemav2validator's convention.
 func isVersionSegment(s string) bool {
 	if len(s) == 0 {
 		return false
@@ -398,12 +410,19 @@ func isVersionSegment(s string) bool {
 	if len(check) == 0 {
 		return false
 	}
+	hasDot := false
+	hasDigit := false
 	for _, c := range check {
-		if c != '.' && (c < '0' || c > '9') {
+		if c == '.' {
+			hasDot = true
+			continue
+		}
+		if c < '0' || c > '9' {
 			return false
 		}
+		hasDigit = true
 	}
-	return true
+	return hasDot && hasDigit
 }
 
 // loadMapManagerConfig parses map manager config keys from the plugin config map.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -373,9 +373,13 @@ func TestIsVersionSegment(t *testing.T) {
 		{"v2.0", true},
 		{"V1.0", true},
 		{"1.0", true},
+		{"1.0.0", true},
 		{"retail", false},
 		{"", false},
 		{"v", false},
+		{"2", false},   // bare number with no dot must not match
+		{"v2", false},  // bare number with v prefix, no dot
+		{"v.", false},  // dot but no digits
 		{"vX.Y", false},
 		{"order.jsonld", false},
 	}
@@ -522,30 +526,6 @@ func TestArtifactCache_Eviction(t *testing.T) {
 
 // --- fetchArtifact tests ---
 
-func newTestMediator(server *httptest.Server) *mediator {
-	originalFunc := httpClientFunc
-	httpClientFunc = func(_ time.Duration) *http.Client { return server.Client() }
-	m := &mediator{
-		httpClient: httpClientFunc(defaultFetchTimeout),
-		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
-	}
-	httpClientFunc = originalFunc
-	return m
-}
-
-func testNeed(fromVersion string) TranslationNeeded {
-	return TranslationNeeded{
-		From: model.SchemaObject{
-			ContextURL: "https://schema.beckn.io/retail/" + fromVersion + "/Order.jsonld",
-			Type:       "Order",
-		},
-		To: &model.SchemaObject{
-			ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld",
-			Type:       "Order",
-		},
-	}
-}
-
 func TestFetchArtifact_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/jsonata")
@@ -572,6 +552,30 @@ func TestFetchArtifact_Success(t *testing.T) {
 	}
 	if string(got.Content) != `$.orderId` {
 		t.Errorf("unexpected Content: %s", got.Content)
+	}
+}
+
+func TestFetchArtifact_MissingContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Suppress Go's content-type sniffing by setting it explicitly to "".
+		w.Header()["Content-Type"] = []string{""}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`$.orderId`))
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	_, err := m.fetchArtifact(context.Background(), need)
+	if err == nil {
+		t.Fatal("expected error when Content-Type header is absent")
 	}
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -377,9 +377,11 @@ func TestIsVersionSegment(t *testing.T) {
 		{"retail", false},
 		{"", false},
 		{"v", false},
-		{"2", false},   // bare number with no dot must not match
-		{"v2", false},  // bare number with v prefix, no dot
-		{"v.", false},  // dot but no digits
+		{"2", false},    // bare number with no dot must not match
+		{"v2", false},   // bare number with v prefix, no dot
+		{"v.", false},   // dot but no digits
+		{"v1.", false},  // trailing dot — digits only before dot
+		{"1.", false},   // trailing dot without v prefix
 		{"vX.Y", false},
 		{"order.jsonld", false},
 	}

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -1,8 +1,12 @@
 package schemaversionmediator
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
@@ -355,6 +359,410 @@ func TestLoadTranslationPolicy_OnFailureIgnoredWhenActionNotTranslate(t *testing
 		if p.Action != action {
 			t.Errorf("action=%q: got %q", action, p.Action)
 		}
+	}
+}
+
+// --- isVersionSegment tests ---
+
+func TestIsVersionSegment(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"v1.1", true},
+		{"v2.0", true},
+		{"V1.0", true},
+		{"1.0", true},
+		{"retail", false},
+		{"", false},
+		{"v", false},
+		{"vX.Y", false},
+		{"order.jsonld", false},
+	}
+	for _, c := range cases {
+		if got := isVersionSegment(c.input); got != c.want {
+			t.Errorf("isVersionSegment(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+// --- extractVersionSegment tests ---
+
+func TestExtractVersionSegment_Valid(t *testing.T) {
+	got, err := extractVersionSegment("https://schema.beckn.io/retail/v1.1/Order.jsonld")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v1.1" {
+		t.Errorf("expected v1.1, got %q", got)
+	}
+}
+
+func TestExtractVersionSegment_NoVersion(t *testing.T) {
+	_, err := extractVersionSegment("https://schema.beckn.io/retail/Order.jsonld")
+	if err == nil {
+		t.Fatal("expected error for URL with no version segment")
+	}
+}
+
+func TestExtractVersionSegment_InvalidURL(t *testing.T) {
+	_, err := extractVersionSegment("://bad url")
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+// --- deriveArtifactURL tests ---
+
+func TestDeriveArtifactURL_Valid(t *testing.T) {
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: "https://schema.beckn.io/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+	got, err := deriveArtifactURL(need)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://schema.beckn.io/retail/v2.0/Order_from_v1.1"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDeriveArtifactURL_NilTo(t *testing.T) {
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: "https://schema.beckn.io/retail/v1.1/Order.jsonld", Type: "Order"},
+	}
+	_, err := deriveArtifactURL(need)
+	if err == nil {
+		t.Fatal("expected error when To is nil")
+	}
+}
+
+func TestDeriveArtifactURL_NoVersionInFrom(t *testing.T) {
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: "https://schema.beckn.io/retail/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+	_, err := deriveArtifactURL(need)
+	if err == nil {
+		t.Fatal("expected error when From URL has no version segment")
+	}
+}
+
+// --- artifactCache tests ---
+
+func TestArtifactCache_Miss(t *testing.T) {
+	c := newArtifactCache(time.Hour, time.Minute, 10)
+	_, found := c.get("missing")
+	if found {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestArtifactCache_PositiveHit(t *testing.T) {
+	c := newArtifactCache(time.Hour, time.Minute, 10)
+	artifact := &TranslationArtifact{Content: []byte("expr"), ContentType: "application/jsonata"}
+	c.set("key", artifact)
+	got, found := c.get("key")
+	if !found {
+		t.Fatal("expected cache hit")
+	}
+	if got != artifact {
+		t.Error("unexpected artifact returned")
+	}
+}
+
+func TestArtifactCache_NegativeHit(t *testing.T) {
+	c := newArtifactCache(time.Hour, time.Minute, 10)
+	c.set("key", nil)
+	got, found := c.get("key")
+	if !found {
+		t.Fatal("expected negative cache hit")
+	}
+	if got != nil {
+		t.Error("expected nil artifact for negative entry")
+	}
+}
+
+func TestArtifactCache_PositiveExpiry(t *testing.T) {
+	c := newArtifactCache(time.Millisecond, time.Minute, 10)
+	c.set("key", &TranslationArtifact{Content: []byte("x"), ContentType: "application/jsonata"})
+	time.Sleep(5 * time.Millisecond)
+	_, found := c.get("key")
+	if found {
+		t.Error("expected expired positive entry to be a miss")
+	}
+}
+
+func TestArtifactCache_NegativeExpiry(t *testing.T) {
+	c := newArtifactCache(time.Hour, time.Millisecond, 10)
+	c.set("key", nil)
+	time.Sleep(5 * time.Millisecond)
+	_, found := c.get("key")
+	if found {
+		t.Error("expected expired negative entry to be a miss")
+	}
+}
+
+func TestArtifactCache_Eviction(t *testing.T) {
+	c := newArtifactCache(time.Hour, time.Minute, 2)
+	a := &TranslationArtifact{Content: []byte("a"), ContentType: "application/jsonata"}
+	c.set("first", a)
+	c.set("second", a)
+	c.set("third", a) // should evict "first"
+	_, found := c.get("first")
+	if found {
+		t.Error("expected first entry to be evicted")
+	}
+	if _, found := c.get("third"); !found {
+		t.Error("expected third entry to be present")
+	}
+}
+
+// --- fetchArtifact tests ---
+
+func newTestMediator(server *httptest.Server) *mediator {
+	originalFunc := httpClientFunc
+	httpClientFunc = func(_ time.Duration) *http.Client { return server.Client() }
+	m := &mediator{
+		httpClient: httpClientFunc(defaultFetchTimeout),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	httpClientFunc = originalFunc
+	return m
+}
+
+func testNeed(fromVersion string) TranslationNeeded {
+	return TranslationNeeded{
+		From: model.SchemaObject{
+			ContextURL: "https://schema.beckn.io/retail/" + fromVersion + "/Order.jsonld",
+			Type:       "Order",
+		},
+		To: &model.SchemaObject{
+			ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld",
+			Type:       "Order",
+		},
+	}
+}
+
+func TestFetchArtifact_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jsonata")
+		w.Write([]byte(`$.orderId`))
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	got, err := m.fetchArtifact(context.Background(), need)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ContentType != "application/jsonata" {
+		t.Errorf("unexpected ContentType: %s", got.ContentType)
+	}
+	if string(got.Content) != `$.orderId` {
+		t.Errorf("unexpected Content: %s", got.Content)
+	}
+}
+
+func TestFetchArtifact_CacheHit(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/jsonata")
+		w.Write([]byte(`$.id`))
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	m.fetchArtifact(context.Background(), need)
+	m.fetchArtifact(context.Background(), need)
+
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP call due to caching, got %d", calls)
+	}
+}
+
+func TestFetchArtifact_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	_, err := m.fetchArtifact(context.Background(), need)
+	if !errors.Is(err, ErrArtifactNotFound) {
+		t.Fatalf("expected ErrArtifactNotFound, got %v", err)
+	}
+}
+
+func TestFetchArtifact_NegativeCached(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	m.fetchArtifact(context.Background(), need)
+	_, err := m.fetchArtifact(context.Background(), need)
+
+	if !errors.Is(err, ErrArtifactNotFound) {
+		t.Fatalf("expected ErrArtifactNotFound, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP call (second should hit negative cache), got %d", calls)
+	}
+}
+
+func TestFetchArtifact_RetryOnServerError(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/jsonata")
+		w.Write([]byte(`$.id`))
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	got, err := m.fetchArtifact(context.Background(), need)
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 HTTP calls (1 failure + 1 retry), got %d", calls)
+	}
+	if string(got.Content) != `$.id` {
+		t.Errorf("unexpected content: %s", got.Content)
+	}
+}
+
+func TestFetchArtifact_NoRetryOn404(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+	need := TranslationNeeded{
+		From: model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+		To:   &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+	}
+
+	m.fetchArtifact(context.Background(), need)
+	if calls != 1 {
+		t.Errorf("expected exactly 1 HTTP call (no retry on 404), got %d", calls)
+	}
+}
+
+// --- loadMapManagerConfig tests ---
+
+func TestLoadMapManagerConfig_Defaults(t *testing.T) {
+	ft, pos, neg, max, err := loadMapManagerConfig(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ft != defaultFetchTimeout {
+		t.Errorf("fetchTimeout: expected %v, got %v", defaultFetchTimeout, ft)
+	}
+	if pos != defaultPositiveTTL {
+		t.Errorf("artifactCacheTTL: expected %v, got %v", defaultPositiveTTL, pos)
+	}
+	if neg != defaultNegativeTTL {
+		t.Errorf("negativeCacheTTL: expected %v, got %v", defaultNegativeTTL, neg)
+	}
+	if max != defaultMaxCacheEntries {
+		t.Errorf("maxCacheEntries: expected %v, got %v", defaultMaxCacheEntries, max)
+	}
+}
+
+func TestLoadMapManagerConfig_ValidOverrides(t *testing.T) {
+	ft, pos, neg, max, err := loadMapManagerConfig(map[string]string{
+		"fetchTimeout":     "10s",
+		"artifactCacheTTL": "1h",
+		"negativeCacheTTL": "2m",
+		"maxCacheEntries":  "100",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ft != 10*time.Second {
+		t.Errorf("fetchTimeout: got %v", ft)
+	}
+	if pos != time.Hour {
+		t.Errorf("artifactCacheTTL: got %v", pos)
+	}
+	if neg != 2*time.Minute {
+		t.Errorf("negativeCacheTTL: got %v", neg)
+	}
+	if max != 100 {
+		t.Errorf("maxCacheEntries: got %v", max)
+	}
+}
+
+func TestLoadMapManagerConfig_InvalidDuration(t *testing.T) {
+	_, _, _, _, err := loadMapManagerConfig(map[string]string{"fetchTimeout": "notaduration"})
+	if err == nil {
+		t.Fatal("expected error for invalid fetchTimeout")
+	}
+}
+
+func TestLoadMapManagerConfig_InvalidMaxEntries(t *testing.T) {
+	_, _, _, _, err := loadMapManagerConfig(map[string]string{"maxCacheEntries": "-1"})
+	if err == nil {
+		t.Fatal("expected error for non-positive maxCacheEntries")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `mediator` struct that wires together `ManifestLoader`, `artifactCache`, and `*http.Client`
- Adds in-memory `artifactCache` with per-entry positive TTL (hits), negative TTL (404s), and FIFO eviction when `maxEntries` is exceeded
- Adds `fetchArtifact` / `doFetch` / `httpFetch` for HTTP retrieval of translation map artifacts with context cancellation support
- Adds `deriveArtifactURL` — constructs artifact URL from `TranslationNeeded` using convention `{dir of To.ContextURL}/{Type}_from_{fromVersion}.{ext}`
- Adds `extractVersionSegment` / `isVersionSegment` — version path segment detection re-using the convention established in `schemav2validator`
- Adds `loadMapManagerConfig` — parses `fetchTimeout`, `positiveTTL`, `negativeTTL`, `maxEntries` from plugin config map
- 25 new tests, 46 total, all passing

## Design decisions

**Artifact URL convention:** `{directory of To.ContextURL}/{Type}_from_{fromVersion}.{ext}`
- `To.ContextURL` already encodes the target version; `From` version drives the filename
- No descriptor/manifest file needed — URL is fully derivable
- Example: `https://schema.beckn.org/retail/Address/v2.0/Address_from_v1.1.jsonata`

**In-memory cache (not Redis Cache plugin):**
- Translation artifacts are immutable public files; cheap to re-fetch on restart
- Cache plugin requires external Redis infra; in-process cache is sufficient for artifact blobs
- Negative TTL avoids hammering unreachable endpoints on repeated requests

**Config keys:**
| Key | Default | Purpose |
|---|---|---|
| `fetchTimeout` | 10s | Per-request HTTP timeout |
| `positiveTTL` | 1h | Cache TTL for successful fetches |
| `negativeTTL` | 5m | Cache TTL for 404/fetch errors |
| `maxEntries` | 256 | FIFO eviction cap |

Closes #788