### PR TITLE
fix(router): forward inbound query parameters to upstream URL

### DIFF
--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -867,6 +867,10 @@ func TestStorePayloadStep_Run_PropagatesError(t *testing.T) {
 	}
 }
 
+// TestProxy_QueryParamsForwardedToUpstream verifies that the proxy director
+// forwards RawQuery from the route URL verbatim to the upstream server.
+// The companion router tests (TestRouteQueryParamsForwarded) verify that the
+// router correctly populates route.URL.RawQuery from the inbound request.
 func TestProxy_QueryParamsForwardedToUpstream(t *testing.T) {
 	var capturedRawQuery string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -875,6 +879,8 @@ func TestProxy_QueryParamsForwardedToUpstream(t *testing.T) {
 	}))
 	defer upstream.Close()
 
+	// Simulate what the router produces after the fix: a route URL that already
+	// carries the inbound query string on its RawQuery field.
 	upstreamURL, _ := url.Parse(upstream.URL)
 	upstreamURL.RawQuery = "subscriptionId=test123&page=2"
 
@@ -883,7 +889,7 @@ func TestProxy_QueryParamsForwardedToUpstream(t *testing.T) {
 		Route:   &model.Route{TargetType: "url", URL: upstreamURL},
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/?subscriptionId=test123&page=2", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
 	rr := httptest.NewRecorder()
 
 	proxy(stepCtx, req, rr, http.DefaultClient, nil)

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -866,3 +866,29 @@ func TestStorePayloadStep_Run_PropagatesError(t *testing.T) {
 		t.Fatal("expected error from Run when Store fails")
 	}
 }
+
+func TestProxy_QueryParamsForwardedToUpstream(t *testing.T) {
+	var capturedRawQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	upstreamURL.RawQuery = "subscriptionId=test123&page=2"
+
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Route:   &model.Route{TargetType: "url", URL: upstreamURL},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/?subscriptionId=test123&page=2", strings.NewReader(`{}`))
+	rr := httptest.NewRecorder()
+
+	proxy(stepCtx, req, rr, http.DefaultClient, nil)
+
+	if capturedRawQuery != "subscriptionId=test123&page=2" {
+		t.Errorf("upstream received RawQuery = %q, want %q", capturedRawQuery, "subscriptionId=test123&page=2")
+	}
+}

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -299,7 +299,7 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	}
 	// For static URL targets, copy inbound query params onto a URL clone so the
 	// upstream receives them. The baked-in URL has no RawQuery of its own.
-	if route.TargetType == targetTypeURL && rawQuery != "" && route.URL != nil {
+	if rawQuery != "" && route.TargetType == targetTypeURL && route.URL != nil {
 		clone := *route.URL
 		clone.RawQuery = rawQuery
 		return &model.Route{TargetType: targetTypeURL, URL: &clone}, nil
@@ -340,7 +340,7 @@ func (r *Router) routeBodyless(endpoint, rawQuery string) (*model.Route, error) 
 		if rawQuery != "" && route.TargetType == targetTypeURL && route.URL != nil {
 			clone := *route.URL
 			clone.RawQuery = rawQuery
-			return &model.Route{TargetType: route.TargetType, URL: &clone}, nil
+			return &model.Route{TargetType: targetTypeURL, URL: &clone}, nil
 		}
 		return route, nil
 	}
@@ -386,10 +386,7 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string)
 	if rawQuery != "" {
 		targetURL.RawQuery = rawQuery
 	}
-	return &model.Route{
-		TargetType: targetTypeURL,
-		URL:        targetURL,
-	}, nil
+	return &model.Route{TargetType: targetTypeURL, URL: targetURL}, nil
 }
 
 func joinPath(u *url.URL, endpoint string) string {

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -383,7 +383,9 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string)
 		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
 	}
 	targetURL.Path = joinPath(targetURL, endpoint)
-	targetURL.RawQuery = rawQuery
+	if rawQuery != "" {
+		targetURL.RawQuery = rawQuery
+	}
 	return &model.Route{
 		TargetType: targetTypeURL,
 		URL:        targetURL,

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -296,13 +296,14 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 		return handleProtocolMapping(route, bppURI, endpoint, rawQuery)
 	case targetTypeBAP, targetTypeSender:
 		return handleProtocolMapping(route, bapURI, endpoint, rawQuery)
-	}
-	// For static URL targets, copy inbound query params onto a URL clone so the
-	// upstream receives them. The baked-in URL has no RawQuery of its own.
-	if rawQuery != "" && route.TargetType == targetTypeURL && route.URL != nil {
-		clone := *route.URL
-		clone.RawQuery = rawQuery
-		return &model.Route{TargetType: targetTypeURL, URL: &clone}, nil
+	case targetTypeURL:
+		// Copy inbound query params onto a URL clone so the upstream receives them.
+		// The baked-in URL has no RawQuery of its own.
+		if rawQuery != "" && route.URL != nil {
+			clone := *route.URL
+			clone.RawQuery = rawQuery
+			return &model.Route{TargetType: targetTypeURL, URL: &clone}, nil
+		}
 	}
 	return route, nil
 }

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -371,12 +371,12 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string)
 		if route.URL == nil {
 			return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, role)
 		}
-		fallback := *route.URL
-		fallback.RawQuery = rawQuery
-		return &model.Route{
-			TargetType: targetTypeURL,
-			URL:        &fallback,
-		}, nil
+		if rawQuery != "" {
+			fallback := *route.URL
+			fallback.RawQuery = rawQuery
+			return &model.Route{TargetType: targetTypeURL, URL: &fallback}, nil
+		}
+		return &model.Route{TargetType: targetTypeURL, URL: route.URL}, nil
 	}
 	targetURL, err := url.Parse(target)
 	if err != nil {

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -219,12 +219,14 @@ func getContextString(ctx map[string]interface{}, keys ...string) string {
 // Route determines the routing destination based on the request context.
 // reqURL.Path holds the Beckn endpoint action already stripped of the module
 // base path by the step layer (e.g. "search" or "catalog/subscription").
+// reqURL.RawQuery is forwarded verbatim to the upstream target URL.
 func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*model.Route, error) {
 	endpoint := reqURL.Path
+	rawQuery := reqURL.RawQuery
 	// Bodyless requests (GET/DELETE) carry no JSON body; domain, version, and
 	// BAP/BPP URIs are not available. Route using the v2 config version.
 	if len(body) == 0 {
-		return r.routeBodyless(endpoint)
+		return r.routeBodyless(endpoint, rawQuery)
 	}
 
 	// Parse domain and version via typed struct.
@@ -288,9 +290,16 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	// Both legacy ("bpp"/"bap") and new spec v2 ("receiver"/"sender") values are accepted.
 	switch route.TargetType {
 	case targetTypeBPP, targetTypeReceiver:
-		return handleProtocolMapping(route, bppURI, endpoint)
+		return handleProtocolMapping(route, bppURI, endpoint, rawQuery)
 	case targetTypeBAP, targetTypeSender:
-		return handleProtocolMapping(route, bapURI, endpoint)
+		return handleProtocolMapping(route, bapURI, endpoint, rawQuery)
+	}
+	// For static URL targets, copy inbound query params onto a URL clone so the
+	// upstream receives them. The baked-in URL has no RawQuery of its own.
+	if route.TargetType == targetTypeURL && rawQuery != "" && route.URL != nil {
+		clone := *route.URL
+		clone.RawQuery = rawQuery
+		return &model.Route{TargetType: targetTypeURL, URL: &clone}, nil
 	}
 	return route, nil
 }
@@ -308,7 +317,7 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 //     should not configure publisher targets for bodyless endpoints.
 //   - bpp / bap / receiver / sender: rejected — the target URI is read from the request body,
 //     which is absent for bodyless requests.
-func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
+func (r *Router) routeBodyless(endpoint, rawQuery string) (*model.Route, error) {
 	v2Rules, ok := r.rules["*"]
 	if !ok {
 		return nil, fmt.Errorf("no v2 routing rules found; bodyless requests require a v2 config")
@@ -322,6 +331,11 @@ func (r *Router) routeBodyless(endpoint string) (*model.Route, error) {
 		switch route.TargetType {
 		case targetTypeBPP, targetTypeBAP, targetTypeReceiver, targetTypeSender:
 			return nil, fmt.Errorf("bodyless endpoint '%s' (version %s) is configured with target type '%s': dynamic BAP/BPP URI routing is not supported for bodyless requests", endpoint, version, route.TargetType)
+		}
+		if rawQuery != "" && route.URL != nil {
+			clone := *route.URL
+			clone.RawQuery = rawQuery
+			return &model.Route{TargetType: route.TargetType, PublisherID: route.PublisherID, URL: &clone}, nil
 		}
 		return route, nil
 	}
@@ -343,17 +357,20 @@ func canonicalRoleName(targetType string) string {
 	}
 }
 
-// handleProtocolMapping handles both BPP and BAP routing with proper URL construction
-func handleProtocolMapping(route *model.Route, npURI, endpoint string) (*model.Route, error) {
+// handleProtocolMapping handles both BPP and BAP routing with proper URL construction.
+// rawQuery is the inbound request's query string and is forwarded verbatim to the upstream URL.
+func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string) (*model.Route, error) {
 	target := strings.TrimSpace(npURI)
 	role := canonicalRoleName(route.TargetType)
 	if len(target) == 0 {
 		if route.URL == nil {
 			return nil, fmt.Errorf("could not determine destination for endpoint '%s': neither request contained a %s URI nor was a default URL configured in routing rules", endpoint, role)
 		}
+		fallback := *route.URL
+		fallback.RawQuery = rawQuery
 		return &model.Route{
 			TargetType: targetTypeURL,
-			URL:        route.URL,
+			URL:        &fallback,
 		}, nil
 	}
 	targetURL, err := url.Parse(target)
@@ -361,6 +378,7 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint string) (*model.R
 		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
 	}
 	targetURL.Path = joinPath(targetURL, endpoint)
+	targetURL.RawQuery = rawQuery
 	return &model.Route{
 		TargetType: targetTypeURL,
 		URL:        targetURL,

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -221,6 +221,9 @@ func getContextString(ctx map[string]interface{}, keys ...string) string {
 // base path by the step layer (e.g. "search" or "catalog/subscription").
 // reqURL.RawQuery is forwarded verbatim to the upstream target URL.
 func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*model.Route, error) {
+	if reqURL == nil {
+		return nil, fmt.Errorf("reqURL must not be nil")
+	}
 	endpoint := reqURL.Path
 	rawQuery := reqURL.RawQuery
 	// Bodyless requests (GET/DELETE) carry no JSON body; domain, version, and
@@ -332,10 +335,12 @@ func (r *Router) routeBodyless(endpoint, rawQuery string) (*model.Route, error) 
 		case targetTypeBPP, targetTypeBAP, targetTypeReceiver, targetTypeSender:
 			return nil, fmt.Errorf("bodyless endpoint '%s' (version %s) is configured with target type '%s': dynamic BAP/BPP URI routing is not supported for bodyless requests", endpoint, version, route.TargetType)
 		}
-		if rawQuery != "" && route.URL != nil {
+		// Publisher routes address a queue by ID — they carry no URL, so
+		// RawQuery does not apply. Only clone for URL-type targets.
+		if rawQuery != "" && route.TargetType == targetTypeURL && route.URL != nil {
 			clone := *route.URL
 			clone.RawQuery = rawQuery
-			return &model.Route{TargetType: route.TargetType, PublisherID: route.PublisherID, URL: &clone}, nil
+			return &model.Route{TargetType: route.TargetType, URL: &clone}, nil
 		}
 		return route, nil
 	}

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -1083,7 +1083,7 @@ func TestRouteQueryParamsForwarded(t *testing.T) {
 				t.Fatalf("Route() error = %v, want nil", err)
 			}
 			if route.URL == nil {
-				t.Fatal("Route() returned nil URL")
+				t.Fatalf("Route() returned nil URL for endpoint %q (config: %s) — check that the test body resolves to a URL-type target", tt.endpoint, tt.configFile)
 			}
 			if route.URL.RawQuery != tt.wantRawQuery {
 				t.Errorf("RawQuery = %q, want %q", route.URL.RawQuery, tt.wantRawQuery)

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -1121,21 +1121,23 @@ func TestRouteNilReqURL(t *testing.T) {
 	}
 }
 
-// TestRouteBodylessPublisherUnaffectedByQueryParams confirms that publisher-type
-// bodyless routes are returned unchanged when RawQuery is present — publisher
-// routes carry no URL, so there is nothing to attach the query string to.
+// TestRouteBodylessPublisherUnaffectedByQueryParams confirms that a truly
+// bodyless request (nil body) whose matched v2 rule has targetType: publisher
+// is returned unchanged when RawQuery is non-empty — publisher routes carry
+// no URL so there is nothing to attach the query string to.
+// This exercises the routeBodyless → switch fall-through → return route, nil path.
 func TestRouteBodylessPublisherUnaffectedByQueryParams(t *testing.T) {
 	ctx := context.Background()
 
-	// bpp_receiver has a publisher target for "search"
-	router, _, rulesFilePath := setupRouter(t, "bpp_receiver.yaml")
+	// v2_bpp_receiver has a v2 publisher target for "search".
+	router, _, rulesFilePath := setupRouter(t, "v2_bpp_receiver.yaml")
 	defer os.RemoveAll(filepath.Dir(rulesFilePath))
 
-	// "search" maps to targetType=publisher in bpp_receiver.yaml — no URL field.
-	// Passing a query string must not cause a panic or error; the route is returned
-	// with its PublisherID intact and URL remaining nil.
+	// nil body → routeBodyless; "search" maps to targetType=publisher.
+	// A non-empty RawQuery must not cause a panic or error; the route is
+	// returned with its PublisherID intact and URL remaining nil.
 	reqURL := &url.URL{Path: "search", RawQuery: "foo=bar"}
-	route, err := router.Route(ctx, reqURL, []byte(`{"context":{"domain":"ONDC:TRV10","version":"1.1.0"}}`))
+	route, err := router.Route(ctx, reqURL, nil)
 	if err != nil {
 		t.Fatalf("Route() error = %v, want nil", err)
 	}

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -1060,7 +1060,10 @@ func TestRouteQueryParamsForwarded(t *testing.T) {
 			wantRawQuery: "",
 		},
 		{
-			name:         "bpp routing with gateway fallback URL preserves query params",
+			// handleProtocolMapping fallback: bpp_uri absent in body, so the
+			// gateway URL configured in the routing rule is used as the target.
+			// Verifies the fallback clone path in handleProtocolMapping carries RawQuery.
+			name:         "bpp routing: no bpp_uri in body falls back to gateway URL and preserves query params",
 			configFile:   "bap_caller.yaml",
 			endpoint:     "search",
 			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
@@ -1105,5 +1108,41 @@ func TestRouteBodylessQueryParamsForwarded(t *testing.T) {
 	}
 	if route.URL.RawQuery != "subscriptionId=test123" {
 		t.Errorf("RawQuery = %q, want %q", route.URL.RawQuery, "subscriptionId=test123")
+	}
+}
+
+func TestRouteNilReqURL(t *testing.T) {
+	router, _, rulesFilePath := setupRouter(t, "bap_caller.yaml")
+	defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+	_, err := router.Route(context.Background(), nil, []byte(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "reqURL must not be nil") {
+		t.Errorf("Route(nil URL) = %v, want error containing 'reqURL must not be nil'", err)
+	}
+}
+
+// TestRouteBodylessPublisherUnaffectedByQueryParams confirms that publisher-type
+// bodyless routes are returned unchanged when RawQuery is present — publisher
+// routes carry no URL, so there is nothing to attach the query string to.
+func TestRouteBodylessPublisherUnaffectedByQueryParams(t *testing.T) {
+	ctx := context.Background()
+
+	// bpp_receiver has a publisher target for "search"
+	router, _, rulesFilePath := setupRouter(t, "bpp_receiver.yaml")
+	defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+	// "search" maps to targetType=publisher in bpp_receiver.yaml — no URL field.
+	// Passing a query string must not cause a panic or error; the route is returned
+	// with its PublisherID intact and URL remaining nil.
+	reqURL := &url.URL{Path: "search", RawQuery: "foo=bar"}
+	route, err := router.Route(ctx, reqURL, []byte(`{"context":{"domain":"ONDC:TRV10","version":"1.1.0"}}`))
+	if err != nil {
+		t.Fatalf("Route() error = %v, want nil", err)
+	}
+	if route.TargetType != targetTypePublisher {
+		t.Errorf("TargetType = %q, want %q", route.TargetType, targetTypePublisher)
+	}
+	if route.URL != nil {
+		t.Errorf("expected route.URL to be nil for publisher route, got %v", route.URL)
 	}
 }

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -1015,3 +1015,95 @@ func TestRouteBodyless(t *testing.T) {
 		})
 	}
 }
+
+func TestRouteQueryParamsForwarded(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		configFile   string
+		endpoint     string
+		body         string
+		rawQuery     string
+		wantRawQuery string
+	}{
+		{
+			name:         "bpp_uri routing preserves query params",
+			configFile:   "bap_caller.yaml",
+			endpoint:     "select",
+			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
+			rawQuery:     "subscriptionId=abc&page=1",
+			wantRawQuery: "subscriptionId=abc&page=1",
+		},
+		{
+			name:         "bap_uri routing preserves query params",
+			configFile:   "bpp_caller.yaml",
+			endpoint:     "on_select",
+			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bap_uri": "https://bap1.example.com"}}`,
+			rawQuery:     "token=xyz",
+			wantRawQuery: "token=xyz",
+		},
+		{
+			name:         "static url routing preserves query params",
+			configFile:   "bpp_receiver.yaml",
+			endpoint:     "select",
+			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			rawQuery:     "filter=active",
+			wantRawQuery: "filter=active",
+		},
+		{
+			name:         "no query params — RawQuery remains empty",
+			configFile:   "bap_caller.yaml",
+			endpoint:     "select",
+			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "https://bpp1.example.com"}}`,
+			rawQuery:     "",
+			wantRawQuery: "",
+		},
+		{
+			name:         "bpp routing with gateway fallback URL preserves query params",
+			configFile:   "bap_caller.yaml",
+			endpoint:     "search",
+			body:         `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0"}}`,
+			rawQuery:     "subscriptionId=abc",
+			wantRawQuery: "subscriptionId=abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, _, rulesFilePath := setupRouter(t, tt.configFile)
+			defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+			reqURL := &url.URL{Path: tt.endpoint, RawQuery: tt.rawQuery}
+			route, err := router.Route(ctx, reqURL, []byte(tt.body))
+			if err != nil {
+				t.Fatalf("Route() error = %v, want nil", err)
+			}
+			if route.URL == nil {
+				t.Fatal("Route() returned nil URL")
+			}
+			if route.URL.RawQuery != tt.wantRawQuery {
+				t.Errorf("RawQuery = %q, want %q", route.URL.RawQuery, tt.wantRawQuery)
+			}
+		})
+	}
+}
+
+func TestRouteBodylessQueryParamsForwarded(t *testing.T) {
+	ctx := context.Background()
+
+	router, _, rulesFilePath := setupRouter(t, "v2_catalog_url.yaml")
+	defer os.RemoveAll(filepath.Dir(rulesFilePath))
+
+	reqURL := &url.URL{Path: "catalog/subscription", RawQuery: "subscriptionId=test123"}
+	route, err := router.Route(ctx, reqURL, nil)
+	if err != nil {
+		t.Fatalf("Route() error = %v, want nil", err)
+	}
+	if route.URL == nil {
+		t.Fatal("Route() returned nil URL")
+	}
+	if route.URL.RawQuery != "subscriptionId=test123" {
+		t.Errorf("RawQuery = %q, want %q", route.URL.RawQuery, "subscriptionId=test123")
+	}
+}


### PR DESCRIPTION
## Summary

- Query parameters on inbound requests (e.g. `?subscriptionId=<id>`) were silently dropped and never forwarded to the upstream BPP/BAP endpoint
- `handleProtocolMapping` and `routeBodyless` now copy `reqURL.RawQuery` onto the constructed target URL
- Static URL route entries are cloned before setting `RawQuery` to avoid mutating the shared baked-in route object
- The `proxy` director required no change — it sets `req.URL = target`, so populating `RawQuery` on the route URL is sufficient

## Test plan

- [ ] `TestRouteQueryParamsForwarded` — 5 table-driven cases covering `bpp_uri`, `bap_uri`, static URL, empty query, and gateway fallback URL routing
- [ ] `TestRouteBodylessQueryParamsForwarded` — bodyless GET path with `?subscriptionId=test123`
- [ ] `TestProxy_QueryParamsForwardedToUpstream` — end-to-end integration test: real `httptest.Server` asserts the upstream receives `subscriptionId=test123&page=2` verbatim
- [ ] All existing router and handler tests continue to pass

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)