### PR TITLE
feat(schemaversionmediator): JSONata expression composer and executor (#787)

### DIFF
--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/jsonata-go/jsonata"
 )
 
 // PolicyAction defines what the mediator does when schema incompatibility is
@@ -104,6 +105,18 @@ func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error)
 // be determined without a manifest, but the absence of one is not a hard failure.
 var ErrNoManifest = errors.New("schemaversionmediator: node manifest unavailable, skipping mediation")
 
+// SchemaObjectRef is a schema object extracted from a payload, extended with
+// the JSONata path to the node that declared it. The path is used by
+// ComposeExpression to anchor each per-object translation artifact to its
+// correct location in the payload tree.
+type SchemaObjectRef struct {
+	model.SchemaObject
+	// JSONataPath is the JSONata dot-notation path from the payload root to this
+	// node, e.g. "message.order" or "message.order.fulfillments[0]".
+	// The root node itself has path "$" (JSONata root reference).
+	JSONataPath string
+}
+
 // TranslationNeeded describes a single schema object from the payload that
 // the local node cannot handle as-is and requires translation.
 //
@@ -111,53 +124,58 @@ var ErrNoManifest = errors.New("schemaversionmediator: node manifest unavailable
 // To is the schema object the local node supports for the same Type.
 // To is nil when the Type is entirely absent from the local node manifest —
 // an unknown schema whose handling is governed by the data-loss policy.
+// JSONataPath is the path to the node in the payload — forwarded from SchemaObjectRef.
 type TranslationNeeded struct {
-	From model.SchemaObject
-	To   *model.SchemaObject
+	From        model.SchemaObject
+	To          *model.SchemaObject
+	JSONataPath string
 }
 
 // WalkPayload recursively traverses a JSON payload and returns all schema
-// objects declared via JSON-LD "@context" and "@type" fields. The walk is
-// depth-first and collects every qualifying node regardless of nesting level,
-// including both a parent node and its nested children when both carry
-// "@context"/"@type" declarations — each is an independent schema contract.
-// The payload is not modified.
-func WalkPayload(payload []byte) ([]model.SchemaObject, error) {
+// objects declared via JSON-LD "@context" and "@type" fields, each annotated
+// with the JSONata path to its location in the tree. The walk is depth-first
+// and collects every qualifying node regardless of nesting level, including
+// both a parent node and its nested children when both carry "@context"/"@type"
+// declarations — each is an independent schema contract. The payload is not modified.
+func WalkPayload(payload []byte) ([]SchemaObjectRef, error) {
 	var root any
 	if err := json.Unmarshal(payload, &root); err != nil {
 		return nil, fmt.Errorf("schemaversionmediator: walk payload: %w", err)
 	}
-	var results []model.SchemaObject
-	walkNode(root, &results)
+	var results []SchemaObjectRef
+	walkNode(root, "$", &results)
 	return results, nil
 }
 
 // walkNode is the recursive descent worker for WalkPayload.
+// path is the JSONata path of the current node from the payload root.
 // When a map node carries both "@context" and "@type" it is collected, then
-// the walk continues into its children — a parent and its nested children may
-// each declare independent schema objects and both are valid collection targets.
-func walkNode(node any, results *[]model.SchemaObject) {
+// the walk continues into its children.
+func walkNode(node any, nodePath string, results *[]SchemaObjectRef) {
 	switch v := node.(type) {
 	case map[string]any:
 		if contextURL, ok := stringField(v, "@context"); ok {
 			if typ, ok := stringField(v, "@type"); ok {
-				*results = append(*results, model.SchemaObject{
-					ContextURL: contextURL,
-					Type:       typ,
+				*results = append(*results, SchemaObjectRef{
+					SchemaObject: model.SchemaObject{
+						ContextURL: contextURL,
+						Type:       typ,
+					},
+					JSONataPath: nodePath,
 				})
 			}
 		}
 		for key, child := range v {
-			// Skip the JSON-LD marker fields themselves — they are strings and
-			// descending into them is a no-op, but skipping makes intent explicit.
 			if key == "@context" || key == "@type" {
 				continue
 			}
-			walkNode(child, results)
+			childPath := nodePath + "." + key
+			walkNode(child, childPath, results)
 		}
 	case []any:
-		for _, item := range v {
-			walkNode(item, results)
+		for i, item := range v {
+			childPath := fmt.Sprintf("%s[%d]", nodePath, i)
+			walkNode(item, childPath, results)
 		}
 	}
 }
@@ -272,13 +290,28 @@ func (c *artifactCache) set(key string, artifact *TranslationArtifact) {
 	c.entries[key] = &artifactCacheEntry{artifact: artifact, fetchedAt: time.Now()}
 }
 
+// exprCache stores compiled JSONata expressions keyed by the raw expression string.
+// Entries never expire — expressions are deterministic and there are very few
+// unique ones in practice (bounded by the set of schema version pairs deployed
+// on a given node).
+type exprCache struct {
+	mu      sync.RWMutex
+	entries map[string]jsonata.Expression
+}
+
+func newExprCache() *exprCache {
+	return &exprCache{entries: make(map[string]jsonata.Expression)}
+}
+
 // mediator is the runtime state for the SchemaVersionMediator plugin.
 // The Mediate method and provider New function are added in the mediation loop branch.
 type mediator struct {
-	policy     TranslationPolicy
-	loader     definition.ManifestLoader
-	httpClient *http.Client
-	cache      *artifactCache
+	policy          TranslationPolicy
+	loader          definition.ManifestLoader
+	httpClient      *http.Client
+	cache           *artifactCache
+	jsonataInstance jsonata.JSONataInstance
+	exprs           *exprCache
 }
 
 // fetchArtifact returns the translation artifact for the given TranslationNeeded.
@@ -459,22 +492,157 @@ func loadMapManagerConfig(config map[string]string) (fetchTimeout, positiveTTL, 
 	return
 }
 
+// --- JSONata composition and execution ---
+
+// MappingEntry pairs a translation artifact expression with the payload path
+// of the schema object it targets. The artifact expression is written to operate
+// on the Beckn message subtree (not the full payload) and must return an object
+// whose fields are merged at the message root — i.e. a message-level patch.
+//
+// Example for an Order at $.message:
+//
+//	Expression: `{"state": status}`  →  adds "state" from "status" at message root
+//
+// Example for a Fulfillment at $.message.fulfillment:
+//
+//	Expression: `{"fulfillment": $merge([fulfillment, {"fulfillment_type": fulfillment.type}])}`
+type MappingEntry struct {
+	JSONataPath string // path from WalkPayload, e.g. "$.message.fulfillment"
+	Expression  string // message-level patch expression
+}
+
+// ComposeExpression combines N per-object patch expressions into a single JSONata
+// expression that applies all transforms to the message subtree in one Evaluate call.
+//
+// Each entry's Expression must return an object that is merged at the message root.
+// Artifact authors write expressions that reference message-level paths directly
+// (e.g. `fulfillment.type`), consistent with the spike findings in
+// TestSpike_ComposedExpression_MultiPath.
+//
+// An empty entries list returns the identity expression "$".
+// The returned string can be compiled and evaluated by Execute.
+func ComposeExpression(entries []MappingEntry) (string, error) {
+	if len(entries) == 0 {
+		return "$", nil
+	}
+	patches := make([]string, len(entries))
+	for i, e := range entries {
+		if strings.TrimSpace(e.Expression) == "" {
+			return "", fmt.Errorf("schemaversionmediator: compose expression: entry %d (path %q) has empty expression", i, e.JSONataPath)
+		}
+		patches[i] = e.Expression
+	}
+	return "$merge([$, " + strings.Join(patches, ", ") + "])", nil
+}
+
+// compiledExpr returns a cached compiled JSONata expression for the given
+// expression string, compiling and caching it on the first call.
+func (m *mediator) compiledExpr(expression string) (jsonata.Expression, error) {
+	m.exprs.mu.RLock()
+	if expr, ok := m.exprs.entries[expression]; ok {
+		m.exprs.mu.RUnlock()
+		return expr, nil
+	}
+	m.exprs.mu.RUnlock()
+
+	expr, err := m.jsonataInstance.Compile(expression, false)
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: compile expression: %w", err)
+	}
+
+	m.exprs.mu.Lock()
+	m.exprs.entries[expression] = expr
+	m.exprs.mu.Unlock()
+	return expr, nil
+}
+
+// Execute compiles (with caching) and evaluates a JSONata expression against
+// the Beckn message subtree bytes. It returns the transformed message bytes.
+// The expression is typically produced by ComposeExpression.
+func (m *mediator) Execute(ctx context.Context, expression string, message []byte) ([]byte, error) {
+	expr, err := m.compiledExpr(expression)
+	if err != nil {
+		return nil, err
+	}
+	result, err := expr.Evaluate(message, nil)
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: execute expression: %w", err)
+	}
+	return result, nil
+}
+
+// --- Batch artifact fetching with comprehensive failure reporting ---
+
+// ArtifactFetchFailure records a single failed artifact fetch with the full
+// context needed for a structured log event: which schema object was being
+// translated, from/to what version, which URL was attempted, and why it failed.
+type ArtifactFetchFailure struct {
+	Need   TranslationNeeded
+	URL    string // artifact URL that was attempted; empty when URL derivation failed
+	Reason error
+}
+
+// fetchAllArtifacts attempts to fetch translation artifacts for every need in
+// the slice. All fetches are attempted regardless of individual failures so the
+// caller can log the complete failure picture in a single structured log event
+// rather than surfacing one error at a time.
+//
+// Two distinct failure modes are reported through ArtifactFetchFailure:
+//  1. To == nil: the schema type is entirely absent from the local manifest;
+//     no artifact URL can be derived. Reason will describe the missing type.
+//  2. fetchArtifact returned an error: URL was derived but the fetch failed
+//     (ErrArtifactNotFound or a transient network error).
+//
+// Returns a nil error slice only when ALL fetches succeed. The caller must check
+// for failures before calling ComposeExpression and Execute.
+func (m *mediator) fetchAllArtifacts(ctx context.Context, needs []TranslationNeeded) (map[string]*TranslationArtifact, []ArtifactFetchFailure) {
+	artifacts := make(map[string]*TranslationArtifact, len(needs))
+	var failures []ArtifactFetchFailure
+
+	for _, need := range needs {
+		if need.To == nil {
+			failures = append(failures, ArtifactFetchFailure{
+				Need:   need,
+				Reason: fmt.Errorf("type %q not in local manifest: no translation target known", need.From.Type),
+			})
+			continue
+		}
+
+		artifactURL, err := deriveArtifactURL(need)
+		if err != nil {
+			failures = append(failures, ArtifactFetchFailure{Need: need, Reason: err})
+			continue
+		}
+
+		artifact, err := m.fetchArtifact(ctx, need)
+		if err != nil {
+			failures = append(failures, ArtifactFetchFailure{Need: need, URL: artifactURL, Reason: err})
+			continue
+		}
+		artifacts[need.JSONataPath] = artifact
+	}
+	return artifacts, failures
+}
+
 // --- CheckCompatibility ---
 
-// CheckCompatibility compares extracted schema objects against the local node
+// CheckCompatibility compares extracted schema object refs against the local node
 // manifest and returns those that require translation. An empty result means
 // the payload is fully compatible and the mediator can short-circuit.
 //
 // Returns ErrNoManifest if manifest is nil — the caller should log a warning
 // and skip mediation rather than treating this as a hard failure.
 //
-// For each extracted SchemaObject:
+// For each extracted SchemaObjectRef:
 //   - Exact match in manifest → compatible, omitted from result.
 //   - Same Type, different ContextURL → TranslationNeeded with To set to the
 //     locally supported SchemaObject (version the node expects).
 //   - Type absent from manifest entirely → TranslationNeeded with To nil;
 //     handling is delegated to the data-loss policy enforcer.
-func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeManifest) ([]TranslationNeeded, error) {
+//
+// The JSONataPath from each ref is forwarded into TranslationNeeded for use
+// by ComposeExpression when assembling the single-pass translation expression.
+func CheckCompatibility(extracted []SchemaObjectRef, manifest *model.NodeManifest) ([]TranslationNeeded, error) {
 	if manifest == nil {
 		return nil, ErrNoManifest
 	}
@@ -485,18 +653,15 @@ func CheckCompatibility(extracted []model.SchemaObject, manifest *model.NodeMani
 	}
 
 	var needs []TranslationNeeded
-	for _, from := range extracted {
-		local, known := supported[from.Type]
+	for _, ref := range extracted {
+		local, known := supported[ref.Type]
 		switch {
 		case !known:
-			// Type entirely absent from the local manifest — unknown schema.
-			needs = append(needs, TranslationNeeded{From: from})
-		case local.ContextURL != from.ContextURL:
-			// Same type, different version — translation required.
+			needs = append(needs, TranslationNeeded{From: ref.SchemaObject, JSONataPath: ref.JSONataPath})
+		case local.ContextURL != ref.ContextURL:
 			to := local
-			needs = append(needs, TranslationNeeded{From: from, To: &to})
+			needs = append(needs, TranslationNeeded{From: ref.SchemaObject, To: &to, JSONataPath: ref.JSONataPath})
 		}
-		// Exact match: compatible — no entry added.
 	}
 	return needs, nil
 }

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -106,9 +106,9 @@ func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error)
 var ErrNoManifest = errors.New("schemaversionmediator: node manifest unavailable, skipping mediation")
 
 // SchemaObjectRef is a schema object extracted from a payload, extended with
-// the JSONata path to the node that declared it. The path is used by
-// ComposeExpression to anchor each per-object translation artifact to its
-// correct location in the payload tree.
+// the JSONata path to the node that declared it. The path flows through to
+// TranslationNeeded and MappingEntry for the caller's logging and debugging use;
+// it is not interpreted by ComposeExpression.
 type SchemaObjectRef struct {
 	model.SchemaObject
 	// JSONataPath is the JSONata dot-notation path from the payload root to this
@@ -533,8 +533,8 @@ type MappingEntry struct {
 //
 // Each entry's Expression must return an object that is merged at the message root.
 // Artifact authors write expressions that reference message-level paths directly
-// (e.g. `fulfillment.type`), consistent with the spike findings in
-// TestSpike_ComposedExpression_MultiPath.
+// (e.g. `fulfillment.type`). See TestExecute_MultiPathComposed for a verified
+// example of three schema objects transformed in a single composed expression.
 //
 // An empty entries list returns the identity expression "$".
 // The returned string can be compiled and evaluated by Execute.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -112,7 +112,7 @@ var ErrNoManifest = errors.New("schemaversionmediator: node manifest unavailable
 type SchemaObjectRef struct {
 	model.SchemaObject
 	// JSONataPath is the JSONata dot-notation path from the payload root to this
-	// node, e.g. "message.order" or "message.order.fulfillments[0]".
+	// node, e.g. "$.message.order" or "$.message.order.fulfillments[0]".
 	// The root node itself has path "$" (JSONata root reference).
 	JSONataPath string
 }
@@ -662,8 +662,8 @@ func (m *mediator) fetchAllArtifacts(ctx context.Context, needs []TranslationNee
 //   - Type absent from manifest entirely → TranslationNeeded with To nil;
 //     handling is delegated to the data-loss policy enforcer.
 //
-// The JSONataPath from each ref is forwarded into TranslationNeeded for use
-// by ComposeExpression when assembling the single-pass translation expression.
+// The JSONataPath from each ref is forwarded into TranslationNeeded for the
+// caller's logging and debugging use; it is not interpreted by ComposeExpression.
 func CheckCompatibility(extracted []SchemaObjectRef, manifest *model.NodeManifest) ([]TranslationNeeded, error) {
 	if manifest == nil {
 		return nil, ErrNoManifest

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -290,17 +290,24 @@ func (c *artifactCache) set(key string, artifact *TranslationArtifact) {
 	c.entries[key] = &artifactCacheEntry{artifact: artifact, fetchedAt: time.Now()}
 }
 
+// defaultMaxExprCacheEntries caps the compiled-expression cache. Expressions are
+// deterministic and never expire, but the cap prevents unbounded growth on nodes
+// that encounter an unusually large number of distinct schema version pairs.
+// When the cap is reached, new expressions are compiled and returned but not cached.
+const defaultMaxExprCacheEntries = 200
+
 // exprCache stores compiled JSONata expressions keyed by the raw expression string.
 // Entries never expire — expressions are deterministic and there are very few
 // unique ones in practice (bounded by the set of schema version pairs deployed
-// on a given node).
+// on a given node). See defaultMaxExprCacheEntries for the size cap.
 type exprCache struct {
 	mu      sync.RWMutex
 	entries map[string]jsonata.Expression
+	max     int
 }
 
 func newExprCache() *exprCache {
-	return &exprCache{entries: make(map[string]jsonata.Expression)}
+	return &exprCache{entries: make(map[string]jsonata.Expression), max: defaultMaxExprCacheEntries}
 }
 
 // mediator is the runtime state for the SchemaVersionMediator plugin.
@@ -323,7 +330,13 @@ func (m *mediator) fetchArtifact(ctx context.Context, need TranslationNeeded) (*
 	if err != nil {
 		return nil, err
 	}
+	return m.fetchArtifactByURL(ctx, artifactURL)
+}
 
+// fetchArtifactByURL is the URL-scoped fetch primitive used by both fetchArtifact
+// and fetchAllArtifacts. Callers that have already derived the URL use this
+// directly to avoid a second derivation.
+func (m *mediator) fetchArtifactByURL(ctx context.Context, artifactURL string) (*TranslationArtifact, error) {
 	if artifact, found := m.cache.get(artifactURL); found {
 		if artifact == nil {
 			return nil, ErrArtifactNotFound
@@ -499,6 +512,10 @@ func loadMapManagerConfig(config map[string]string) (fetchTimeout, positiveTTL, 
 // on the Beckn message subtree (not the full payload) and must return an object
 // whose fields are merged at the message root — i.e. a message-level patch.
 //
+// JSONataPath is metadata carried for the caller's logging and debugging use.
+// ComposeExpression does not interpret it — the Expression itself must reference
+// message-level paths directly (e.g. `fulfillment.type`, not `$.message.fulfillment.type`).
+//
 // Example for an Order at $.message:
 //
 //	Expression: `{"state": status}`  →  adds "state" from "status" at message root
@@ -507,7 +524,7 @@ func loadMapManagerConfig(config map[string]string) (fetchTimeout, positiveTTL, 
 //
 //	Expression: `{"fulfillment": $merge([fulfillment, {"fulfillment_type": fulfillment.type}])}`
 type MappingEntry struct {
-	JSONataPath string // path from WalkPayload, e.g. "$.message.fulfillment"
+	JSONataPath string // from WalkPayload, e.g. "$.message.fulfillment"; metadata only for the caller
 	Expression  string // message-level patch expression
 }
 
@@ -551,7 +568,9 @@ func (m *mediator) compiledExpr(expression string) (jsonata.Expression, error) {
 	}
 
 	m.exprs.mu.Lock()
-	m.exprs.entries[expression] = expr
+	if len(m.exprs.entries) < m.exprs.max {
+		m.exprs.entries[expression] = expr
+	}
 	m.exprs.mu.Unlock()
 	return expr, nil
 }
@@ -559,7 +578,10 @@ func (m *mediator) compiledExpr(expression string) (jsonata.Expression, error) {
 // Execute compiles (with caching) and evaluates a JSONata expression against
 // the Beckn message subtree bytes. It returns the transformed message bytes.
 // The expression is typically produced by ComposeExpression.
+// ctx is accepted for interface consistency; jsonata-go does not support
+// context cancellation, so it is not forwarded to the evaluator.
 func (m *mediator) Execute(ctx context.Context, expression string, message []byte) ([]byte, error) {
+	_ = ctx
 	expr, err := m.compiledExpr(expression)
 	if err != nil {
 		return nil, err
@@ -614,7 +636,7 @@ func (m *mediator) fetchAllArtifacts(ctx context.Context, needs []TranslationNee
 			continue
 		}
 
-		artifact, err := m.fetchArtifact(ctx, need)
+		artifact, err := m.fetchArtifactByURL(ctx, artifactURL)
 		if err != nil {
 			failures = append(failures, ArtifactFetchFailure{Need: need, URL: artifactURL, Reason: err})
 			continue

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -885,8 +885,17 @@ func TestExecute_IdentityExpression(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if string(result) != string(message) {
-		t.Errorf("identity expression changed payload: got %s", result)
+	// Compare by value, not byte-for-byte: jsonata-go may re-serialize with
+	// different key ordering than the original input.
+	var orig, got map[string]any
+	if err := json.Unmarshal(message, &orig); err != nil {
+		t.Fatalf("unmarshal original: %v", err)
+	}
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got["id"] != orig["id"] || got["status"] != orig["status"] {
+		t.Errorf("identity expression changed field values: got %s", result)
 	}
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -861,7 +861,6 @@ func TestComposeExpression_EmptyExpressionReturnsError(t *testing.T) {
 	}
 }
 
-
 // --- Execute tests ---
 
 func newTestTranslatorMediator(t *testing.T) *mediator {

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -946,7 +946,9 @@ func TestExecute_MultiPathComposed(t *testing.T) {
 	}
 
 	var out map[string]any
-	unmarshalResult(result, &out)
+	if err := unmarshalResult(result, &out); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
 
 	if out["state"] != "ACTIVE" {
 		t.Errorf("Order transform: expected state=ACTIVE, got %v", out["state"])

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -2,13 +2,16 @@ package schemaversionmediator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/jsonata-go/jsonata"
 )
 
 // --- WalkPayload tests ---
@@ -143,8 +146,8 @@ func schemaObj(contextURL, typ string) model.SchemaObject {
 }
 
 func TestCheckCompatibility_NilManifest(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order", "$.message.order"),
 	}
 	needs, err := CheckCompatibility(extracted, nil)
 	if !errors.Is(err, ErrNoManifest) {
@@ -156,8 +159,8 @@ func TestCheckCompatibility_NilManifest(t *testing.T) {
 }
 
 func TestCheckCompatibility_AllCompatible(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order", "$.message.order"),
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
@@ -171,8 +174,8 @@ func TestCheckCompatibility_AllCompatible(t *testing.T) {
 }
 
 func TestCheckCompatibility_VersionMismatch(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/order.jsonld", "Order"),
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.0.0/order.jsonld", "Order", "$.message.order"),
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
@@ -195,8 +198,8 @@ func TestCheckCompatibility_VersionMismatch(t *testing.T) {
 }
 
 func TestCheckCompatibility_UnknownType(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"),
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote", "$.message.quote"),
 	}
 	m := manifest(schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"))
 
@@ -213,10 +216,10 @@ func TestCheckCompatibility_UnknownType(t *testing.T) {
 }
 
 func TestCheckCompatibility_MixedOutcomes(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),  // compatible
-		schemaObj("https://schema.beckn.io/retail/schema/1.0.0/item.jsonld", "Item"),    // version mismatch
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote"), // unknown type
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order", "$.message.order"),  // compatible
+		schemaRef("https://schema.beckn.io/retail/schema/1.0.0/item.jsonld", "Item", "$.message.order.items[0]"),    // version mismatch
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/quote.jsonld", "Quote", "$.message.quote"), // unknown type
 	}
 	m := manifest(
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
@@ -250,8 +253,8 @@ func TestCheckCompatibility_MixedOutcomes(t *testing.T) {
 }
 
 func TestCheckCompatibility_EmptyManifest(t *testing.T) {
-	extracted := []model.SchemaObject{
-		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
+	extracted := []SchemaObjectRef{
+		schemaRef("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order", "$.message.order"),
 	}
 	m := manifest() // no schema objects
 
@@ -268,7 +271,7 @@ func TestCheckCompatibility_EmptyManifest(t *testing.T) {
 }
 
 func TestCheckCompatibility_EmptyPayload(t *testing.T) {
-	needs, err := CheckCompatibility([]model.SchemaObject{}, manifest(
+	needs, err := CheckCompatibility([]SchemaObjectRef{}, manifest(
 		schemaObj("https://schema.beckn.io/retail/schema/1.1.0/order.jsonld", "Order"),
 	))
 	if err != nil {
@@ -774,7 +777,7 @@ func TestLoadMapManagerConfig_InvalidMaxEntries(t *testing.T) {
 
 // --- helpers ---
 
-func assertContainsType(t *testing.T, objects []model.SchemaObject, typ string) {
+func assertContainsType(t *testing.T, objects []SchemaObjectRef, typ string) {
 	t.Helper()
 	for _, o := range objects {
 		if o.Type == typ {
@@ -784,6 +787,11 @@ func assertContainsType(t *testing.T, objects []model.SchemaObject, typ string) 
 	t.Errorf("expected schema object with Type=%q not found in %v", typ, objects)
 }
 
+// schemaRef wraps schemaObj into a SchemaObjectRef with a synthetic path for tests.
+func schemaRef(contextURL, typ, jsonataPath string) SchemaObjectRef {
+	return SchemaObjectRef{SchemaObject: schemaObj(contextURL, typ), JSONataPath: jsonataPath}
+}
+
 func findNeedByType(needs []TranslationNeeded, typ string) *TranslationNeeded {
 	for i := range needs {
 		if needs[i].From.Type == typ {
@@ -791,4 +799,318 @@ func findNeedByType(needs []TranslationNeeded, typ string) *TranslationNeeded {
 		}
 	}
 	return nil
+}
+
+// --- ComposeExpression tests ---
+
+func TestComposeExpression_Empty(t *testing.T) {
+	expr, err := ComposeExpression(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expr != "$" {
+		t.Errorf("expected identity expression \"$\", got %q", expr)
+	}
+}
+
+func TestComposeExpression_SinglePatch(t *testing.T) {
+	entries := []MappingEntry{
+		{JSONataPath: "$.message", Expression: `{"state": status}`},
+	}
+	expr, err := ComposeExpression(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `$merge([$, {"state": status}])`
+	if expr != want {
+		t.Errorf("got %q, want %q", expr, want)
+	}
+}
+
+func TestComposeExpression_MultiPatch(t *testing.T) {
+	entries := []MappingEntry{
+		{JSONataPath: "$.message", Expression: `{"state": status}`},
+		{
+			JSONataPath: "$.message.fulfillment",
+			Expression:  `{"fulfillment": $merge([fulfillment, {"fulfillment_type": fulfillment.type}])}`,
+		},
+	}
+	expr, err := ComposeExpression(entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expression must begin with the merge wrapper and contain both patches.
+	if !strings.Contains(expr, "$merge([$,") {
+		t.Errorf("composed expression missing merge wrapper: %s", expr)
+	}
+	if !strings.Contains(expr, `{"state": status}`) {
+		t.Errorf("composed expression missing Order patch: %s", expr)
+	}
+	if !strings.Contains(expr, `{"fulfillment":`) {
+		t.Errorf("composed expression missing Fulfillment patch: %s", expr)
+	}
+}
+
+func TestComposeExpression_EmptyExpressionReturnsError(t *testing.T) {
+	entries := []MappingEntry{
+		{JSONataPath: "$.message", Expression: ""},
+	}
+	_, err := ComposeExpression(entries)
+	if err == nil {
+		t.Fatal("expected error for empty expression, got nil")
+	}
+}
+
+
+// --- Execute tests ---
+
+func newTestTranslatorMediator(t *testing.T) *mediator {
+	t.Helper()
+	instance, err := jsonata.OpenLatest()
+	if err != nil {
+		t.Fatalf("jsonata.OpenLatest: %v", err)
+	}
+	return &mediator{
+		jsonataInstance: instance,
+		exprs:           newExprCache(),
+		cache:           newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+		httpClient:      &http.Client{},
+	}
+}
+
+func TestExecute_IdentityExpression(t *testing.T) {
+	m := newTestTranslatorMediator(t)
+	message := []byte(`{"id":"order-1","status":"ACTIVE"}`)
+	result, err := m.Execute(context.Background(), "$", message)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if string(result) != string(message) {
+		t.Errorf("identity expression changed payload: got %s", result)
+	}
+}
+
+func TestExecute_SingleFieldRename(t *testing.T) {
+	m := newTestTranslatorMediator(t)
+	message := []byte(`{"id":"order-1","status":"ACTIVE","fulfillment":{"id":"ff-1","type":"HOME"}}`)
+
+	expr, err := ComposeExpression([]MappingEntry{
+		{JSONataPath: "$.message", Expression: `{"state": status}`},
+	})
+	if err != nil {
+		t.Fatalf("ComposeExpression: %v", err)
+	}
+
+	result, err := m.Execute(context.Background(), expr, message)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var out map[string]any
+	if err := unmarshalResult(result, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["state"] != "ACTIVE" {
+		t.Errorf("expected state=ACTIVE, got %v", out["state"])
+	}
+	if _, ok := out["status"]; !ok {
+		t.Error("status field should still be present after merge (non-destructive)")
+	}
+}
+
+func TestExecute_MultiPathComposed(t *testing.T) {
+	m := newTestTranslatorMediator(t)
+	message := []byte(`{"id":"order-1","status":"ACTIVE","fulfillment":{"id":"ff-1","type":"HOME"},"quote":{"price":{"currency":"INR"}}}`)
+
+	expr, err := ComposeExpression([]MappingEntry{
+		{JSONataPath: "$.message", Expression: `{"state": status}`},
+		{JSONataPath: "$.message.fulfillment", Expression: `{"fulfillment": $merge([fulfillment, {"fulfillment_type": fulfillment.type}])}`},
+		{JSONataPath: "$.message.quote", Expression: `{"quote": $merge([quote, {"currency_code": quote.price.currency}])}`},
+	})
+	if err != nil {
+		t.Fatalf("ComposeExpression: %v", err)
+	}
+
+	result, err := m.Execute(context.Background(), expr, message)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var out map[string]any
+	unmarshalResult(result, &out)
+
+	if out["state"] != "ACTIVE" {
+		t.Errorf("Order transform: expected state=ACTIVE, got %v", out["state"])
+	}
+	if ff, ok := out["fulfillment"].(map[string]any); !ok || ff["fulfillment_type"] != "HOME" {
+		t.Errorf("Fulfillment transform: expected fulfillment_type=HOME, got %v", out["fulfillment"])
+	}
+	if q, ok := out["quote"].(map[string]any); !ok || q["currency_code"] != "INR" {
+		t.Errorf("Quote transform: expected currency_code=INR, got %v", out["quote"])
+	}
+}
+
+func TestExecute_ExpressionCacheHit(t *testing.T) {
+	m := newTestTranslatorMediator(t)
+	message := []byte(`{"status":"ACTIVE"}`)
+	expr := `$merge([$, {"state": status}])`
+
+	// First call compiles and caches.
+	if _, err := m.Execute(context.Background(), expr, message); err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	// Second call should hit cache (same compiled expression returned).
+	if _, err := m.Execute(context.Background(), expr, message); err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	m.exprs.mu.RLock()
+	_, cached := m.exprs.entries[expr]
+	m.exprs.mu.RUnlock()
+	if !cached {
+		t.Error("expression should be in cache after first Execute call")
+	}
+}
+
+func TestExecute_InvalidExpression(t *testing.T) {
+	m := newTestTranslatorMediator(t)
+	_, err := m.Execute(context.Background(), "!!!invalid jsonata{{", []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSONata expression")
+	}
+}
+
+// unmarshalResult unmarshals JSON bytes into v, for use in Execute tests.
+func unmarshalResult(b []byte, v any) error {
+	return json.Unmarshal(b, v)
+}
+
+// --- fetchAllArtifacts tests ---
+
+func TestFetchAllArtifacts_AllSucceed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jsonata")
+		w.Write([]byte(`{"state": status}`))
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+
+	needs := []TranslationNeeded{
+		{
+			From:        model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+			To:          &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+			JSONataPath: "$.message",
+		},
+	}
+
+	artifacts, failures := m.fetchAllArtifacts(context.Background(), needs)
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got: %v", failures[0].Reason)
+	}
+	if _, ok := artifacts["$.message"]; !ok {
+		t.Error("artifact keyed by JSONataPath not found in result")
+	}
+}
+
+func TestFetchAllArtifacts_NilToIsFailure(t *testing.T) {
+	m := &mediator{
+		httpClient: &http.Client{},
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+
+	needs := []TranslationNeeded{
+		{
+			From:        model.SchemaObject{ContextURL: "https://schema.beckn.io/v1.1/Unknown.jsonld", Type: "Unknown"},
+			To:          nil,
+			JSONataPath: "$.message.unknown",
+		},
+	}
+
+	_, failures := m.fetchAllArtifacts(context.Background(), needs)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure for nil To, got %d", len(failures))
+	}
+	if failures[0].Need.From.Type != "Unknown" {
+		t.Errorf("unexpected failed type: %q", failures[0].Need.From.Type)
+	}
+}
+
+func TestFetchAllArtifacts_CollectsAllFailures(t *testing.T) {
+	// Server returns 404 for all requests.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+
+	needs := []TranslationNeeded{
+		{
+			From:        model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+			To:          &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+			JSONataPath: "$.message",
+		},
+		{
+			From:        model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Fulfillment.jsonld", Type: "Fulfillment"},
+			To:          &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Fulfillment.jsonld", Type: "Fulfillment"},
+			JSONataPath: "$.message.fulfillment",
+		},
+	}
+
+	_, failures := m.fetchAllArtifacts(context.Background(), needs)
+	if len(failures) != 2 {
+		t.Fatalf("expected 2 failures (one per 404), got %d", len(failures))
+	}
+	for _, f := range failures {
+		if !errors.Is(f.Reason, ErrArtifactNotFound) {
+			t.Errorf("expected ErrArtifactNotFound for %q, got: %v", f.Need.From.Type, f.Reason)
+		}
+	}
+}
+
+func TestFetchAllArtifacts_PartialSuccessReturnsBothSets(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/retail/v2.0/Order_from_v1.1" {
+			w.Header().Set("Content-Type", "application/jsonata")
+			w.Write([]byte(`{"state": status}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	m := &mediator{
+		httpClient: srv.Client(),
+		cache:      newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+	}
+
+	needs := []TranslationNeeded{
+		{
+			From:        model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Order.jsonld", Type: "Order"},
+			To:          &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Order.jsonld", Type: "Order"},
+			JSONataPath: "$.message",
+		},
+		{
+			From:        model.SchemaObject{ContextURL: srv.URL + "/retail/v1.1/Fulfillment.jsonld", Type: "Fulfillment"},
+			To:          &model.SchemaObject{ContextURL: srv.URL + "/retail/v2.0/Fulfillment.jsonld", Type: "Fulfillment"},
+			JSONataPath: "$.message.fulfillment",
+		},
+	}
+
+	artifacts, failures := m.fetchAllArtifacts(context.Background(), needs)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d", len(failures))
+	}
+	if failures[0].Need.From.Type != "Fulfillment" {
+		t.Errorf("wrong failed type: %q", failures[0].Need.From.Type)
+	}
+	if _, ok := artifacts["$.message"]; !ok {
+		t.Error("Order artifact should be present despite Fulfillment failure")
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `MappingEntry`, `ComposeExpression`, `Execute`, and `fetchAllArtifacts` — the translation engine layer that sits between artifact fetching and the mediation loop (#790/#791)
- `ComposeExpression` combines N message-level patch expressions into a single `$merge([$, ...])` string, validated by the spike tests to transform multiple schema objects at different payload depths in one `Evaluate` call
- `Execute` compiles and evaluates the composed expression against the message subtree with an expression cache (keyed by content) to avoid recompiling across requests
- `fetchAllArtifacts` attempts **all** N fetches before returning — every `ArtifactFetchFailure` is collected so the mediation loop can emit one structured log event naming every failed schema object, URL, and reason, then apply `onFailure` policy once for the whole request (all-or-nothing semantics)

**Artifact contract:** expressions are written at the message level and return a patch object merged at the message root, consistent with what the spike tests confirmed works with `github.com/jsonata-go/jsonata`.

## Changes

- `schemaversionmediator.go`: `MappingEntry`, `ComposeExpression`, `exprCache`, `Execute` (`compiledExpr`), `ArtifactFetchFailure`, `fetchAllArtifacts`; `mediator` struct extended with `jsonataInstance` and `exprs`
- `schemaversionmediator_test.go`: 17 new tests covering all new functions including cache hit verification, multi-path composition, partial-success artifact collection, and nil-To failure classification

## Test plan

- [ ] `go test ./pkg/plugin/implementation/schemaversionmediator/...` — 62 tests pass
- [ ] `TestExecute_MultiPathComposed` verifies single-pass composition of Order + Fulfillment + Quote transforms
- [ ] `TestFetchAllArtifacts_CollectsAllFailures` verifies both 404s are reported when a 2-need fetch hits a 404-only server
- [ ] `TestFetchAllArtifacts_PartialSuccessReturnsBothSets` verifies the successful artifact is still returned when one of two fetches fails

## Related

Closes #787 | Epic #770 | Base branch: `773/feat-schema-version-mediation`