### PR TITLE
fix(signvalidator): cross-check signing subscriber identity against request context

### DIFF
--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -389,7 +389,7 @@ func (v *validateAckSignatureStep) RunOnResponse(ctx *model.StepContext, rctx *m
 		return nil
 	}
 
-	if err := v.signValidator.ValidateAck(ctx, rctx.Body, sigHeader, outboundAuth, publicKey); err != nil {
+	if err := v.signValidator.ValidateAck(ctx, rctx.Body, sigHeader, outboundAuth, publicKey, false); err != nil {
 		log.Warnf(ctx, "validateAckSign: Signature verification failed (status=%d): %v — degraded trust", rctx.StatusCode, err)
 		return nil
 	}

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -481,11 +481,11 @@ type mockSignValidatorWithAck struct {
 	validateAckErr    error
 }
 
-func (m *mockSignValidatorWithAck) Validate(_ *model.StepContext, _ string, _ string) error {
+func (m *mockSignValidatorWithAck) Validate(_ *model.StepContext, _ string, _ string, _ bool) error {
 	return nil
 }
 
-func (m *mockSignValidatorWithAck) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string) error {
+func (m *mockSignValidatorWithAck) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string, _ bool) error {
 	m.validateAckCalled = true
 	return m.validateAckErr
 }

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -481,11 +481,11 @@ type mockSignValidatorWithAck struct {
 	validateAckErr    error
 }
 
-func (m *mockSignValidatorWithAck) Validate(_ context.Context, _ []byte, _ string, _ string) error {
+func (m *mockSignValidatorWithAck) Validate(_ *model.StepContext, _ string, _ string) error {
 	return nil
 }
 
-func (m *mockSignValidatorWithAck) ValidateAck(_ context.Context, _ []byte, _, _, _ string) error {
+func (m *mockSignValidatorWithAck) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string) error {
 	m.validateAckCalled = true
 	return m.validateAckErr
 }

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -213,6 +213,10 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
 	}
+	if err := s.checkSubscriberIdentity(ctx, headerValue); err != nil {
+		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
+		return model.NewSignValidationErr(err)
+	}
 	return nil
 }
 
@@ -270,6 +274,44 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 	}
 	if validErr != nil {
 		return fmt.Errorf("sign validation failed: %w", validErr)
+	}
+	return nil
+}
+
+// checkSubscriberIdentity asserts that the subscriber who signed the request
+// (from the Authorization header's keyId) matches the caller identity declared
+// in the request body context.
+// Uses ContextKeyRemoteID when already resolved by reqpreprocessor; falls back
+// to parsing the body directly via model.ResolveCallerID so the check runs even
+// without reqpreprocessor in the middleware chain.
+func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, authHeader string) error {
+	// Fast path: reqpreprocessor already resolved and cached the caller ID.
+	expected, _ := ctx.Value(model.ContextKeyRemoteID).(string)
+
+	// Slow path: reqpreprocessor not configured; parse body directly.
+	if expected == "" {
+		var payload struct {
+			Context map[string]interface{} `json:"context"`
+		}
+		if err := json.Unmarshal(ctx.Body, &payload); err == nil && payload.Context != nil {
+			expected = model.ResolveCallerID(payload.Context, ctx.Role)
+		}
+	}
+
+	if expected == "" {
+		// Gateway role or body has no matching context field;
+		// a missing field will be caught by schema validation separately.
+		log.Debugf(ctx, "checkSubscriberIdentity: no caller ID available for role %v; skipping check", ctx.Role)
+		return nil
+	}
+
+	parsed, err := parseHeader(authHeader)
+	if err != nil {
+		return fmt.Errorf("failed to parse header for identity check: %w", err)
+	}
+	if parsed.SubscriberID != expected {
+		return fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
+			parsed.SubscriberID, expected)
 	}
 	return nil
 }

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -192,7 +192,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue := ctx.Request.Header.Get(model.AuthHeaderGateway)
 	if len(headerValue) != 0 {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
-		if err := s.validate(ctx, headerValue, ""); err != nil {
+		if err := s.validate(ctx, headerValue, "", false); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
 			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
 		}
@@ -209,7 +209,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(err)
 	}
-	if err := s.validate(ctx, headerValue, reqSig); err != nil {
+	if err := s.validate(ctx, headerValue, reqSig, true); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
 	}
@@ -247,7 +247,7 @@ func (s *validateSignStep) lookupCallbackRequestSig(ctx *model.StepContext, auth
 // When requestSig is non-empty (solicited callback path) it calls ValidateAck
 // to verify against the 4-line signing string (NFH-004 §3.3); otherwise it
 // calls Validate for the standard 3-line signing string.
-func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) error {
+func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string, checkIdentity bool) error {
 	headerVals, err := parseHeader(value)
 	if err != nil {
 		return fmt.Errorf("failed to parse header")
@@ -264,9 +264,9 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 	}
 	var validErr error
 	if requestSig != "" {
-		validErr = s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey)
+		validErr = s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey, checkIdentity)
 	} else {
-		validErr = s.validator.Validate(ctx, value, signingPublicKey)
+		validErr = s.validator.Validate(ctx, value, signingPublicKey, checkIdentity)
 	}
 	if validErr != nil {
 		return fmt.Errorf("sign validation failed: %w", validErr)

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -192,7 +192,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue := ctx.Request.Header.Get(model.AuthHeaderGateway)
 	if len(headerValue) != 0 {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
-		if err := s.validate(ctx, headerValue, ""); err != nil {
+		if _, err := s.validate(ctx, headerValue, ""); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
 			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
 		}
@@ -209,11 +209,12 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(err)
 	}
-	if err := s.validate(ctx, headerValue, reqSig); err != nil {
+	parsedSubscriberHeader, err := s.validate(ctx, headerValue, reqSig)
+	if err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
 	}
-	if err := s.checkSubscriberIdentity(ctx, headerValue); err != nil {
+	if err := s.checkSubscriberIdentity(ctx, parsedSubscriberHeader); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(err)
 	}
@@ -251,20 +252,22 @@ func (s *validateSignStep) lookupCallbackRequestSig(ctx *model.StepContext, auth
 // When requestSig is non-empty (solicited callback path) it calls ValidateAck
 // to verify against the 4-line signing string (NFH-004 §3.3); otherwise it
 // calls Validate for the standard 3-line signing string.
-func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) error {
+// Returns the parsed authHeader on success so callers can reuse it without
+// re-parsing (e.g. checkSubscriberIdentity).
+func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) (*authHeader, error) {
 	headerVals, err := parseHeader(value)
 	if err != nil {
-		return fmt.Errorf("failed to parse header")
+		return nil, fmt.Errorf("failed to parse header")
 	}
 	// Guards the keyId component (sub|key|alg); parseAuthHeader in signvalidator
 	// guards the outer algorithm= attribute — the two cover different header fields.
 	if headerVals.Algorithm != "ed25519" {
-		return fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
+		return nil, fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
 	}
 	log.Debugf(ctx, "Validating Signature for subscriberID: %v", headerVals.SubscriberID)
 	signingPublicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
 	if err != nil {
-		return fmt.Errorf("failed to get validation key: %w", err)
+		return nil, fmt.Errorf("failed to get validation key: %w", err)
 	}
 	var validErr error
 	if requestSig != "" {
@@ -273,18 +276,18 @@ func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig st
 		validErr = s.validator.Validate(ctx, ctx.Body, value, signingPublicKey)
 	}
 	if validErr != nil {
-		return fmt.Errorf("sign validation failed: %w", validErr)
+		return nil, fmt.Errorf("sign validation failed: %w", validErr)
 	}
-	return nil
+	return headerVals, nil
 }
 
 // checkSubscriberIdentity asserts that the subscriber who signed the request
-// (from the Authorization header's keyId) matches the caller identity declared
-// in the request body context.
+// (from the already-parsed Authorization header) matches the caller identity
+// declared in the request body context.
 // Uses ContextKeyRemoteID when already resolved by reqpreprocessor; falls back
 // to parsing the body directly via model.ResolveCallerID so the check runs even
 // without reqpreprocessor in the middleware chain.
-func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, authHeader string) error {
+func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, parsed *authHeader) error {
 	// Fast path: reqpreprocessor already resolved and cached the caller ID.
 	expected, _ := ctx.Value(model.ContextKeyRemoteID).(string)
 
@@ -293,7 +296,9 @@ func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, authH
 		var payload struct {
 			Context map[string]interface{} `json:"context"`
 		}
-		if err := json.Unmarshal(ctx.Body, &payload); err == nil && payload.Context != nil {
+		if err := json.Unmarshal(ctx.Body, &payload); err != nil {
+			log.Debugf(ctx, "checkSubscriberIdentity: failed to parse body: %v; skipping check", err)
+		} else if payload.Context != nil {
 			expected = model.ResolveCallerID(payload.Context, ctx.Role)
 		}
 	}
@@ -305,10 +310,6 @@ func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, authH
 		return nil
 	}
 
-	parsed, err := parseHeader(authHeader)
-	if err != nil {
-		return fmt.Errorf("failed to parse header for identity check: %w", err)
-	}
 	if parsed.SubscriberID != expected {
 		return fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
 			parsed.SubscriberID, expected)

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -192,7 +192,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue := ctx.Request.Header.Get(model.AuthHeaderGateway)
 	if len(headerValue) != 0 {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
-		if _, err := s.validate(ctx, headerValue, ""); err != nil {
+		if err := s.validate(ctx, headerValue, ""); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
 			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
 		}
@@ -209,14 +209,9 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(err)
 	}
-	parsedSubscriberHeader, err := s.validate(ctx, headerValue, reqSig)
-	if err != nil {
+	if err := s.validate(ctx, headerValue, reqSig); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
 		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
-	}
-	if err := s.checkSubscriberIdentity(ctx, parsedSubscriberHeader); err != nil {
-		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
-		return model.NewSignValidationErr(err)
 	}
 	return nil
 }
@@ -252,67 +247,29 @@ func (s *validateSignStep) lookupCallbackRequestSig(ctx *model.StepContext, auth
 // When requestSig is non-empty (solicited callback path) it calls ValidateAck
 // to verify against the 4-line signing string (NFH-004 §3.3); otherwise it
 // calls Validate for the standard 3-line signing string.
-// Returns the parsed authHeader on success so callers can reuse it without
-// re-parsing (e.g. checkSubscriberIdentity).
-func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) (*authHeader, error) {
+func (s *validateSignStep) validate(ctx *model.StepContext, value, requestSig string) error {
 	headerVals, err := parseHeader(value)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse header")
+		return fmt.Errorf("failed to parse header")
 	}
 	// Guards the keyId component (sub|key|alg); parseAuthHeader in signvalidator
 	// guards the outer algorithm= attribute — the two cover different header fields.
 	if headerVals.Algorithm != "ed25519" {
-		return nil, fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
+		return fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", headerVals.Algorithm)
 	}
 	log.Debugf(ctx, "Validating Signature for subscriberID: %v", headerVals.SubscriberID)
 	signingPublicKey, _, err := s.km.LookupNPKeys(ctx, headerVals.SubscriberID, headerVals.UniqueID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get validation key: %w", err)
+		return fmt.Errorf("failed to get validation key: %w", err)
 	}
 	var validErr error
 	if requestSig != "" {
 		validErr = s.validator.ValidateAck(ctx, ctx.Body, value, requestSig, signingPublicKey)
 	} else {
-		validErr = s.validator.Validate(ctx, ctx.Body, value, signingPublicKey)
+		validErr = s.validator.Validate(ctx, value, signingPublicKey)
 	}
 	if validErr != nil {
-		return nil, fmt.Errorf("sign validation failed: %w", validErr)
-	}
-	return headerVals, nil
-}
-
-// checkSubscriberIdentity asserts that the subscriber who signed the request
-// (from the already-parsed Authorization header) matches the caller identity
-// declared in the request body context.
-// Uses ContextKeyRemoteID when already resolved by reqpreprocessor; falls back
-// to parsing the body directly via model.ResolveCallerID so the check runs even
-// without reqpreprocessor in the middleware chain.
-func (s *validateSignStep) checkSubscriberIdentity(ctx *model.StepContext, parsed *authHeader) error {
-	// Fast path: reqpreprocessor already resolved and cached the caller ID.
-	expected, _ := ctx.Value(model.ContextKeyRemoteID).(string)
-
-	// Slow path: reqpreprocessor not configured; parse body directly.
-	if expected == "" {
-		var payload struct {
-			Context map[string]interface{} `json:"context"`
-		}
-		if err := json.Unmarshal(ctx.Body, &payload); err != nil {
-			log.Debugf(ctx, "checkSubscriberIdentity: failed to parse body: %v; skipping check", err)
-		} else if payload.Context != nil {
-			expected = model.ResolveCallerID(payload.Context, ctx.Role)
-		}
-	}
-
-	if expected == "" {
-		// Gateway role or body has no matching context field;
-		// a missing field will be caught by schema validation separately.
-		log.Debugf(ctx, "checkSubscriberIdentity: no caller ID available for role %v; skipping check", ctx.Role)
-		return nil
-	}
-
-	if parsed.SubscriberID != expected {
-		return fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
-			parsed.SubscriberID, expected)
+		return fmt.Errorf("sign validation failed: %w", validErr)
 	}
 	return nil
 }

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -483,6 +483,161 @@ func TestValidate_NonEd25519Algorithm_ReturnsError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// validateHeaders — subscriber identity cross-check
+// ---------------------------------------------------------------------------
+
+// makeValidateStepCtxFull builds a StepContext with an optional role and callerID
+// (simulating what reqpreprocessor writes to model.ContextKeyRemoteID).
+func makeValidateStepCtxFull(role model.Role, callerID, protocolVersion, messageID, subID, authHeader, bodyJSON string) *model.StepContext {
+	goCtx := context.Background()
+	if callerID != "" {
+		goCtx = context.WithValue(goCtx, model.ContextKeyRemoteID, callerID)
+	}
+	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(bodyJSON))
+	req.Header.Set(model.AuthHeaderSubscriber, authHeader)
+	return &model.StepContext{
+		Context:         goCtx,
+		Request:         req,
+		Body:            []byte(bodyJSON),
+		Role:            role,
+		ProtocolVersion: protocolVersion,
+		MessageID:       messageID,
+		SubID:           subID,
+		RespHeader:      http.Header{},
+	}
+}
+
+func TestValidateHeaders_SubIdentity_FromContext_Match_NoError(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("bap.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "bap.example.com", "2.0.0", "msg-si-001", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-001","version":"2.0.0","bap_id":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_FromContext_Mismatch_ReturnsError(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("evil.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "bap.example.com", "2.0.0", "msg-si-002", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-002","version":"2.0.0","bap_id":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err == nil {
+		t.Fatal("expected error when signing subscriber does not match declared context identity")
+	}
+}
+
+func TestValidateHeaders_SubIdentity_FromBody_Match_NoError(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	// No ContextKeyRemoteID in context — check falls back to body.
+	authHeader := providerInitiatedAuthHeader("bap.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-003", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-003","version":"2.0.0","bap_id":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_FromBody_Mismatch_ReturnsError(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("evil.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-004", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-004","version":"2.0.0","bap_id":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err == nil {
+		t.Fatal("expected error when body bap_id does not match signing subscriber")
+	}
+}
+
+func TestValidateHeaders_SubIdentity_V2Alias_SenderId_Match(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("bap.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-005", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-005","version":"2.0.0","senderId":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error with senderId alias: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_V2Alias_ReceiverId_Match(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("bpp.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleBAP, "", "2.0.0", "msg-si-006", "bap.example.com",
+		authHeader,
+		`{"context":{"action":"on_search","messageId":"msg-si-006","version":"2.0.0","receiverId":"bpp.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error with receiverId alias: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_NoCallerIDField_Skips(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	// Body has no bap_id/bapId/senderId — check should be skipped.
+	authHeader := providerInitiatedAuthHeader("anyone.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-007", "bpp.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-007","version":"2.0.0"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error when no caller ID field in body: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_GatewayRole_Skips(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("gateway.example.com")
+	ctx := makeValidateStepCtxFull(model.RoleGateway, "", "2.0.0", "msg-si-008", "gateway.example.com",
+		authHeader,
+		`{"context":{"action":"search","messageId":"msg-si-008","version":"2.0.0","bap_id":"bap.example.com"}}`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() unexpected error for Gateway role: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // signStep — constructor and generateAuthHeader tests
 // ---------------------------------------------------------------------------
 

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -474,7 +474,7 @@ func TestValidate_NonEd25519Algorithm_ReturnsError(t *testing.T) {
 		badAlgHeader,
 		`{"context":{"action":"on_search","messageId":"msg-alg-001","version":"2.0.0"}}`)
 
-	if err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
+	if _, err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
 		t.Fatal("expected error for non-ed25519 algorithm")
 	}
 	if sv.validateCalled || sv.validateAckCalled {
@@ -634,6 +634,22 @@ func TestValidateHeaders_SubIdentity_GatewayRole_Skips(t *testing.T) {
 
 	if err := vStep.validateHeaders(ctx); err != nil {
 		t.Fatalf("validateHeaders() unexpected error for Gateway role: %v", err)
+	}
+}
+
+func TestValidateHeaders_SubIdentity_MalformedBody_Skips(t *testing.T) {
+	sv := &mockSignValidatorBasic{}
+	km := &mockKMBasic{publicKey: "pubKey=="}
+	step, _ := newValidateSignStep(sv, km, nil)
+	vStep := step.(*validateSignStep)
+
+	authHeader := providerInitiatedAuthHeader("anyone.example.com")
+	// Body is not valid JSON — Unmarshal will fail; check must skip, not error.
+	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-malformed", "bpp.example.com",
+		authHeader, `not-valid-json`)
+
+	if err := vStep.validateHeaders(ctx); err != nil {
+		t.Fatalf("validateHeaders() should skip identity check on malformed body, got: %v", err)
 	}
 }
 

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -25,11 +25,11 @@ type mockSignValidatorBasic struct {
 	validateAckCalled bool
 }
 
-func (m *mockSignValidatorBasic) Validate(_ *model.StepContext, _ string, _ string) error {
+func (m *mockSignValidatorBasic) Validate(_ *model.StepContext, _ string, _ string, _ bool) error {
 	m.validateCalled = true
 	return m.validateErr
 }
-func (m *mockSignValidatorBasic) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string) error {
+func (m *mockSignValidatorBasic) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string, _ bool) error {
 	m.validateAckCalled = true
 	return m.validateAckErr
 }
@@ -474,7 +474,7 @@ func TestValidate_NonEd25519Algorithm_ReturnsError(t *testing.T) {
 		badAlgHeader,
 		`{"context":{"action":"on_search","messageId":"msg-alg-001","version":"2.0.0"}}`)
 
-	if err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
+	if err := vStep.validate(ctx, badAlgHeader, "", false); err == nil {
 		t.Fatal("expected error for non-ed25519 algorithm")
 	}
 	if sv.validateCalled || sv.validateAckCalled {

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -25,11 +25,11 @@ type mockSignValidatorBasic struct {
 	validateAckCalled bool
 }
 
-func (m *mockSignValidatorBasic) Validate(_ context.Context, _ []byte, _ string, _ string) error {
+func (m *mockSignValidatorBasic) Validate(_ *model.StepContext, _ string, _ string) error {
 	m.validateCalled = true
 	return m.validateErr
 }
-func (m *mockSignValidatorBasic) ValidateAck(_ context.Context, _ []byte, _, _, _ string) error {
+func (m *mockSignValidatorBasic) ValidateAck(_ *model.StepContext, _ []byte, _, _, _ string) error {
 	m.validateAckCalled = true
 	return m.validateAckErr
 }
@@ -474,182 +474,11 @@ func TestValidate_NonEd25519Algorithm_ReturnsError(t *testing.T) {
 		badAlgHeader,
 		`{"context":{"action":"on_search","messageId":"msg-alg-001","version":"2.0.0"}}`)
 
-	if _, err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
+	if err := vStep.validate(ctx, badAlgHeader, ""); err == nil {
 		t.Fatal("expected error for non-ed25519 algorithm")
 	}
 	if sv.validateCalled || sv.validateAckCalled {
 		t.Error("signature validator must not be called when algorithm is rejected")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// validateHeaders — subscriber identity cross-check
-// ---------------------------------------------------------------------------
-
-// makeValidateStepCtxFull builds a StepContext with an optional role and callerID
-// (simulating what reqpreprocessor writes to model.ContextKeyRemoteID).
-func makeValidateStepCtxFull(role model.Role, callerID, protocolVersion, messageID, subID, authHeader, bodyJSON string) *model.StepContext {
-	goCtx := context.Background()
-	if callerID != "" {
-		goCtx = context.WithValue(goCtx, model.ContextKeyRemoteID, callerID)
-	}
-	req, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(bodyJSON))
-	req.Header.Set(model.AuthHeaderSubscriber, authHeader)
-	return &model.StepContext{
-		Context:         goCtx,
-		Request:         req,
-		Body:            []byte(bodyJSON),
-		Role:            role,
-		ProtocolVersion: protocolVersion,
-		MessageID:       messageID,
-		SubID:           subID,
-		RespHeader:      http.Header{},
-	}
-}
-
-func TestValidateHeaders_SubIdentity_FromContext_Match_NoError(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("bap.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "bap.example.com", "2.0.0", "msg-si-001", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-001","version":"2.0.0","bap_id":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_FromContext_Mismatch_ReturnsError(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("evil.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "bap.example.com", "2.0.0", "msg-si-002", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-002","version":"2.0.0","bap_id":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err == nil {
-		t.Fatal("expected error when signing subscriber does not match declared context identity")
-	}
-}
-
-func TestValidateHeaders_SubIdentity_FromBody_Match_NoError(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	// No ContextKeyRemoteID in context — check falls back to body.
-	authHeader := providerInitiatedAuthHeader("bap.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-003", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-003","version":"2.0.0","bap_id":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_FromBody_Mismatch_ReturnsError(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("evil.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-004", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-004","version":"2.0.0","bap_id":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err == nil {
-		t.Fatal("expected error when body bap_id does not match signing subscriber")
-	}
-}
-
-func TestValidateHeaders_SubIdentity_V2Alias_SenderId_Match(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("bap.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-005", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-005","version":"2.0.0","senderId":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error with senderId alias: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_V2Alias_ReceiverId_Match(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("bpp.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleBAP, "", "2.0.0", "msg-si-006", "bap.example.com",
-		authHeader,
-		`{"context":{"action":"on_search","messageId":"msg-si-006","version":"2.0.0","receiverId":"bpp.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error with receiverId alias: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_NoCallerIDField_Skips(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	// Body has no bap_id/bapId/senderId — check should be skipped.
-	authHeader := providerInitiatedAuthHeader("anyone.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-007", "bpp.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-007","version":"2.0.0"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error when no caller ID field in body: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_GatewayRole_Skips(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("gateway.example.com")
-	ctx := makeValidateStepCtxFull(model.RoleGateway, "", "2.0.0", "msg-si-008", "gateway.example.com",
-		authHeader,
-		`{"context":{"action":"search","messageId":"msg-si-008","version":"2.0.0","bap_id":"bap.example.com"}}`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() unexpected error for Gateway role: %v", err)
-	}
-}
-
-func TestValidateHeaders_SubIdentity_MalformedBody_Skips(t *testing.T) {
-	sv := &mockSignValidatorBasic{}
-	km := &mockKMBasic{publicKey: "pubKey=="}
-	step, _ := newValidateSignStep(sv, km, nil)
-	vStep := step.(*validateSignStep)
-
-	authHeader := providerInitiatedAuthHeader("anyone.example.com")
-	// Body is not valid JSON — Unmarshal will fail; check must skip, not error.
-	ctx := makeValidateStepCtxFull(model.RoleBPP, "", "2.0.0", "msg-si-malformed", "bpp.example.com",
-		authHeader, `not-valid-json`)
-
-	if err := vStep.validateHeaders(ctx); err != nil {
-		t.Fatalf("validateHeaders() should skip identity check on malformed body, got: %v", err)
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -171,6 +171,50 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// ResolveCallerID returns the expected signing subscriber ID from a parsed Beckn context map.
+// For BAP role: returns the BPP's declared ID (bpp_id / bppId / receiverId).
+// For BPP role: returns the BAP's declared ID (bap_id / bapId / senderId).
+// Returns "" when the role is not BAP/BPP or no matching key is found.
+func ResolveCallerID(reqContext map[string]interface{}, role Role) string {
+	var keys []string
+	switch role {
+	case RoleBAP:
+		keys = []string{"bpp_id", "bppId", "receiverId"}
+	case RoleBPP:
+		keys = []string{"bap_id", "bapId", "senderId"}
+	default:
+		return ""
+	}
+	for _, k := range keys {
+		if v, ok := reqContext[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// ResolveSubscriberID returns the node's own subscriber ID from a parsed Beckn context map.
+// For BAP role: returns bap_id / bapId / senderId.
+// For BPP role: returns bpp_id / bppId / receiverId.
+// Returns "" when the role is not BAP/BPP or no matching key is found.
+func ResolveSubscriberID(reqContext map[string]interface{}, role Role) string {
+	var keys []string
+	switch role {
+	case RoleBAP:
+		keys = []string{"bap_id", "bapId", "senderId"}
+	case RoleBPP:
+		keys = []string{"bpp_id", "bppId", "receiverId"}
+	default:
+		return ""
+	}
+	for _, k := range keys {
+		if v, ok := reqContext[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // Route represents a network route for message processing.
 type Route struct {
 	TargetType  string   // "url" or "publisher"

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -171,9 +171,10 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// ResolveCallerID returns the expected signing subscriber ID from a parsed Beckn context map.
-// For BAP role: returns the BPP's declared ID (bpp_id / bppId / receiverId).
-// For BPP role: returns the BAP's declared ID (bap_id / bapId / senderId).
+// ResolveCallerID returns the ID of the other party in a Beckn exchange — i.e. who
+// sent the inbound message — from a parsed Beckn context map.
+// For BPP role: the caller is the BAP (bap_id / bapId / senderId).
+// For BAP role: the caller is the BPP (bpp_id / bppId / receiverId).
 // Returns "" when the role is not BAP/BPP or no matching key is found.
 func ResolveCallerID(reqContext map[string]interface{}, role Role) string {
 	var keys []string

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,0 +1,171 @@
+package model
+
+import "testing"
+
+func TestResolveCallerID(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     map[string]interface{}
+		role    Role
+		want    string
+	}{
+		{
+			name: "BAP role returns bpp_id",
+			ctx:  map[string]interface{}{"bpp_id": "bpp.example.com"},
+			role: RoleBAP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "BAP role falls back to bppId",
+			ctx:  map[string]interface{}{"bppId": "bpp.example.com"},
+			role: RoleBAP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "BAP role falls back to receiverId",
+			ctx:  map[string]interface{}{"receiverId": "bpp.example.com"},
+			role: RoleBAP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "BAP role: bpp_id takes precedence over bppId and receiverId",
+			ctx:  map[string]interface{}{"bpp_id": "primary.com", "bppId": "camel.com", "receiverId": "v2.com"},
+			role: RoleBAP,
+			want: "primary.com",
+		},
+		{
+			name: "BPP role returns bap_id",
+			ctx:  map[string]interface{}{"bap_id": "bap.example.com"},
+			role: RoleBPP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BPP role falls back to bapId",
+			ctx:  map[string]interface{}{"bapId": "bap.example.com"},
+			role: RoleBPP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BPP role falls back to senderId",
+			ctx:  map[string]interface{}{"senderId": "bap.example.com"},
+			role: RoleBPP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BPP role: bap_id takes precedence over bapId and senderId",
+			ctx:  map[string]interface{}{"bap_id": "primary.com", "bapId": "camel.com", "senderId": "v2.com"},
+			role: RoleBPP,
+			want: "primary.com",
+		},
+		{
+			name: "Gateway role returns empty",
+			ctx:  map[string]interface{}{"bap_id": "bap.example.com", "bpp_id": "bpp.example.com"},
+			role: RoleGateway,
+			want: "",
+		},
+		{
+			name: "Empty context map returns empty",
+			ctx:  map[string]interface{}{},
+			role: RoleBPP,
+			want: "",
+		},
+		{
+			name: "No matching key returns empty",
+			ctx:  map[string]interface{}{"some_other_field": "value"},
+			role: RoleBPP,
+			want: "",
+		},
+		{
+			name: "Non-string value is skipped",
+			ctx:  map[string]interface{}{"bap_id": 12345},
+			role: RoleBPP,
+			want: "",
+		},
+		{
+			name: "Empty string value is skipped",
+			ctx:  map[string]interface{}{"bap_id": "", "bapId": "bap.example.com"},
+			role: RoleBPP,
+			want: "bap.example.com",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveCallerID(tc.ctx, tc.role)
+			if got != tc.want {
+				t.Errorf("ResolveCallerID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSubscriberID(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  map[string]interface{}
+		role Role
+		want string
+	}{
+		{
+			name: "BAP role returns bap_id",
+			ctx:  map[string]interface{}{"bap_id": "bap.example.com"},
+			role: RoleBAP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BAP role falls back to bapId",
+			ctx:  map[string]interface{}{"bapId": "bap.example.com"},
+			role: RoleBAP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BAP role falls back to senderId",
+			ctx:  map[string]interface{}{"senderId": "bap.example.com"},
+			role: RoleBAP,
+			want: "bap.example.com",
+		},
+		{
+			name: "BAP role: bap_id takes precedence",
+			ctx:  map[string]interface{}{"bap_id": "primary.com", "bapId": "camel.com", "senderId": "v2.com"},
+			role: RoleBAP,
+			want: "primary.com",
+		},
+		{
+			name: "BPP role returns bpp_id",
+			ctx:  map[string]interface{}{"bpp_id": "bpp.example.com"},
+			role: RoleBPP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "BPP role falls back to bppId",
+			ctx:  map[string]interface{}{"bppId": "bpp.example.com"},
+			role: RoleBPP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "BPP role falls back to receiverId",
+			ctx:  map[string]interface{}{"receiverId": "bpp.example.com"},
+			role: RoleBPP,
+			want: "bpp.example.com",
+		},
+		{
+			name: "Gateway role returns empty",
+			ctx:  map[string]interface{}{"bap_id": "bap.example.com", "bpp_id": "bpp.example.com"},
+			role: RoleGateway,
+			want: "",
+		},
+		{
+			name: "Empty context map returns empty",
+			ctx:  map[string]interface{}{},
+			role: RoleBAP,
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveSubscriberID(tc.ctx, tc.role)
+			if got != tc.want {
+				t.Errorf("ResolveSubscriberID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/definition/signvalidator.go
+++ b/pkg/plugin/definition/signvalidator.go
@@ -1,23 +1,25 @@
 package definition
 
-import "context"
+import (
+	"context"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+)
 
 // SignValidator defines the method for verifying signatures.
 type SignValidator interface {
-	// Validate checks the validity of the signature for the given body.
-	// Used for inbound request Authorization header verification.
-	Validate(ctx context.Context, body []byte, header string, publicKeyBase64 string) error
+	// Validate verifies the 3-line signing string for inbound requests.
+	// The request body is available as ctx.Body.
+	Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error
 
-	// ValidateAck verifies a Beckn v2.0.0 AckSignature per NFH-004 §3.4.
-	// The four-line signing string is:
+	// ValidateAck verifies the 4-line signing string per NFH-004 §3.4:
 	//   (created): <ts>
 	//   (expires): <ts>
-	//   digest: BLAKE-512=<base64(blake2b512(ackBody))>
-	//   request-signature: <outboundAuthSignature>
-	// outboundAuthSignature is the raw Base64 signature value from the original
-	// outbound Authorization header's signature="..." attribute. If empty the
-	// fourth line is omitted (matches the ackSigner signing-string construction).
-	ValidateAck(ctx context.Context, ackBody []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error
+	//   digest: BLAKE-512=<base64(blake2b512(body))>
+	//   request-signature: <outboundAuthSignature>  (omitted when empty)
+	// body is passed explicitly because the two call sites hash different bodies:
+	// the on_search request body (step.go) vs the ACK response body (responsestep.go).
+	ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error
 }
 
 // SignValidatorProvider initializes a new Verifier instance with the given config.

--- a/pkg/plugin/definition/signvalidator.go
+++ b/pkg/plugin/definition/signvalidator.go
@@ -10,7 +10,10 @@ import (
 type SignValidator interface {
 	// Validate verifies the 3-line signing string for inbound requests.
 	// The request body is available as ctx.Body.
-	Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error
+	// checkIdentity controls whether the signer's subscriber ID (from keyId) is
+	// matched against the caller identity declared in the request body context.
+	// Pass true for subscriber Authorization headers, false for gateway headers.
+	Validate(ctx *model.StepContext, header string, publicKeyBase64 string, checkIdentity bool) error
 
 	// ValidateAck verifies a Beckn v2.0.0 AckSignature per NFH-004 §3.4.
 	// The four-line signing string is:
@@ -23,7 +26,8 @@ type SignValidator interface {
 	// fourth line is omitted (matches the ackSigner signing-string construction).
 	// body is passed explicitly because different call sites hash different bodies:
 	// solicited callback bodies differ from synchronous ACK response bodies.
-	ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error
+	// checkIdentity: true for solicited callbacks (step.go), false for ACK responses (responsestep.go).
+	ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string, checkIdentity bool) error
 }
 
 // SignValidatorProvider initializes a new Verifier instance with the given config.

--- a/pkg/plugin/definition/signvalidator.go
+++ b/pkg/plugin/definition/signvalidator.go
@@ -12,13 +12,17 @@ type SignValidator interface {
 	// The request body is available as ctx.Body.
 	Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error
 
-	// ValidateAck verifies the 4-line signing string per NFH-004 §3.4:
+	// ValidateAck verifies a Beckn v2.0.0 AckSignature per NFH-004 §3.4.
+	// The four-line signing string is:
 	//   (created): <ts>
 	//   (expires): <ts>
 	//   digest: BLAKE-512=<base64(blake2b512(body))>
-	//   request-signature: <outboundAuthSignature>  (omitted when empty)
-	// body is passed explicitly because the two call sites hash different bodies:
-	// the on_search request body (step.go) vs the ACK response body (responsestep.go).
+	//   request-signature: <outboundAuthSignature>
+	// outboundAuthSignature is the raw Base64 signature value from the original
+	// outbound Authorization header's signature="..." attribute. If empty the
+	// fourth line is omitted (matches the ackSigner signing-string construction).
+	// body is passed explicitly because different call sites hash different bodies:
+	// solicited callback bodies differ from synchronous ACK response bodies.
 	ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error
 }
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -23,18 +23,6 @@ type Config struct {
 
 const contextKey = "context"
 
-// firstNonNil returns the first non-nil value from the provided list.
-// Used to resolve context fields that may appear under different key names
-// (e.g. bap_id, bapId, or senderId) depending on the beckn spec version in use.
-func firstNonNil(values ...any) any {
-	for _, v := range values {
-		if v != nil {
-			return v
-		}
-	}
-	return nil
-}
-
 // snakeToCamel converts a snake_case string to camelCase.
 // For example: "transaction_id" -> "transactionId".
 // Returns the input unchanged if it contains no underscores.
@@ -95,26 +83,12 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				return
 			}
 
-			// Resolve subscriber ID — tries legacy snake_case, then camelCase, then
-			// the new Beckn spec v2 names (senderId / receiverId).
-			var subID any
-			switch cfg.Role {
-			case "bap":
-				subID = firstNonNil(reqContext["bap_id"], reqContext["bapId"], reqContext["senderId"])
-			case "bpp":
-				subID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"], reqContext["receiverId"])
-			}
+			// Resolve subscriber ID and caller ID using shared utilities that handle
+			// the triple-key alias chain (legacy snake_case, camelCase, spec v2 names).
+			subID := model.ResolveSubscriberID(reqContext, model.Role(cfg.Role))
+			callerID := model.ResolveCallerID(reqContext, model.Role(cfg.Role))
 
-			// Resolve caller ID — same triple-key pattern, opposite role.
-			var callerID any
-			switch cfg.Role {
-			case "bap":
-				callerID = firstNonNil(reqContext["bpp_id"], reqContext["bppId"], reqContext["receiverId"])
-			case "bpp":
-				callerID = firstNonNil(reqContext["bap_id"], reqContext["bapId"], reqContext["senderId"])
-			}
-
-			if subID != nil {
+			if subID != "" {
 				log.Debugf(ctx, "adding subscriberId to request:%s, %v", model.ContextKeySubscriberID, subID)
 				ctx = context.WithValue(ctx, model.ContextKeySubscriberID, subID)
 			}
@@ -124,7 +98,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				ctx = context.WithValue(ctx, model.ContextKeyParentID, cfg.ParentID)
 			}
 
-			if callerID != nil {
+			if callerID != "" {
 				log.Debugf(ctx, "adding callerID to request:%s, %v", model.ContextKeyRemoteID, callerID)
 				ctx = context.WithValue(ctx, model.ContextKeyRemoteID, callerID)
 			}

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -192,8 +192,8 @@ func checkSubscriberIdentity(ctx *model.StepContext, body []byte, header string)
 
 	signerID := extractSubscriberIDFromHeader(header)
 	if signerID != expected {
-		return fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
-			signerID, expected)
+		return model.NewSignValidationErr(fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
+			signerID, expected))
 	}
 	return nil
 }

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -32,7 +32,7 @@ func New(ctx context.Context, config *Config) (*validator, func() error, error) 
 }
 
 // Validate verifies the 3-line signing string for inbound requests.
-func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error {
+func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(header)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing header: %w", err))
@@ -61,7 +61,7 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 		return model.NewSignValidationErr(fmt.Errorf("signature verification failed"))
 	}
 
-	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == header {
+	if checkIdentity {
 		if err := checkSubscriberIdentity(ctx, ctx.Body, subscriberID); err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func parseAuthHeader(header string) (int64, int64, string, string, error) {
 // ValidateAck verifies the 4-line signing string per NFH-004 §3.4.
 // body is passed explicitly because the two call sites hash different bodies:
 // the on_search request body (step.go) vs the ACK response body (responsestep.go).
-func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error {
+func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(signatureHeader)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing Signature header: %w", err))
@@ -146,7 +146,7 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 		return model.NewSignValidationErr(fmt.Errorf("AckSignature verification failed"))
 	}
 
-	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == signatureHeader {
+	if checkIdentity {
 		if err := checkSubscriberIdentity(ctx, body, subscriberID); err != nil {
 			return err
 		}

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -33,7 +33,7 @@ func New(ctx context.Context, config *Config) (*validator, func() error, error) 
 
 // Validate verifies the 3-line signing string for inbound requests.
 func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error {
-	createdTimestamp, expiredTimestamp, signature, err := parseAuthHeader(header)
+	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(header)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing header: %w", err))
 	}
@@ -62,7 +62,7 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 	}
 
 	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == header {
-		if err := checkSubscriberIdentity(ctx, ctx.Body, header); err != nil {
+		if err := checkSubscriberIdentity(ctx, ctx.Body, subscriberID); err != nil {
 			return err
 		}
 	}
@@ -70,7 +70,8 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 }
 
 // parseAuthHeader extracts signature values from the Authorization header.
-func parseAuthHeader(header string) (int64, int64, string, error) {
+// subscriberID is the first |-delimited component of keyId="..." (empty if keyId absent).
+func parseAuthHeader(header string) (int64, int64, string, string, error) {
 	header = strings.TrimPrefix(header, "Signature ")
 
 	parts := strings.Split(header, ",")
@@ -86,34 +87,41 @@ func parseAuthHeader(header string) (int64, int64, string, error) {
 	}
 
 	if signatureMap["algorithm"] != "ed25519" {
-		return 0, 0, "", model.NewSignValidationErr(fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
+		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
 	}
 
 	createdTimestamp, err := strconv.ParseInt(signatureMap["created"], 10, 64)
 	if err != nil {
 		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", fmt.Errorf("invalid created timestamp: %w", err)
+		return 0, 0, "", "", fmt.Errorf("invalid created timestamp: %w", err)
 	}
 
 	expiredTimestamp, err := strconv.ParseInt(signatureMap["expires"], 10, 64)
 	if err != nil {
-		return 0, 0, "", model.NewSignValidationErr(fmt.Errorf("invalid expires timestamp: %w", err))
+		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("invalid expires timestamp: %w", err))
 	}
 
 	signature := signatureMap["signature"]
 	if signature == "" {
 		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", model.NewSignValidationErr(fmt.Errorf("signature missing in header"))
+		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("signature missing in header"))
 	}
 
-	return createdTimestamp, expiredTimestamp, signature, nil
+	var subscriberID string
+	if keyID := signatureMap["keyId"]; keyID != "" {
+		if p := strings.SplitN(keyID, "|", 2); len(p) >= 2 {
+			subscriberID = strings.TrimSpace(p[0])
+		}
+	}
+
+	return createdTimestamp, expiredTimestamp, signature, subscriberID, nil
 }
 
 // ValidateAck verifies the 4-line signing string per NFH-004 §3.4.
 // body is passed explicitly because the two call sites hash different bodies:
 // the on_search request body (step.go) vs the ACK response body (responsestep.go).
 func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error {
-	createdTimestamp, expiredTimestamp, signature, err := parseAuthHeader(signatureHeader)
+	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(signatureHeader)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing Signature header: %w", err))
 	}
@@ -139,39 +147,18 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 	}
 
 	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == signatureHeader {
-		if err := checkSubscriberIdentity(ctx, body, signatureHeader); err != nil {
+		if err := checkSubscriberIdentity(ctx, body, subscriberID); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// extractSubscriberIDFromHeader extracts the subscriber ID (first |-delimited
-// component of keyId) from a Beckn Authorization header. Returns "" if keyId
-// is absent or malformed.
-func extractSubscriberIDFromHeader(header string) string {
-	const prefix = `keyId="`
-	idx := strings.Index(header, prefix)
-	if idx == -1 {
-		return ""
-	}
-	idx += len(prefix)
-	end := strings.Index(header[idx:], `"`)
-	if end == -1 {
-		return ""
-	}
-	parts := strings.SplitN(strings.TrimSpace(header[idx:idx+end]), "|", 2)
-	if len(parts) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(parts[0])
-}
-
 // checkSubscriberIdentity asserts that the subscriber who signed the request
-// (from keyId in the Authorization header) matches the caller identity declared
+// (signerID from keyId in the parsed header) matches the caller identity declared
 // in the request body context. body is the body that was actually validated so
 // callers with different bodies (Validate vs ValidateAck) each pass the right one.
-func checkSubscriberIdentity(ctx *model.StepContext, body []byte, header string) error {
+func checkSubscriberIdentity(ctx *model.StepContext, body []byte, signerID string) error {
 	expected, _ := ctx.Value(model.ContextKeyRemoteID).(string)
 
 	if expected == "" {
@@ -190,7 +177,6 @@ func checkSubscriberIdentity(ctx *model.StepContext, body []byte, header string)
 		return nil
 	}
 
-	signerID := extractSubscriberIDFromHeader(header)
 	if signerID != expected {
 		return model.NewSignValidationErr(fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
 			signerID, expected))

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"golang.org/x/crypto/blake2b"
 )
@@ -29,8 +31,8 @@ func New(ctx context.Context, config *Config) (*validator, func() error, error) 
 	return v, nil, nil
 }
 
-// Verify checks the signature for the given payload and public key.
-func (v *validator) Validate(ctx context.Context, body []byte, header string, publicKeyBase64 string) error {
+// Validate verifies the 3-line signing string for inbound requests.
+func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string) error {
 	createdTimestamp, expiredTimestamp, signature, err := parseAuthHeader(header)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing header: %w", err))
@@ -48,7 +50,7 @@ func (v *validator) Validate(ctx context.Context, body []byte, header string, pu
 	createdTime := time.Unix(createdTimestamp, 0)
 	expiredTime := time.Unix(expiredTimestamp, 0)
 
-	signingString := hash(body, createdTime.Unix(), expiredTime.Unix())
+	signingString := hash(ctx.Body, createdTime.Unix(), expiredTime.Unix())
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
@@ -59,6 +61,11 @@ func (v *validator) Validate(ctx context.Context, body []byte, header string, pu
 		return model.NewSignValidationErr(fmt.Errorf("signature verification failed"))
 	}
 
+	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == header {
+		if err := checkSubscriberIdentity(ctx, ctx.Body, header); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -102,14 +109,10 @@ func parseAuthHeader(header string) (int64, int64, string, error) {
 	return createdTimestamp, expiredTimestamp, signature, nil
 }
 
-// ValidateAck verifies a Beckn v2.0.0 AckSignature per NFH-004 §3.4.
-// The signing string is identical to regular request signing with one addition:
-// if outboundAuthSignature is non-empty, a fourth line is appended:
-//
-//	request-signature: <outboundAuthSignature>
-//
-// This mirrors exactly what ackSigner builds in SignAck.
-func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error {
+// ValidateAck verifies the 4-line signing string per NFH-004 §3.4.
+// body is passed explicitly because the two call sites hash different bodies:
+// the on_search request body (step.go) vs the ACK response body (responsestep.go).
+func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string) error {
 	createdTimestamp, expiredTimestamp, signature, err := parseAuthHeader(signatureHeader)
 	if err != nil {
 		return model.NewSignValidationErr(fmt.Errorf("error parsing Signature header: %w", err))
@@ -124,7 +127,7 @@ func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHe
 		return err
 	}
 
-	signingString := hashAck(ackBody, createdTimestamp, expiredTimestamp, outboundAuthSignature)
+	signingString := hashAck(body, createdTimestamp, expiredTimestamp, outboundAuthSignature)
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
@@ -135,6 +138,63 @@ func (v *validator) ValidateAck(ctx context.Context, ackBody []byte, signatureHe
 		return model.NewSignValidationErr(fmt.Errorf("AckSignature verification failed"))
 	}
 
+	if ctx.Request.Header.Get(model.AuthHeaderSubscriber) == signatureHeader {
+		if err := checkSubscriberIdentity(ctx, body, signatureHeader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractSubscriberIDFromHeader extracts the subscriber ID (first |-delimited
+// component of keyId) from a Beckn Authorization header. Returns "" if keyId
+// is absent or malformed.
+func extractSubscriberIDFromHeader(header string) string {
+	const prefix = `keyId="`
+	idx := strings.Index(header, prefix)
+	if idx == -1 {
+		return ""
+	}
+	idx += len(prefix)
+	end := strings.Index(header[idx:], `"`)
+	if end == -1 {
+		return ""
+	}
+	parts := strings.SplitN(strings.TrimSpace(header[idx:idx+end]), "|", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
+// checkSubscriberIdentity asserts that the subscriber who signed the request
+// (from keyId in the Authorization header) matches the caller identity declared
+// in the request body context. body is the body that was actually validated so
+// callers with different bodies (Validate vs ValidateAck) each pass the right one.
+func checkSubscriberIdentity(ctx *model.StepContext, body []byte, header string) error {
+	expected, _ := ctx.Value(model.ContextKeyRemoteID).(string)
+
+	if expected == "" {
+		var payload struct {
+			Context map[string]interface{} `json:"context"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Debugf(ctx, "checkSubscriberIdentity: failed to parse body: %v; skipping check", err)
+		} else if payload.Context != nil {
+			expected = model.ResolveCallerID(payload.Context, ctx.Role)
+		}
+	}
+
+	if expected == "" {
+		log.Debugf(ctx, "checkSubscriberIdentity: no caller ID available for role %v; skipping check", ctx.Role)
+		return nil
+	}
+
+	signerID := extractSubscriberIDFromHeader(header)
+	if signerID != expected {
+		return fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
+			signerID, expected)
+	}
 	return nil
 }
 

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -349,3 +349,96 @@ func TestValidate_SubIdentity_MalformedBody_Skips(t *testing.T) {
 		t.Fatalf("expected identity check to be skipped on malformed body, got: %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Subscriber identity check — ValidateAck
+// ---------------------------------------------------------------------------
+
+// signAckTestData signs a body using the 4-line ACK signing string (NFH-004 §3.4).
+func signAckTestData(privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
+	privateKeyBytes, _ := base64.StdEncoding.DecodeString(privateKeyBase64)
+	signingString := hashAck(body, createdAt, expiresAt, outboundAuth)
+	signature := ed25519.Sign(ed25519.PrivateKey(privateKeyBytes), []byte(signingString))
+	return base64.StdEncoding.EncodeToString(signature)
+}
+
+// signedAckHeaderWithKeyID builds a full ACK Signature header including keyId.
+func signedAckHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
+	sig := signAckTestData(privateKeyBase64, body, outboundAuth, createdAt, expiresAt)
+	return fmt.Sprintf(
+		`Signature keyId="%s|key-1|ed25519",algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		subscriberID, createdAt, expiresAt, sig,
+	)
+}
+
+func TestValidateAck_SubIdentity_FromContext_Match(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
+	outboundAuth := "outbound-sig-value=="
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedAckHeaderWithKeyID("bap.example.com", privateKey, body, outboundAuth, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateAck_SubIdentity_FromContext_Mismatch(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
+	outboundAuth := "outbound-sig-value=="
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err == nil {
+		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+}
+
+func TestValidateAck_SubIdentity_FromBody_Match(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
+	outboundAuth := "outbound-sig-value=="
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedAckHeaderWithKeyID("bap.example.com", privateKey, body, outboundAuth, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateAck_SubIdentity_FromBody_Mismatch(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
+	outboundAuth := "outbound-sig-value=="
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err == nil {
+		t.Fatal("expected error: signer evil.com does not match body bap_id bap.example.com")
+	}
+}
+
+func TestValidateAck_SubIdentity_GateClosedForAckResponse(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
+	outboundAuth := "outbound-sig-value=="
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	// Signer is mismatched — but gate must stay closed, so identity check must be skipped.
+	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	// Authorization header is NOT set to match the ACK Signature header — gate evaluates false.
+	ctx := makeCtx(body, model.RoleBPP, "")
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
+		t.Fatalf("expected identity check to be skipped when gate is closed, got: %v", err)
+	}
+}

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -4,11 +4,19 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
 // generateTestKeyPair generates a new ED25519 key pair for testing.
 func generateTestKeyPair() (string, string) {
@@ -26,6 +34,54 @@ func signTestData(privateKeyBase64 string, body []byte, createdAt, expiresAt int
 
 	return base64.StdEncoding.EncodeToString(signature)
 }
+
+// signedHeaderWithKeyID builds a full Authorization header including keyId so that
+// extractSubscriberIDFromHeader can extract the subscriber ID for identity checks.
+func signedHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, createdAt, expiresAt int64) string {
+	sig := signTestData(privateKeyBase64, body, createdAt, expiresAt)
+	return fmt.Sprintf(
+		`Signature keyId="%s|key-1|ed25519",algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		subscriberID, createdAt, expiresAt, sig,
+	)
+}
+
+// makeCtx builds a minimal StepContext. When subscriberHeader is non-empty it is
+// set as the Authorization header on the request, which causes the identity check
+// gate inside Validate/ValidateAck to open.
+func makeCtx(body []byte, role model.Role, subscriberHeader string) *model.StepContext {
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
+	if subscriberHeader != "" {
+		req.Header.Set(model.AuthHeaderSubscriber, subscriberHeader)
+	}
+	return &model.StepContext{
+		Context:    context.Background(),
+		Body:       body,
+		Role:       role,
+		Request:    req,
+		RespHeader: http.Header{},
+	}
+}
+
+// makeCtxWithCallerID is like makeCtx but also injects a callerID into the Go
+// context, simulating what reqpreprocessor writes to model.ContextKeyRemoteID.
+func makeCtxWithCallerID(body []byte, role model.Role, subscriberHeader, callerID string) *model.StepContext {
+	goCtx := context.WithValue(context.Background(), model.ContextKeyRemoteID, callerID)
+	req, _ := http.NewRequest(http.MethodPost, "/", nil)
+	if subscriberHeader != "" {
+		req.Header.Set(model.AuthHeaderSubscriber, subscriberHeader)
+	}
+	return &model.StepContext{
+		Context:    goCtx,
+		Body:       body,
+		Role:       role,
+		Request:    req,
+		RespHeader: http.Header{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Crypto verification — Validate
+// ---------------------------------------------------------------------------
 
 // TestVerifySuccessCases tests all valid signature verification cases.
 func TestVerifySuccess(t *testing.T) {
@@ -53,7 +109,8 @@ func TestVerifySuccess(t *testing.T) {
 				`", signature="` + signature + `"`
 
 			verifier, close, _ := New(context.Background(), &Config{})
-			err := verifier.Validate(context.Background(), tt.body, header, publicKeyBase64)
+			// subscriberHeader not set — identity check gate evaluates false, check skipped.
+			err := verifier.Validate(makeCtx(tt.body, "", ""), header, publicKeyBase64)
 
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
@@ -151,7 +208,8 @@ func TestVerifyFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			verifier, close, _ := New(context.Background(), &Config{})
-			err := verifier.Validate(context.Background(), tt.body, tt.header, tt.pubKey)
+			// subscriberHeader not set — identity check gate evaluates false, check skipped.
+			err := verifier.Validate(makeCtx(tt.body, "", ""), tt.header, tt.pubKey)
 
 			if err == nil {
 				t.Fatal("Expected an error but got none")
@@ -165,5 +223,129 @@ func TestVerifyFailure(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Subscriber identity check — Validate
+// ---------------------------------------------------------------------------
+
+func TestValidate_SubIdentity_FromContext_Match(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","bap_id":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_FromContext_Mismatch(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","bap_id":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("evil.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
+	if err := verifier.Validate(ctx, header, publicKey); err == nil {
+		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+}
+
+func TestValidate_SubIdentity_FromBody_Match(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","bap_id":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	// No ContextKeyRemoteID — check falls back to body.
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_FromBody_Mismatch(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","bap_id":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("evil.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err == nil {
+		t.Fatal("expected error: signer evil.com does not match body bap_id bap.example.com")
+	}
+}
+
+func TestValidate_SubIdentity_V2Alias_SenderId(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","senderId":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error with senderId alias, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_V2Alias_ReceiverId(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"on_search","receiverId":"bpp.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("bpp.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBAP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error with receiverId alias, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_NoCallerIDField_Skips(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	// Body has no bap_id/bapId/senderId — identity check must be skipped.
+	body := []byte(`{"context":{"action":"search"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("anyone.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error when no caller ID field in body, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_GatewayRole_Skips(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`{"context":{"action":"search","bap_id":"bap.example.com"}}`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("gateway.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	// Gate is open (header set), but RoleGateway causes ResolveCallerID to return "" → skipped.
+	ctx := makeCtx(body, model.RoleGateway, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected no error for Gateway role, got: %v", err)
+	}
+}
+
+func TestValidate_SubIdentity_MalformedBody_Skips(t *testing.T) {
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte(`not-valid-json`)
+	now, exp := time.Now().Unix(), time.Now().Unix()+3600
+	header := signedHeaderWithKeyID("anyone.example.com", privateKey, body, now, exp)
+
+	verifier, _, _ := New(context.Background(), &Config{})
+	ctx := makeCtx(body, model.RoleBPP, header)
+	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+		t.Fatalf("expected identity check to be skipped on malformed body, got: %v", err)
 	}
 }

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -28,15 +28,12 @@ func generateTestKeyPair() (string, string) {
 func signTestData(privateKeyBase64 string, body []byte, createdAt, expiresAt int64) string {
 	privateKeyBytes, _ := base64.StdEncoding.DecodeString(privateKeyBase64)
 	privateKey := ed25519.PrivateKey(privateKeyBytes)
-
 	signingString := hash(body, createdAt, expiresAt)
 	signature := ed25519.Sign(privateKey, []byte(signingString))
-
 	return base64.StdEncoding.EncodeToString(signature)
 }
 
-// signedHeaderWithKeyID builds a full Authorization header including keyId so that
-// extractSubscriberIDFromHeader can extract the subscriber ID for identity checks.
+// signedHeaderWithKeyID builds a full Authorization header including keyId.
 func signedHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, createdAt, expiresAt int64) string {
 	sig := signTestData(privateKeyBase64, body, createdAt, expiresAt)
 	return fmt.Sprintf(
@@ -45,14 +42,26 @@ func signedHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, c
 	)
 }
 
-// makeCtx builds a minimal StepContext. When subscriberHeader is non-empty it is
-// set as the Authorization header on the request, which causes the identity check
-// gate inside Validate/ValidateAck to open.
-func makeCtx(body []byte, role model.Role, subscriberHeader string) *model.StepContext {
+// signAckTestData signs a body using the 4-line ACK signing string (NFH-004 §3.4).
+func signAckTestData(privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
+	privateKeyBytes, _ := base64.StdEncoding.DecodeString(privateKeyBase64)
+	signingString := hashAck(body, createdAt, expiresAt, outboundAuth)
+	signature := ed25519.Sign(ed25519.PrivateKey(privateKeyBytes), []byte(signingString))
+	return base64.StdEncoding.EncodeToString(signature)
+}
+
+// signedAckHeaderWithKeyID builds a full ACK Signature header including keyId.
+func signedAckHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
+	sig := signAckTestData(privateKeyBase64, body, outboundAuth, createdAt, expiresAt)
+	return fmt.Sprintf(
+		`Signature keyId="%s|key-1|ed25519",algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		subscriberID, createdAt, expiresAt, sig,
+	)
+}
+
+// makeCtx builds a minimal StepContext.
+func makeCtx(body []byte, role model.Role) *model.StepContext {
 	req, _ := http.NewRequest(http.MethodPost, "/", nil)
-	if subscriberHeader != "" {
-		req.Header.Set(model.AuthHeaderSubscriber, subscriberHeader)
-	}
 	return &model.StepContext{
 		Context:    context.Background(),
 		Body:       body,
@@ -62,14 +71,11 @@ func makeCtx(body []byte, role model.Role, subscriberHeader string) *model.StepC
 	}
 }
 
-// makeCtxWithCallerID is like makeCtx but also injects a callerID into the Go
-// context, simulating what reqpreprocessor writes to model.ContextKeyRemoteID.
-func makeCtxWithCallerID(body []byte, role model.Role, subscriberHeader, callerID string) *model.StepContext {
+// makeCtxWithCallerID is like makeCtx but injects a callerID into the Go context,
+// simulating what reqpreprocessor writes to model.ContextKeyRemoteID.
+func makeCtxWithCallerID(body []byte, role model.Role, callerID string) *model.StepContext {
 	goCtx := context.WithValue(context.Background(), model.ContextKeyRemoteID, callerID)
 	req, _ := http.NewRequest(http.MethodPost, "/", nil)
-	if subscriberHeader != "" {
-		req.Header.Set(model.AuthHeaderSubscriber, subscriberHeader)
-	}
 	return &model.StepContext{
 		Context:    goCtx,
 		Body:       body,
@@ -83,7 +89,6 @@ func makeCtxWithCallerID(body []byte, role model.Role, subscriberHeader, callerI
 // Crypto verification — Validate
 // ---------------------------------------------------------------------------
 
-// TestVerifySuccessCases tests all valid signature verification cases.
 func TestVerifySuccess(t *testing.T) {
 	privateKeyBase64, publicKeyBase64 := generateTestKeyPair()
 
@@ -109,8 +114,7 @@ func TestVerifySuccess(t *testing.T) {
 				`", signature="` + signature + `"`
 
 			verifier, close, _ := New(context.Background(), &Config{})
-			// subscriberHeader not set — identity check gate evaluates false, check skipped.
-			err := verifier.Validate(makeCtx(tt.body, "", ""), header, publicKeyBase64)
+			err := verifier.Validate(makeCtx(tt.body, ""), header, publicKeyBase64, false)
 
 			if err != nil {
 				t.Fatalf("Expected no error, but got: %v", err)
@@ -124,7 +128,6 @@ func TestVerifySuccess(t *testing.T) {
 	}
 }
 
-// TestVerifyFailureCases tests all invalid signature verification cases.
 func TestVerifyFailure(t *testing.T) {
 	privateKeyBase64, publicKeyBase64 := generateTestKeyPair()
 	_, wrongPublicKeyBase64 := generateTestKeyPair()
@@ -208,8 +211,7 @@ func TestVerifyFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			verifier, close, _ := New(context.Background(), &Config{})
-			// subscriberHeader not set — identity check gate evaluates false, check skipped.
-			err := verifier.Validate(makeCtx(tt.body, "", ""), tt.header, tt.pubKey)
+			err := verifier.Validate(makeCtx(tt.body, ""), tt.header, tt.pubKey, false)
 
 			if err == nil {
 				t.Fatal("Expected an error but got none")
@@ -237,8 +239,8 @@ func TestValidate_SubIdentity_FromContext_Match(t *testing.T) {
 	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
+	if err := verifier.Validate(ctx, header, publicKey, true); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
@@ -250,8 +252,8 @@ func TestValidate_SubIdentity_FromContext_Mismatch(t *testing.T) {
 	header := signedHeaderWithKeyID("evil.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
-	if err := verifier.Validate(ctx, header, publicKey); err == nil {
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
+	if err := verifier.Validate(ctx, header, publicKey, true); err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
 	}
 }
@@ -263,9 +265,8 @@ func TestValidate_SubIdentity_FromBody_Match(t *testing.T) {
 	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	// No ContextKeyRemoteID — check falls back to body.
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+	ctx := makeCtx(body, model.RoleBPP)
+	if err := verifier.Validate(ctx, header, publicKey, true); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
@@ -277,8 +278,8 @@ func TestValidate_SubIdentity_FromBody_Mismatch(t *testing.T) {
 	header := signedHeaderWithKeyID("evil.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err == nil {
+	ctx := makeCtx(body, model.RoleBPP)
+	if err := verifier.Validate(ctx, header, publicKey, true); err == nil {
 		t.Fatal("expected error: signer evil.com does not match body bap_id bap.example.com")
 	}
 }
@@ -290,8 +291,7 @@ func TestValidate_SubIdentity_V2Alias_SenderId(t *testing.T) {
 	header := signedHeaderWithKeyID("bap.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+	if err := verifier.Validate(makeCtx(body, model.RoleBPP), header, publicKey, true); err != nil {
 		t.Fatalf("expected no error with senderId alias, got: %v", err)
 	}
 }
@@ -303,23 +303,20 @@ func TestValidate_SubIdentity_V2Alias_ReceiverId(t *testing.T) {
 	header := signedHeaderWithKeyID("bpp.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBAP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+	if err := verifier.Validate(makeCtx(body, model.RoleBAP), header, publicKey, true); err != nil {
 		t.Fatalf("expected no error with receiverId alias, got: %v", err)
 	}
 }
 
 func TestValidate_SubIdentity_NoCallerIDField_Skips(t *testing.T) {
 	privateKey, publicKey := generateTestKeyPair()
-	// Body has no bap_id/bapId/senderId — identity check must be skipped.
 	body := []byte(`{"context":{"action":"search"}}`)
 	now, exp := time.Now().Unix(), time.Now().Unix()+3600
 	header := signedHeaderWithKeyID("anyone.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
-		t.Fatalf("expected no error when no caller ID field in body, got: %v", err)
+	if err := verifier.Validate(makeCtx(body, model.RoleBPP), header, publicKey, true); err != nil {
+		t.Fatalf("expected identity check skipped when no caller ID in body, got: %v", err)
 	}
 }
 
@@ -330,9 +327,8 @@ func TestValidate_SubIdentity_GatewayRole_Skips(t *testing.T) {
 	header := signedHeaderWithKeyID("gateway.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	// Gate is open (header set), but RoleGateway causes ResolveCallerID to return "" → skipped.
-	ctx := makeCtx(body, model.RoleGateway, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
+	// RoleGateway causes ResolveCallerID to return "" → check skipped.
+	if err := verifier.Validate(makeCtx(body, model.RoleGateway), header, publicKey, true); err != nil {
 		t.Fatalf("expected no error for Gateway role, got: %v", err)
 	}
 }
@@ -344,32 +340,14 @@ func TestValidate_SubIdentity_MalformedBody_Skips(t *testing.T) {
 	header := signedHeaderWithKeyID("anyone.example.com", privateKey, body, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.Validate(ctx, header, publicKey); err != nil {
-		t.Fatalf("expected identity check to be skipped on malformed body, got: %v", err)
+	if err := verifier.Validate(makeCtx(body, model.RoleBPP), header, publicKey, true); err != nil {
+		t.Fatalf("expected identity check skipped on malformed body, got: %v", err)
 	}
 }
 
 // ---------------------------------------------------------------------------
 // Subscriber identity check — ValidateAck
 // ---------------------------------------------------------------------------
-
-// signAckTestData signs a body using the 4-line ACK signing string (NFH-004 §3.4).
-func signAckTestData(privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
-	privateKeyBytes, _ := base64.StdEncoding.DecodeString(privateKeyBase64)
-	signingString := hashAck(body, createdAt, expiresAt, outboundAuth)
-	signature := ed25519.Sign(ed25519.PrivateKey(privateKeyBytes), []byte(signingString))
-	return base64.StdEncoding.EncodeToString(signature)
-}
-
-// signedAckHeaderWithKeyID builds a full ACK Signature header including keyId.
-func signedAckHeaderWithKeyID(subscriberID, privateKeyBase64 string, body []byte, outboundAuth string, createdAt, expiresAt int64) string {
-	sig := signAckTestData(privateKeyBase64, body, outboundAuth, createdAt, expiresAt)
-	return fmt.Sprintf(
-		`Signature keyId="%s|key-1|ed25519",algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
-		subscriberID, createdAt, expiresAt, sig,
-	)
-}
 
 func TestValidateAck_SubIdentity_FromContext_Match(t *testing.T) {
 	privateKey, publicKey := generateTestKeyPair()
@@ -379,8 +357,8 @@ func TestValidateAck_SubIdentity_FromContext_Match(t *testing.T) {
 	header := signedAckHeaderWithKeyID("bap.example.com", privateKey, body, outboundAuth, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
@@ -393,8 +371,8 @@ func TestValidateAck_SubIdentity_FromContext_Mismatch(t *testing.T) {
 	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtxWithCallerID(body, model.RoleBPP, header, "bap.example.com")
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err == nil {
+	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
+	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true); err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
 	}
 }
@@ -407,8 +385,7 @@ func TestValidateAck_SubIdentity_FromBody_Match(t *testing.T) {
 	header := signedAckHeaderWithKeyID("bap.example.com", privateKey, body, outboundAuth, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
+	if err := verifier.ValidateAck(makeCtx(body, model.RoleBPP), body, header, outboundAuth, publicKey, true); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
@@ -421,24 +398,7 @@ func TestValidateAck_SubIdentity_FromBody_Mismatch(t *testing.T) {
 	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
 
 	verifier, _, _ := New(context.Background(), &Config{})
-	ctx := makeCtx(body, model.RoleBPP, header)
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err == nil {
+	if err := verifier.ValidateAck(makeCtx(body, model.RoleBPP), body, header, outboundAuth, publicKey, true); err == nil {
 		t.Fatal("expected error: signer evil.com does not match body bap_id bap.example.com")
-	}
-}
-
-func TestValidateAck_SubIdentity_GateClosedForAckResponse(t *testing.T) {
-	privateKey, publicKey := generateTestKeyPair()
-	body := []byte(`{"context":{"action":"on_search","bap_id":"bap.example.com"}}`)
-	outboundAuth := "outbound-sig-value=="
-	now, exp := time.Now().Unix(), time.Now().Unix()+3600
-	// Signer is mismatched — but gate must stay closed, so identity check must be skipped.
-	header := signedAckHeaderWithKeyID("evil.com", privateKey, body, outboundAuth, now, exp)
-
-	verifier, _, _ := New(context.Background(), &Config{})
-	// Authorization header is NOT set to match the ACK Signature header — gate evaluates false.
-	ctx := makeCtx(body, model.RoleBPP, "")
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey); err != nil {
-		t.Fatalf("expected identity check to be skipped when gate is closed, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #806.

During signature validation the adapter verified that the `Authorization` header contained a valid signature from a registered subscriber, but did not assert that the signing subscriber (`subscriber_id` from `keyId`) matched the caller identity declared in the request body (`context.bap_id` on a BPP receiver, `context.bpp_id` on a BAP receiver). A registered participant could therefore sign a request while impersonating a different participant in the context, leading to spoofed identity in downstream processing, audit logs, and policy decisions.

## Changes

### `pkg/model/model.go`
- Added `ResolveCallerID` — returns the expected signing subscriber ID from a Beckn context map for a given role (opposite-role lookup: BAP→bpp_id/bppId/receiverId, BPP→bap_id/bapId/senderId)
- Added `ResolveSubscriberID` — returns the node's own subscriber ID from a Beckn context map (same-role lookup)
- Both functions handle the triple-key alias chain (legacy snake_case, camelCase, Beckn spec v2 names) and return `""` for Gateway role or missing fields

### `core/module/handler/step.go`
- `validate()` now returns `(*authHeader, error)` so the parsed header is available to the caller without re-parsing
- Added `checkSubscriberIdentity(ctx, *authHeader)` — asserts `parsed.SubscriberID == expected`, where `expected` is resolved via fast path (reqpreprocessor-cached `ContextKeyRemoteID`) or slow path (direct body parse via `model.ResolveCallerID`)
- Check is skipped (with debug log) when no caller ID field is present in the body or the role is Gateway; malformed body is logged and skipped rather than errored, since schema validation handles that separately
- `checkSubscriberIdentity` is called in `validateHeaders` immediately after signature validation succeeds

### `pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go`
- Replaced the local `firstNonNil(any...)` pattern with `model.ResolveSubscriberID` and `model.ResolveCallerID`
- Removed the `firstNonNil` helper
- Guard conditions changed from `!= nil` to `!= ""` to match the new typed string returns

## Tests

- `pkg/model/model_test.go` (new): 13 table-driven cases for `ResolveCallerID` and 9 for `ResolveSubscriberID`, covering precedence, empty strings, non-string values, and unsupported roles
- `core/module/handler/step_test.go`: 9 new cases covering fast path (context) and slow path (body), both roles, both spec versions (bap_id vs senderId/receiverId), Gateway role skip, missing field skip, and malformed body skip