### PR TITLE
feat(schemaversionmediator): inbound mediation loop, cold-start guard, data-loss enforcement (#790)

### DIFF
--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,9 +33,10 @@ const (
 	// PolicyActionTranslate attempts translation for each incompatible schema
 	// object. On failure the OnFailure policy applies.
 	PolicyActionTranslate PolicyAction = "translate"
-	// PolicyActionPassIncompatible forwards the request as-is with a structured
-	// log signal indicating which schema objects were not translated.
-	PolicyActionPassIncompatible PolicyAction = "pass_incompatible"
+	// PolicyActionPassThrough forwards the request as-is with a structured log
+	// signal. Valid only as onFailure — used when no artifact is published yet
+	// and the operator accepts the risk of forwarding an untranslated payload.
+	PolicyActionPassThrough PolicyAction = "passThrough"
 )
 
 // TranslationPolicy governs mediator behaviour when schema incompatibilities
@@ -62,10 +64,11 @@ var defaultPolicy = TranslationPolicy{
 // Config keys: "action" and "onFailure". Both are optional — absent keys fall
 // back to the default policy (translate/reject).
 //
-// Valid values for action:    reject | translate | pass_incompatible
-// Valid values for onFailure: reject | pass_incompatible (only validated when action=translate;
+// Valid values for action:    reject | translate
+// Valid values for onFailure: reject | passThrough (only validated when action=translate;
 // ignored otherwise since no translation is ever attempted)
 // Setting onFailure to "translate" is not permitted — it would cause a loop.
+// "passThrough" is not a valid action — it may only appear as onFailure.
 func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error) {
 	p := &TranslationPolicy{
 		Action:    defaultPolicy.Action,
@@ -74,10 +77,12 @@ func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error)
 
 	if raw, ok := config["action"]; ok {
 		switch PolicyAction(raw) {
-		case PolicyActionReject, PolicyActionTranslate, PolicyActionPassIncompatible:
+		case PolicyActionReject, PolicyActionTranslate:
 			p.Action = PolicyAction(raw)
+		case PolicyActionPassThrough:
+			return nil, fmt.Errorf("schemaversionmediator: action cannot be %q — passThrough is only valid as onFailure", raw)
 		default:
-			return nil, fmt.Errorf("schemaversionmediator: invalid action %q: must be reject, translate, or pass_incompatible", raw)
+			return nil, fmt.Errorf("schemaversionmediator: invalid action %q: must be reject or translate", raw)
 		}
 	}
 
@@ -87,12 +92,12 @@ func loadTranslationPolicy(config map[string]string) (*TranslationPolicy, error)
 	if p.Action == PolicyActionTranslate {
 		if raw, ok := config["onFailure"]; ok {
 			switch PolicyAction(raw) {
-			case PolicyActionReject, PolicyActionPassIncompatible:
+			case PolicyActionReject, PolicyActionPassThrough:
 				p.OnFailure = PolicyAction(raw)
 			case PolicyActionTranslate:
 				return nil, fmt.Errorf("schemaversionmediator: onFailure cannot be %q — would cause a translation loop", raw)
 			default:
-				return nil, fmt.Errorf("schemaversionmediator: invalid onFailure %q: must be reject or pass_incompatible", raw)
+				return nil, fmt.Errorf("schemaversionmediator: invalid onFailure %q: must be reject or passThrough", raw)
 			}
 		}
 	}
@@ -311,7 +316,6 @@ func newExprCache() *exprCache {
 }
 
 // mediator is the runtime state for the SchemaVersionMediator plugin.
-// The Mediate method and provider New function are added in the mediation loop branch.
 type mediator struct {
 	policy          TranslationPolicy
 	loader          definition.ManifestLoader
@@ -319,6 +323,304 @@ type mediator struct {
 	cache           *artifactCache
 	jsonataInstance jsonata.JSONataInstance
 	exprs           *exprCache
+	notOnboarded    bool // set at New() when local manifest is absent or has no schemaObjects
+}
+
+// provider is the factory for mediator instances. It implements
+// definition.SchemaVersionMediatorProvider.
+type provider struct{}
+
+// New constructs a mediator, validates config, and performs the cold-start
+// check. If the local node manifest is absent or carries no schemaObjects the
+// mediator's notOnboarded flag is set; Mediate will reject every inbound
+// request until the manifest is published and the adapter is restarted.
+func (p *provider) New(ctx context.Context, loader definition.ManifestLoader, cfg map[string]string) (definition.SchemaVersionMediator, func() error, error) {
+	policy, err := loadTranslationPolicy(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fetchTimeout, positiveTTL, negativeTTL, maxEntries, err := loadMapManagerConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	instance, err := jsonata.OpenLatest()
+	if err != nil {
+		return nil, nil, fmt.Errorf("schemaversionmediator: open jsonata: %w", err)
+	}
+
+	m := &mediator{
+		policy:          *policy,
+		loader:          loader,
+		httpClient:      httpClientFunc(fetchTimeout),
+		cache:           newArtifactCache(positiveTTL, negativeTTL, maxEntries),
+		jsonataInstance: instance,
+		exprs:           newExprCache(),
+	}
+
+	// Cold-start check: attempt to load the local node manifest. If it is
+	// absent or has no schemaObjects, mark as not onboarded so Mediate rejects
+	// every inbound call with a clear error rather than silently pass-through.
+	nodeID := cfg["nodeId"]
+	if nodeID == "" {
+		m.notOnboarded = true
+	} else {
+		doc, err := loader.GetBySubscriberID(ctx, nodeID)
+		if err != nil || doc == nil {
+			m.notOnboarded = true
+		} else {
+			nm, err := parseNodeManifest(doc)
+			if err != nil || len(nm.Schema.SchemaObjects) == 0 {
+				m.notOnboarded = true
+			}
+		}
+	}
+
+	return m, func() error { return nil }, nil
+}
+
+// Mediate runs the full inbound schema version mediation sequence on ctx.Body.
+// It is direction-agnostic: the caller (BAPCaller / BPPCaller handler) invokes
+// it for inbound payloads; the response path uses RunOnResponse (not yet implemented).
+func (m *mediator) Mediate(ctx *model.StepContext) error {
+	if m.notOnboarded {
+		return &MediationError{
+			Code:    "subscriberNotOnboarded",
+			Message: "Local node manifest is missing or has no schemaObjects. Publish your manifest to DeDi before going live.",
+		}
+	}
+
+	networkID := extractNetworkID(ctx.Body)
+	counterpartyID, _ := ctx.Value(model.ContextKeyRemoteID).(string)
+
+	// No policy match → pass through unchanged.
+	if networkID == "" || counterpartyID == "" {
+		return nil
+	}
+
+	// Fetch counterparty manifest. Absent manifest drives onFailure branch.
+	counterpartyManifest, err := m.fetchCounterpartyManifest(ctx, counterpartyID)
+	if err != nil {
+		return m.applyOnFailure(fmt.Errorf("schemaversionmediator: counterparty manifest unavailable for %q: %w", counterpartyID, err))
+	}
+
+	refs, err := WalkPayload(ctx.Body)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: walk payload: %w", err)
+	}
+
+	needs, err := CheckCompatibility(refs, counterpartyManifest)
+	if err != nil {
+		return err
+	}
+	if len(needs) == 0 {
+		return nil // fully compatible
+	}
+
+	if m.policy.Action == PolicyActionReject {
+		return &MediationError{
+			Code:    "schemaIncompatible",
+			Message: fmt.Sprintf("payload contains %d incompatible schema object(s) and policy is reject", len(needs)),
+		}
+	}
+
+	// Fetch all translation artifacts; any failure applies onFailure policy.
+	artifacts, failures := m.fetchAllArtifacts(ctx, needs)
+	if len(failures) > 0 {
+		return m.applyOnFailure(fmt.Errorf("schemaversionmediator: %d artifact fetch failure(s): first: %w", len(failures), failures[0].Reason))
+	}
+
+	// Build mapping entries from artifacts (JSONata content-type only for now).
+	entries := make([]MappingEntry, 0, len(artifacts))
+	for jsonataPath, artifact := range artifacts {
+		entries = append(entries, MappingEntry{
+			JSONataPath: jsonataPath,
+			Expression:  string(artifact.Content),
+		})
+	}
+
+	expression, err := ComposeExpression(entries)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: compose expression: %w", err)
+	}
+
+	msgBytes, err := extractMessageSubtree(ctx.Body)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: extract message subtree: %w", err)
+	}
+
+	translated, err := m.Execute(ctx, expression, msgBytes)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: execute translation: %w", err)
+	}
+
+	dropped, err := droppedFields(msgBytes, translated)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: data-loss detection: %w", err)
+	}
+	if len(dropped) > 0 {
+		return &MediationError{
+			Code:         "schemaTranslationDataLoss",
+			Message:      "translation dropped fields that were present in the source payload",
+			DroppedFields: dropped,
+		}
+	}
+
+	patched, err := patchMessageSubtree(ctx.Body, translated)
+	if err != nil {
+		return fmt.Errorf("schemaversionmediator: patch message subtree: %w", err)
+	}
+	ctx.Body = patched
+	return nil
+}
+
+// applyOnFailure returns the appropriate error or nil depending on policy.OnFailure.
+// cause is retained for the wrapped error chain but not surfaced in the
+// user-facing MediationError.Message to avoid leaking internal detail.
+func (m *mediator) applyOnFailure(cause error) error {
+	if m.policy.OnFailure == PolicyActionPassThrough {
+		return nil
+	}
+	return &MediationError{
+		Code:    "schemaIncompatible",
+		Message: "schema version mediation failed; check adapter logs for details",
+		cause:   cause,
+	}
+}
+
+// fetchCounterpartyManifest fetches and parses the counterparty's node manifest
+// via the manifest loader.
+func (m *mediator) fetchCounterpartyManifest(ctx context.Context, counterpartyID string) (*model.NodeManifest, error) {
+	doc, err := m.loader.GetBySubscriberID(ctx, counterpartyID)
+	if err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("no manifest document returned")
+	}
+	return parseNodeManifest(doc)
+}
+
+// parseNodeManifest parses the raw YAML content of a ManifestDocument into a NodeManifest.
+func parseNodeManifest(doc *model.ManifestDocument) (*model.NodeManifest, error) {
+	nm, err := model.ParseNodeManifest(doc.Content)
+	if err != nil {
+		return nil, fmt.Errorf("schemaversionmediator: parse node manifest: %w", err)
+	}
+	return nm, nil
+}
+
+// extractNetworkID reads context.network_id / context.networkId from a Beckn payload.
+func extractNetworkID(body []byte) string {
+	var envelope struct {
+		Context map[string]json.RawMessage `json:"context"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
+	}
+	for _, key := range []string{"network_id", "networkId"} {
+		if raw, ok := envelope.Context[key]; ok {
+			var s string
+			if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// extractMessageSubtree returns the raw JSON bytes of the "message" field from
+// a Beckn payload. Returns an error if "message" is absent.
+func extractMessageSubtree(body []byte) ([]byte, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	msg, ok := envelope["message"]
+	if !ok {
+		return nil, fmt.Errorf("payload has no \"message\" field")
+	}
+	return msg, nil
+}
+
+// patchMessageSubtree replaces the "message" value in body with translated and
+// returns the re-serialised full payload.
+func patchMessageSubtree(body, translated []byte) ([]byte, error) {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
+	envelope["message"] = translated
+	return json.Marshal(envelope)
+}
+
+// MediationError is a structured rejection returned by Mediate. It carries a
+// camelCase error code and a human-readable message so the handler can build a
+// Beckn NACK response with the correct fault details. cause is the underlying
+// technical error; it is available via errors.Unwrap for logging but is not
+// exposed in the user-facing Message.
+type MediationError struct {
+	Code          string
+	Message       string
+	DroppedFields []string // non-nil only for schemaTranslationDataLoss
+	cause         error    // internal; use errors.Unwrap to access
+}
+
+func (e *MediationError) Error() string {
+	if len(e.DroppedFields) > 0 {
+		return fmt.Sprintf("schemaversionmediator: %s: %s (dropped: %s)", e.Code, e.Message, strings.Join(e.DroppedFields, ", "))
+	}
+	return fmt.Sprintf("schemaversionmediator: %s: %s", e.Code, e.Message)
+}
+
+func (e *MediationError) Unwrap() error { return e.cause }
+
+// droppedFields returns the sorted set of dot-notation key paths that are
+// present in src but absent in dst. Both must be JSON object bytes.
+// Arrays are treated as opaque leaf values — element-level drops within an
+// array are not detected. Only object key presence is compared.
+func droppedFields(src, dst []byte) ([]string, error) {
+	var srcMap, dstMap map[string]any
+	if err := json.Unmarshal(src, &srcMap); err != nil {
+		return nil, fmt.Errorf("unmarshal source: %w", err)
+	}
+	if err := json.Unmarshal(dst, &dstMap); err != nil {
+		return nil, fmt.Errorf("unmarshal translated: %w", err)
+	}
+	srcKeys := flattenKeyPaths(srcMap, "")
+	dstKeys := flattenKeyPaths(dstMap, "")
+	dstSet := make(map[string]struct{}, len(dstKeys))
+	for _, k := range dstKeys {
+		dstSet[k] = struct{}{}
+	}
+	var dropped []string
+	for _, k := range srcKeys {
+		if _, ok := dstSet[k]; !ok {
+			dropped = append(dropped, k)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped, nil
+}
+
+// flattenKeyPaths recursively collects all dot-notation leaf paths from a
+// JSON object tree. Array elements are not indexed — array presence is
+// tracked at the array key level only.
+func flattenKeyPaths(v map[string]any, prefix string) []string {
+	var keys []string
+	for k, child := range v {
+		full := k
+		if prefix != "" {
+			full = prefix + "." + k
+		}
+		if nested, ok := child.(map[string]any); ok {
+			keys = append(keys, flattenKeyPaths(nested, full)...)
+		} else {
+			keys = append(keys, full)
+		}
+	}
+	return keys
 }
 
 // fetchArtifact returns the translation artifact for the given TranslationNeeded.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -14,6 +14,26 @@ import (
 	"github.com/jsonata-go/jsonata"
 )
 
+// mockManifestLoader is a test double for definition.ManifestLoader.
+type mockManifestLoader struct {
+	bySubscriberID func(ctx context.Context, subscriberID string) (*model.ManifestDocument, error)
+}
+
+func (m *mockManifestLoader) GetBySubscriberID(ctx context.Context, subscriberID string) (*model.ManifestDocument, error) {
+	if m.bySubscriberID != nil {
+		return m.bySubscriberID(ctx, subscriberID)
+	}
+	return nil, nil
+}
+
+func (m *mockManifestLoader) GetByNetworkID(ctx context.Context, networkID string) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+
+func (m *mockManifestLoader) GetByMetadata(ctx context.Context, metadata model.ManifestMetadata) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+
 // --- WalkPayload tests ---
 
 func TestWalkPayload_SingleObject(t *testing.T) {
@@ -298,7 +318,7 @@ func TestLoadTranslationPolicy_Defaults(t *testing.T) {
 }
 
 func TestLoadTranslationPolicy_AllValidActions(t *testing.T) {
-	for _, action := range []PolicyAction{PolicyActionReject, PolicyActionTranslate, PolicyActionPassIncompatible} {
+	for _, action := range []PolicyAction{PolicyActionReject, PolicyActionTranslate} {
 		p, err := loadTranslationPolicy(map[string]string{"action": string(action)})
 		if err != nil {
 			t.Errorf("action=%q: unexpected error: %v", action, err)
@@ -310,8 +330,15 @@ func TestLoadTranslationPolicy_AllValidActions(t *testing.T) {
 	}
 }
 
+func TestLoadTranslationPolicy_PassThroughAsActionRejected(t *testing.T) {
+	_, err := loadTranslationPolicy(map[string]string{"action": "passThrough"})
+	if err == nil {
+		t.Fatal("expected error when action=passThrough, got nil")
+	}
+}
+
 func TestLoadTranslationPolicy_ValidOnFailure(t *testing.T) {
-	for _, onFailure := range []PolicyAction{PolicyActionReject, PolicyActionPassIncompatible} {
+	for _, onFailure := range []PolicyAction{PolicyActionReject, PolicyActionPassThrough} {
 		p, err := loadTranslationPolicy(map[string]string{
 			"action":    "translate",
 			"onFailure": string(onFailure),
@@ -348,20 +375,17 @@ func TestLoadTranslationPolicy_OnFailureTranslateRejected(t *testing.T) {
 }
 
 func TestLoadTranslationPolicy_OnFailureIgnoredWhenActionNotTranslate(t *testing.T) {
-	// onFailure is meaningless when action=reject or pass_incompatible.
-	// A stale/invalid onFailure key must not produce an error in those cases.
-	for _, action := range []PolicyAction{PolicyActionReject, PolicyActionPassIncompatible} {
-		p, err := loadTranslationPolicy(map[string]string{
-			"action":    string(action),
-			"onFailure": "unknown_value",
-		})
-		if err != nil {
-			t.Errorf("action=%q: expected no error for stale onFailure key, got %v", action, err)
-			continue
-		}
-		if p.Action != action {
-			t.Errorf("action=%q: got %q", action, p.Action)
-		}
+	// onFailure is meaningless when action=reject.
+	// A stale/invalid onFailure key must not produce an error in that case.
+	p, err := loadTranslationPolicy(map[string]string{
+		"action":    "reject",
+		"onFailure": "unknown_value",
+	})
+	if err != nil {
+		t.Errorf("action=reject: expected no error for stale onFailure key, got %v", err)
+	}
+	if p != nil && p.Action != PolicyActionReject {
+		t.Errorf("action=reject: got %q", p.Action)
 	}
 }
 
@@ -1122,5 +1146,418 @@ func TestFetchAllArtifacts_PartialSuccessReturnsBothSets(t *testing.T) {
 	}
 	if _, ok := artifacts["$.message"]; !ok {
 		t.Error("Order artifact should be present despite Fulfillment failure")
+	}
+}
+
+// --- provider.New / cold-start tests ---
+
+// nodeManifestDoc returns a ManifestDocument whose Content is a valid node
+// manifest YAML parseable by model.ParseNodeManifest. YAML keys match the
+// struct tags in model.NodeManifest (camelCase).
+func nodeManifestDoc(objects ...model.SchemaObject) *model.ManifestDocument {
+	var sb strings.Builder
+	sb.WriteString("manifestType: node-manifest\n")
+	sb.WriteString("schema:\n  schemaObjects:\n")
+	for _, o := range objects {
+		sb.WriteString("  - contextUrl: " + o.ContextURL + "\n")
+		sb.WriteString("    type: " + o.Type + "\n")
+	}
+	return &model.ManifestDocument{Content: []byte(sb.String())}
+}
+
+func TestNew_ColdStart_LoaderError(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nil, errors.New("dedi unavailable")
+		},
+	}
+	p := &provider{}
+	svm, _, err := p.New(context.Background(), loader, map[string]string{"nodeId": "test-node"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	med := svm.(*mediator)
+	if !med.notOnboarded {
+		t.Error("expected notOnboarded=true when loader returns error")
+	}
+}
+
+func TestNew_ColdStart_EmptySchemaObjects(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc( /* no objects */ ), nil
+		},
+	}
+	p := &provider{}
+	svm, _, err := p.New(context.Background(), loader, map[string]string{"nodeId": "test-node"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	med := svm.(*mediator)
+	if !med.notOnboarded {
+		t.Error("expected notOnboarded=true when manifest has no schemaObjects")
+	}
+}
+
+func TestNew_ColdStart_MissingNodeId(t *testing.T) {
+	p := &provider{}
+	svm, _, err := p.New(context.Background(), &mockManifestLoader{}, map[string]string{})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	med := svm.(*mediator)
+	if !med.notOnboarded {
+		t.Error("expected notOnboarded=true when nodeId config key is absent")
+	}
+}
+
+func TestNew_ValidManifest_NotOnboarded_False(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+	p := &provider{}
+	svm, _, err := p.New(context.Background(), loader, map[string]string{"nodeId": "test-node"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	med := svm.(*mediator)
+	if med.notOnboarded {
+		t.Error("expected notOnboarded=false for valid manifest with schemaObjects")
+	}
+}
+
+// --- Mediate tests ---
+
+// buildPayload builds a minimal Beckn JSON body with the given network_id and
+// optional message-level schema object declaration.
+func buildPayload(networkID, counterpartyID string, msgContextURL, msgType string) []byte {
+	msg := `{}`
+	if msgContextURL != "" {
+		msg = `{"@context":"` + msgContextURL + `","@type":"` + msgType + `"}`
+	}
+	return []byte(`{"context":{"network_id":"` + networkID + `","bap_id":"` + counterpartyID + `"},"message":` + msg + `}`)
+}
+
+func newTestMediatorFull(t *testing.T, loader *mockManifestLoader, cfg map[string]string) *mediator {
+	t.Helper()
+	instance, err := jsonata.OpenLatest()
+	if err != nil {
+		t.Fatalf("jsonata.OpenLatest: %v", err)
+	}
+	policy, err := loadTranslationPolicy(cfg)
+	if err != nil {
+		t.Fatalf("loadTranslationPolicy: %v", err)
+	}
+	return &mediator{
+		policy:          *policy,
+		loader:          loader,
+		httpClient:      &http.Client{},
+		cache:           newArtifactCache(defaultPositiveTTL, defaultNegativeTTL, defaultMaxCacheEntries),
+		jsonataInstance: instance,
+		exprs:           newExprCache(),
+	}
+}
+
+func stepCtxWithRemoteID(body []byte, remoteID string) *model.StepContext {
+	ctx := context.WithValue(context.Background(), model.ContextKeyRemoteID, remoteID)
+	return &model.StepContext{
+		Context: ctx,
+		Body:    body,
+	}
+}
+
+func TestMediate_NotOnboarded(t *testing.T) {
+	m := &mediator{notOnboarded: true}
+	err := m.Mediate(&model.StepContext{Context: context.Background(), Body: []byte(`{}`)})
+	var me *MediationError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MediationError, got %T: %v", err, err)
+	}
+	if me.Code != "subscriberNotOnboarded" {
+		t.Errorf("expected subscriberNotOnboarded, got %q", me.Code)
+	}
+}
+
+func TestMediate_NoNetworkID_PassThrough(t *testing.T) {
+	m := newTestMediatorFull(t, &mockManifestLoader{}, map[string]string{})
+	body := []byte(`{"context":{},"message":{}}`)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	if err := m.Mediate(ctx); err != nil {
+		t.Fatalf("expected pass-through (nil), got: %v", err)
+	}
+}
+
+func TestMediate_NetworkIdCamelCase_Recognised(t *testing.T) {
+	// networkId (camelCase) must be accepted in addition to network_id (snake_case).
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nil, errors.New("dedi lookup failed")
+		},
+	}
+	m := newTestMediatorFull(t, loader, map[string]string{"onFailure": "reject"})
+	// Use camelCase networkId key.
+	body := []byte(`{"context":{"networkId":"net1"},"message":{}}`)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	// Expecting schemaIncompatible (not pass-through) proves networkId was read.
+	err := m.Mediate(ctx)
+	var me *MediationError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MediationError (networkId recognised), got %T: %v", err, err)
+	}
+	if me.Code != "schemaIncompatible" {
+		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	}
+}
+
+func TestMediate_NoCounterpartyID_PassThrough(t *testing.T) {
+	m := newTestMediatorFull(t, &mockManifestLoader{}, map[string]string{})
+	body := []byte(`{"context":{"network_id":"net1"},"message":{}}`)
+	sctx := &model.StepContext{Context: context.Background(), Body: body}
+	if err := m.Mediate(sctx); err != nil {
+		t.Fatalf("expected pass-through (nil), got: %v", err)
+	}
+}
+
+func TestMediate_CounterpartyManifestUnavailable_Reject(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nil, errors.New("dedi lookup failed")
+		},
+	}
+	m := newTestMediatorFull(t, loader, map[string]string{"onFailure": "reject"})
+	body := buildPayload("net1", "bap.example.com", "", "")
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	err := m.Mediate(ctx)
+	var me *MediationError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MediationError, got %T: %v", err, err)
+	}
+	if me.Code != "schemaIncompatible" {
+		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	}
+}
+
+func TestMediate_CounterpartyManifestUnavailable_PassThrough(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nil, errors.New("dedi lookup failed")
+		},
+	}
+	m := newTestMediatorFull(t, loader, map[string]string{"onFailure": "passThrough"})
+	body := buildPayload("net1", "bap.example.com", "", "")
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	if err := m.Mediate(ctx); err != nil {
+		t.Fatalf("expected pass-through (nil), got: %v", err)
+	}
+}
+
+func TestMediate_AllCompatible_PassThrough(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: "https://schema.beckn.io/retail/v2.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+	m := newTestMediatorFull(t, loader, map[string]string{})
+	body := buildPayload("net1", "bap.example.com",
+		"https://schema.beckn.io/retail/v2.0/Order.jsonld", "Order")
+	original := string(body)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	if err := m.Mediate(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(ctx.Body) != original {
+		t.Error("body should be unchanged when all schema objects are compatible")
+	}
+}
+
+func TestMediate_ActionReject_OnIncompatible(t *testing.T) {
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			// counterparty is on v1.0, we are on v2.0 — mismatch
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: "https://schema.beckn.io/retail/v1.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+	m := newTestMediatorFull(t, loader, map[string]string{"action": "reject"})
+	body := buildPayload("net1", "bap.example.com",
+		"https://schema.beckn.io/retail/v2.0/Order.jsonld", "Order")
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	err := m.Mediate(ctx)
+	var me *MediationError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MediationError, got %T: %v", err, err)
+	}
+	if me.Code != "schemaIncompatible" {
+		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	}
+}
+
+func TestMediate_ArtifactNotFound_Reject(t *testing.T) {
+	// Artifact server returns 404 for all requests.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// Loader returns a manifest whose ContextURL is on srv so the derived
+	// artifact URL points at srv and the 404 is actually exercised.
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: srv.URL + "/retail/v1.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+
+	m := newTestMediatorFull(t, loader, map[string]string{"onFailure": "reject"})
+	m.httpClient = srv.Client()
+
+	body := []byte(`{"context":{"network_id":"net1"},"message":{"@context":"` +
+		srv.URL + `/retail/v2.0/Order.jsonld","@type":"Order"}}`)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	err := m.Mediate(ctx)
+	var me *MediationError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected MediationError, got %T: %v", err, err)
+	}
+	if me.Code != "schemaIncompatible" {
+		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	}
+}
+
+func TestMediate_ArtifactNotFound_PassThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: srv.URL + "/retail/v1.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+
+	m := newTestMediatorFull(t, loader, map[string]string{"onFailure": "passThrough"})
+	m.httpClient = srv.Client()
+
+	body := []byte(`{"context":{"network_id":"net1"},"message":{"@context":"` +
+		srv.URL + `/retail/v2.0/Order.jsonld","@type":"Order"}}`)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+	if err := m.Mediate(ctx); err != nil {
+		t.Fatalf("expected pass-through (nil), got: %v", err)
+	}
+}
+
+func TestMediate_TranslationApplied(t *testing.T) {
+	// Artifact server returns a JSONata expression that adds "state" from "status".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jsonata")
+		w.Write([]byte(`{"state": status}`))
+	}))
+	defer srv.Close()
+
+	// Counterparty manifest is on v1.0 (srv-hosted URLs); inbound payload declares
+	// v2.0 URLs → mismatch, artifact fetch goes to srv, translation applied.
+	loader := &mockManifestLoader{
+		bySubscriberID: func(_ context.Context, _ string) (*model.ManifestDocument, error) {
+			return nodeManifestDoc(model.SchemaObject{
+				ContextURL: srv.URL + "/retail/v1.0/Order.jsonld",
+				Type:       "Order",
+			}), nil
+		},
+	}
+
+	m := newTestMediatorFull(t, loader, map[string]string{})
+	m.httpClient = srv.Client()
+
+	body := []byte(`{"context":{"network_id":"net1"},"message":{"@context":"` +
+		srv.URL + `/retail/v2.0/Order.jsonld","@type":"Order","status":"ACTIVE"}}`)
+	ctx := stepCtxWithRemoteID(body, "bap.example.com")
+
+	if err := m.Mediate(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(ctx.Body, &envelope); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	var msg map[string]any
+	if err := json.Unmarshal(envelope["message"], &msg); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if msg["state"] != "ACTIVE" {
+		t.Errorf("expected state=ACTIVE after translation, got %v", msg["state"])
+	}
+}
+
+// TestMediate_DataLoss note: the JSONata $merge executor is additive by design —
+// it cannot drop fields present in the source. Data-loss detection in Mediate is
+// therefore not reachable through the current JSONata executor path. The
+// droppedFields function is tested directly in TestDroppedFields_* below. A
+// Mediate-level integration test requires a replacement (non-merge) executor and
+// will be added when non-JSONata translator support is introduced.
+
+// --- droppedFields tests ---
+
+func TestDroppedFields_NoneDropped(t *testing.T) {
+	src := []byte(`{"a":"1","b":"2"}`)
+	dst := []byte(`{"a":"1","b":"2","c":"3"}`)
+	dropped, err := droppedFields(src, dst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("expected no dropped fields, got %v", dropped)
+	}
+}
+
+func TestDroppedFields_OneDropped(t *testing.T) {
+	src := []byte(`{"a":"1","b":"2"}`)
+	dst := []byte(`{"a":"1"}`)
+	dropped, err := droppedFields(src, dst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "b" {
+		t.Errorf("expected [b], got %v", dropped)
+	}
+}
+
+func TestDroppedFields_NestedDropped(t *testing.T) {
+	src := []byte(`{"order":{"id":"1","status":"ACTIVE"}}`)
+	dst := []byte(`{"order":{"id":"1"}}`)
+	dropped, err := droppedFields(src, dst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != "order.status" {
+		t.Errorf("expected [order.status], got %v", dropped)
+	}
+}
+
+func TestDroppedFields_NoneDropped_Nested(t *testing.T) {
+	src := []byte(`{"order":{"id":"1","status":"ACTIVE"}}`)
+	dst := []byte(`{"order":{"id":"1","status":"ACTIVE","state":"ACTIVE"}}`)
+	dropped, err := droppedFields(src, dst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("expected no dropped fields, got %v", dropped)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements `provider.New` and `mediator.Mediate` — the full inbound schema version mediation sequence for the `SchemaVersionMediator` plugin.
- `provider.New` validates config, initialises the artifact cache and JSONata instance, and performs a cold-start check via `ManifestLoader.GetBySubscriberID`; sets `notOnboarded=true` when the local node manifest is absent or carries no `schemaObjects`.
- `mediator.Mediate` extracts `networkId`/`network_id` and the counterparty ID (`ContextKeyRemoteID`), fetches the counterparty manifest from DeDi, gates on `CheckCompatibility`, fetches translation artifacts, composes and executes the JSONata expression, detects dropped fields (data-loss guard), and patches `ctx.Body` with the translated message subtree.
- `MediationError`: structured rejection type with camelCase codes (`subscriberNotOnboarded`, `schemaIncompatible`, `schemaTranslationDataLoss`), human-readable `Message`, optional `DroppedFields`, and unexported `cause` via `errors.Unwrap` — internal errors not surfaced to callers.
- `PolicyActionPassThrough` (`"passThrough"`, camelCase) replaces `PolicyActionPassIncompatible`; valid only as `onFailure`, rejected if used as `action`.

## Test plan

- [ ] `go test ./pkg/plugin/implementation/schemaversionmediator/...` passes
- [ ] Cold-start variants: loader error, empty schemaObjects, missing nodeId, valid manifest
- [ ] Mediate branches: notOnboarded, missing networkID, missing counterpartyID, manifest unavailable (reject + passThrough), all compatible, action=reject, artifact 404 (reject + passThrough), translation applied
- [ ] `droppedFields` unit cases: none, one, nested, none-nested
- [ ] `passThrough` as `action` is rejected by `loadTranslationPolicy`

## Related

- Closes #790
- Part of epic #770
- Handler wiring error-shape note added to #792