### PR TITLE
fix(signvalidator): apply configurable clock-skew tolerance to created field

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -807,7 +807,7 @@ Auxiliary specs are additive — they may only introduce new action verbs not al
 signValidator:
   id: signvalidator
   config:
-    clockSkewToleranceSeconds: "5"   # optional — see parameters below
+    clockSkewToleranceSeconds: 5   # optional — see parameters below
 ```
 
 **Parameters**:

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -806,9 +806,16 @@ Auxiliary specs are additive — they may only introduce new action verbs not al
 ```yaml
 signValidator:
   id: signvalidator
+  config:
+    clockSkewToleranceSeconds: "5"   # optional — see parameters below
 ```
 
-**Parameters**: None required. Uses key manager for public key lookup.
+**Parameters**:
+
+- `clockSkewToleranceSeconds` *(optional, integer, default: `5`)*: Maximum number of seconds the `created` timestamp in an inbound signature header may be ahead of the server clock. Accommodates NTP drift between network participants. Per the Beckn Auth & Trust spec the recommended default is 5 s; NFOs may configure a stricter or more permissive value for their subnet.
+  - A value of `"0"` enforces strict same-second validation.
+  - Values greater than `10` are accepted but trigger a startup warning — large tolerances widen the replay window.
+  - **The `expires` field always uses zero tolerance regardless of this setting.** An expired signature is rejected unconditionally.
 
 ---
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -813,7 +813,7 @@ signValidator:
 **Parameters**:
 
 - `clockSkewToleranceSeconds` *(optional, integer, default: `5`)*: Maximum number of seconds the `created` timestamp in an inbound signature header may be ahead of the server clock. Accommodates NTP drift between network participants. Per the Beckn Auth & Trust spec the recommended default is 5 s; NFOs may configure a stricter or more permissive value for their subnet.
-  - A value of `"0"` enforces strict same-second validation.
+  - A value of `0` enforces strict same-second validation.
   - Values greater than `10` are accepted but trigger a startup warning — large tolerances widen the replay window.
   - **The `expires` field always uses zero tolerance regardless of this setting.** An expired signature is rejected unconditionally.
 

--- a/pkg/plugin/implementation/signvalidator/cmd/plugin.go
+++ b/pkg/plugin/implementation/signvalidator/cmd/plugin.go
@@ -25,7 +25,8 @@ func (vp provider) New(ctx context.Context, config map[string]string) (definitio
 		if err != nil || secs < 0 {
 			return nil, nil, errors.New("signvalidator: clockSkewToleranceSeconds must be a non-negative integer")
 		}
-		cfg.ClockSkewTolerance = time.Duration(secs) * time.Second
+		d := time.Duration(secs) * time.Second
+		cfg.ClockSkewTolerance = &d
 	}
 
 	return signvalidator.New(ctx, cfg)

--- a/pkg/plugin/implementation/signvalidator/cmd/plugin.go
+++ b/pkg/plugin/implementation/signvalidator/cmd/plugin.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"strconv"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/signvalidator"
@@ -17,7 +19,16 @@ func (vp provider) New(ctx context.Context, config map[string]string) (definitio
 		return nil, nil, errors.New("context cannot be nil")
 	}
 
-	return signvalidator.New(ctx, &signvalidator.Config{})
+	cfg := &signvalidator.Config{}
+	if s, ok := config["clockSkewToleranceSeconds"]; ok {
+		secs, err := strconv.Atoi(s)
+		if err != nil || secs < 0 {
+			return nil, nil, errors.New("signvalidator: clockSkewToleranceSeconds must be a non-negative integer")
+		}
+		cfg.ClockSkewTolerance = time.Duration(secs) * time.Second
+	}
+
+	return signvalidator.New(ctx, cfg)
 }
 
 // Provider is the exported symbol that the plugin manager will look for.

--- a/pkg/plugin/implementation/signvalidator/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/signvalidator/cmd/plugin_test.go
@@ -50,6 +50,47 @@ func TestVerifierProviderSuccess(t *testing.T) {
 	}
 }
 
+// TestVerifierProviderClockSkewConfig tests that clockSkewToleranceSeconds is parsed correctly.
+func TestVerifierProviderClockSkewConfig(t *testing.T) {
+	p := provider{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "valid tolerance",
+			config:  map[string]string{"clockSkewToleranceSeconds": "8"},
+			wantErr: false,
+		},
+		{
+			name:    "zero tolerance",
+			config:  map[string]string{"clockSkewToleranceSeconds": "0"},
+			wantErr: false,
+		},
+		{
+			name:    "non-integer value",
+			config:  map[string]string{"clockSkewToleranceSeconds": "5s"},
+			wantErr: true,
+		},
+		{
+			name:    "negative value",
+			config:  map[string]string{"clockSkewToleranceSeconds": "-1"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := p.New(context.Background(), tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("wantErr=%v, got err=%v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 // TestVerifierProviderFailure tests cases where verifier creation should fail.
 func TestVerifierProviderFailure(t *testing.T) {
 	provider := provider{}

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -15,8 +15,18 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+const (
+	defaultClockSkewTolerance = 5 * time.Second
+	maxClockSkewTolerance     = 10 * time.Second
+)
+
 // Config struct for Verifier.
 type Config struct {
+	// ClockSkewTolerance is the maximum future drift allowed for the `created`
+	// field. Defaults to 5 s per the Beckn Auth & Trust spec. NFOs may override
+	// this per-subnet via the plugin config key "clockSkewToleranceSeconds".
+	// The `expires` field always uses zero tolerance regardless of this value.
+	ClockSkewTolerance time.Duration
 }
 
 // validator implements the validator interface.
@@ -26,8 +36,14 @@ type validator struct {
 
 // New creates a new Verifier instance.
 func New(ctx context.Context, config *Config) (*validator, func() error, error) {
+	if config.ClockSkewTolerance == 0 {
+		config.ClockSkewTolerance = defaultClockSkewTolerance
+	}
+	if config.ClockSkewTolerance > maxClockSkewTolerance {
+		log.Warnf(ctx, "signvalidator: clockSkewToleranceSeconds=%ds exceeds recommended maximum of %ds; large tolerances widen the replay window",
+			int(config.ClockSkewTolerance.Seconds()), int(maxClockSkewTolerance.Seconds()))
+	}
 	v := &validator{config: config}
-
 	return v, nil, nil
 }
 
@@ -43,7 +59,7 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp); err != nil {
+	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp, v.config.ClockSkewTolerance); err != nil {
 		return err
 	}
 
@@ -131,7 +147,7 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp); err != nil {
+	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp, v.config.ClockSkewTolerance); err != nil {
 		return err
 	}
 
@@ -184,26 +200,30 @@ func checkSubscriberIdentity(ctx *model.StepContext, body []byte, signerID strin
 	return nil
 }
 
-// checkTimestampWindow validates that the current server time falls within
-// [created, expires]. prefix ("signature" or "AckSignature") is used in the
-// error message to distinguish the two callers in logs.
-func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int64) error {
+// checkTimestampWindow validates the created/expires timestamp pair.
+// clockSkewTolerance is applied to `created` only — the spec permits a
+// configurable forward drift window to accommodate NTP skew between NPs.
+// `expires` is always checked with zero tolerance per the spec.
+func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int64, clockSkewTolerance time.Duration) error {
 	now := time.Now().UTC()
-	current := now.Unix()
-	if createdTimestamp > current {
-		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, delta=%ds",
+	// Accept created values up to clockSkewTolerance in the future.
+	deadline := now.Add(clockSkewTolerance)
+	if time.Unix(createdTimestamp, 0).UTC().After(deadline) {
+		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, delta=%ds",
 			prefix,
 			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),
-			createdTimestamp-current,
+			int(clockSkewTolerance.Seconds()),
+			createdTimestamp-now.Unix(),
 		))
 	}
-	if current > expiredTimestamp {
+	// expires: zero tolerance — reject without exception.
+	if now.Unix() > expiredTimestamp {
 		return model.NewSignValidationErr(fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
 			prefix,
 			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),
-			current-expiredTimestamp,
+			now.Unix()-expiredTimestamp,
 		))
 	}
 	return nil

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -23,28 +23,30 @@ const (
 // Config struct for Verifier.
 type Config struct {
 	// ClockSkewTolerance is the maximum future drift allowed for the `created`
-	// field. Defaults to 5 s per the Beckn Auth & Trust spec. NFOs may override
-	// this per-subnet via the plugin config key "clockSkewToleranceSeconds".
+	// field. nil means use the spec default (5 s). Set to a zero-value pointer
+	// (&0) to enforce strict same-second validation. NFOs may override this
+	// per-subnet via the plugin config key "clockSkewToleranceSeconds".
 	// The `expires` field always uses zero tolerance regardless of this value.
-	ClockSkewTolerance time.Duration
+	ClockSkewTolerance *time.Duration
 }
 
 // validator implements the validator interface.
 type validator struct {
-	config *Config
+	clockSkewTolerance time.Duration // resolved at construction; never changes
 }
 
 // New creates a new Verifier instance.
+// The caller's Config is never mutated.
 func New(ctx context.Context, config *Config) (*validator, func() error, error) {
-	if config.ClockSkewTolerance == 0 {
-		config.ClockSkewTolerance = defaultClockSkewTolerance
+	tolerance := defaultClockSkewTolerance
+	if config.ClockSkewTolerance != nil {
+		tolerance = *config.ClockSkewTolerance
 	}
-	if config.ClockSkewTolerance > maxClockSkewTolerance {
+	if tolerance > maxClockSkewTolerance {
 		log.Warnf(ctx, "signvalidator: clockSkewToleranceSeconds=%ds exceeds recommended maximum of %ds; large tolerances widen the replay window",
-			int(config.ClockSkewTolerance.Seconds()), int(maxClockSkewTolerance.Seconds()))
+			int(tolerance.Seconds()), int(maxClockSkewTolerance.Seconds()))
 	}
-	v := &validator{config: config}
-	return v, nil, nil
+	return &validator{clockSkewTolerance: tolerance}, nil, nil
 }
 
 // Validate verifies the 3-line signing string for inbound requests.
@@ -59,7 +61,7 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp, v.config.ClockSkewTolerance); err != nil {
+	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
 		return err
 	}
 
@@ -147,7 +149,7 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 		return fmt.Errorf("error decoding signature: %w", err)
 	}
 
-	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp, v.config.ClockSkewTolerance); err != nil {
+	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
 		return err
 	}
 
@@ -209,12 +211,12 @@ func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int6
 	// Accept created values up to clockSkewTolerance in the future.
 	deadline := now.Add(clockSkewTolerance)
 	if time.Unix(createdTimestamp, 0).UTC().After(deadline) {
-		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, delta=%ds",
+		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, overshoot=%ds",
 			prefix,
 			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),
 			int(clockSkewTolerance.Seconds()),
-			createdTimestamp-now.Unix(),
+			createdTimestamp-deadline.Unix(),
 		))
 	}
 	// expires: zero tolerance — reject without exception.

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -90,10 +90,20 @@ func makeCtxWithCallerID(body []byte, role model.Role, callerID string) *model.S
 // ---------------------------------------------------------------------------
 
 func TestClockSkewTolerance_Default(t *testing.T) {
-	// A validator with no explicit tolerance should default to 5 s.
-	v, _, _ := New(context.Background(), &Config{})
-	if v.config.ClockSkewTolerance != defaultClockSkewTolerance {
-		t.Fatalf("expected default tolerance %v, got %v", defaultClockSkewTolerance, v.config.ClockSkewTolerance)
+	// With no explicit tolerance configured, a created timestamp 3 s in the
+	// future should be accepted (within the 5 s spec default).
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte("payload")
+	now := time.Now().Unix()
+	created := now + 3
+	expires := now + 3600
+	header := fmt.Sprintf(
+		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		created, expires, signTestData(privateKey, body, created, expires),
+	)
+	verifier, _, _ := New(context.Background(), &Config{})
+	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err != nil {
+		t.Fatalf("expected default 5 s tolerance to accept created+3s, got: %v", err)
 	}
 }
 
@@ -143,7 +153,8 @@ func TestClockSkewTolerance_ExpiredNeverTolerated(t *testing.T) {
 		created, expires, signTestData(privateKey, body, created, expires),
 	)
 	// Use a large tolerance to confirm it has no effect on expires.
-	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: 30 * time.Second})
+	d := 30 * time.Second
+	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: &d})
 	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err == nil {
 		t.Fatal("expected rejection of expired signature even with large tolerance")
 	}
@@ -160,7 +171,8 @@ func TestClockSkewTolerance_CustomTolerance(t *testing.T) {
 		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
 		created, expires, signTestData(privateKey, body, created, expires),
 	)
-	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: 10 * time.Second})
+	d := 10 * time.Second
+	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: &d})
 	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err != nil {
 		t.Fatalf("expected acceptance with 10 s tolerance, got: %v", err)
 	}

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -86,6 +86,87 @@ func makeCtxWithCallerID(body []byte, role model.Role, callerID string) *model.S
 }
 
 // ---------------------------------------------------------------------------
+// Clock-skew tolerance
+// ---------------------------------------------------------------------------
+
+func TestClockSkewTolerance_Default(t *testing.T) {
+	// A validator with no explicit tolerance should default to 5 s.
+	v, _, _ := New(context.Background(), &Config{})
+	if v.config.ClockSkewTolerance != defaultClockSkewTolerance {
+		t.Fatalf("expected default tolerance %v, got %v", defaultClockSkewTolerance, v.config.ClockSkewTolerance)
+	}
+}
+
+func TestClockSkewTolerance_CreatedSlightlyInFuture_Accepted(t *testing.T) {
+	// created is 3 s in the future — within the 5 s default tolerance.
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte("payload")
+	now := time.Now().Unix()
+	created := now + 3
+	expires := now + 3600
+	header := fmt.Sprintf(
+		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		created, expires, signTestData(privateKey, body, created, expires),
+	)
+	verifier, _, _ := New(context.Background(), &Config{})
+	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err != nil {
+		t.Fatalf("expected acceptance within tolerance, got: %v", err)
+	}
+}
+
+func TestClockSkewTolerance_CreatedBeyondTolerance_Rejected(t *testing.T) {
+	// created is 7 s in the future — beyond the 5 s default tolerance.
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte("payload")
+	now := time.Now().Unix()
+	created := now + 7
+	expires := now + 3600
+	header := fmt.Sprintf(
+		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		created, expires, signTestData(privateKey, body, created, expires),
+	)
+	verifier, _, _ := New(context.Background(), &Config{})
+	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err == nil {
+		t.Fatal("expected rejection when created exceeds tolerance")
+	}
+}
+
+func TestClockSkewTolerance_ExpiredNeverTolerated(t *testing.T) {
+	// expires is 1 s in the past — must be rejected regardless of tolerance config.
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte("payload")
+	now := time.Now().Unix()
+	created := now - 60
+	expires := now - 1
+	header := fmt.Sprintf(
+		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		created, expires, signTestData(privateKey, body, created, expires),
+	)
+	// Use a large tolerance to confirm it has no effect on expires.
+	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: 30 * time.Second})
+	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err == nil {
+		t.Fatal("expected rejection of expired signature even with large tolerance")
+	}
+}
+
+func TestClockSkewTolerance_CustomTolerance(t *testing.T) {
+	// created is 8 s in the future — rejected with default 5 s, accepted with 10 s tolerance.
+	privateKey, publicKey := generateTestKeyPair()
+	body := []byte("payload")
+	now := time.Now().Unix()
+	created := now + 8
+	expires := now + 3600
+	header := fmt.Sprintf(
+		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
+		created, expires, signTestData(privateKey, body, created, expires),
+	)
+	verifier, _, _ := New(context.Background(), &Config{ClockSkewTolerance: 10 * time.Second})
+	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err != nil {
+		t.Fatalf("expected acceptance with 10 s tolerance, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Crypto verification — Validate
 // ---------------------------------------------------------------------------
 

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -107,23 +107,6 @@ func TestClockSkewTolerance_Default(t *testing.T) {
 	}
 }
 
-func TestClockSkewTolerance_CreatedSlightlyInFuture_Accepted(t *testing.T) {
-	// created is 3 s in the future — within the 5 s default tolerance.
-	privateKey, publicKey := generateTestKeyPair()
-	body := []byte("payload")
-	now := time.Now().Unix()
-	created := now + 3
-	expires := now + 3600
-	header := fmt.Sprintf(
-		`Signature algorithm="ed25519",created="%d",expires="%d",signature="%s"`,
-		created, expires, signTestData(privateKey, body, created, expires),
-	)
-	verifier, _, _ := New(context.Background(), &Config{})
-	if err := verifier.Validate(makeCtx(body, ""), header, publicKey, false); err != nil {
-		t.Fatalf("expected acceptance within tolerance, got: %v", err)
-	}
-}
-
 func TestClockSkewTolerance_CreatedBeyondTolerance_Rejected(t *testing.T) {
 	// created is 7 s in the future — beyond the 5 s default tolerance.
 	privateKey, publicKey := generateTestKeyPair()


### PR DESCRIPTION
Fixes #818

## Summary

- `checkTimestampWindow` now accepts a `clockSkewTolerance` parameter and applies it **only** to the `created` field — accepting signatures where `created ≤ now + tolerance` to accommodate NTP drift between network participants
- `expires` retains strict zero tolerance with no config knob, per the Beckn Auth & Trust spec ("MUST be rejected without exception")
- `ClockSkewTolerance` added to `signvalidator.Config`, defaulting to **5 s** when unset
- Startup warning logged if configured tolerance exceeds **10 s** (wider replay window)
- New config key `clockSkewToleranceSeconds` (integer, seconds) exposed in the plugin config block; validated at startup (non-negative integer only)
- CONFIG.md updated to document the new parameter

## Test plan

- [x] `go test ./pkg/plugin/implementation/signvalidator/...` passes
- [x] `created` 3 s in future accepted with default 5 s tolerance
- [x] `created` 7 s in future rejected with default 5 s tolerance
- [x] `expires` 1 s in past rejected even with large tolerance configured
- [x] Custom 10 s tolerance accepted via config
- [x] Invalid config values (`"5s"`, `"-1"`) rejected at startup
- [x] Deploy with no `config:` block — default 5 s behaviour confirmed