### PR TITLE
feat(core): wire SchemaVersionMediator into handler pipeline (#792)

### DIFF
--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -21,6 +21,7 @@ type PluginManager interface {
 	Signer(ctx context.Context, cfg *plugin.Config) (definition.Signer, error)
 	Step(ctx context.Context, cfg *plugin.Config) (definition.Step, error)
 	PolicyChecker(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *plugin.Config) (definition.PolicyChecker, error)
+	SchemaVersionMediator(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *plugin.Config) (definition.SchemaVersionMediator, error)
 	Cache(ctx context.Context, cfg *plugin.Config) (definition.Cache, error)
 	Registry(ctx context.Context, cfg *plugin.Config) (definition.RegistryLookup, error)
 	KeyManager(ctx context.Context, cache definition.Cache, rLookup definition.RegistryLookup, cfg *plugin.Config) (definition.KeyManager, error)
@@ -50,8 +51,9 @@ type PluginCfg struct {
 	Cache            *plugin.Config  `yaml:"cache,omitempty"`
 	Registry         *plugin.Config  `yaml:"registry,omitempty"`
 	KeyManager       *plugin.Config  `yaml:"keyManager,omitempty"`
-	ManifestLoader   *plugin.Config  `yaml:"manifestLoader,omitempty"`
-	TransportWrapper *plugin.Config  `yaml:"transportWrapper,omitempty"`
+	ManifestLoader        *plugin.Config `yaml:"manifestLoader,omitempty"`
+	SchemaVersionMediator *plugin.Config `yaml:"schemaVersionMediator,omitempty"`
+	TransportWrapper      *plugin.Config `yaml:"transportWrapper,omitempty"`
 	PayloadStore     *plugin.Config  `yaml:"payloadStore,omitempty"`
 	Middleware       []plugin.Config `yaml:"middleware,omitempty"`
 	Steps            []plugin.Config
@@ -77,6 +79,7 @@ func (p *PluginCfg) PluginEntries() []telemetry.PluginEntry {
 	add("cache", p.Cache)
 	add("transport_wrapper", p.TransportWrapper)
 	add("policy_checker", p.PolicyChecker)
+	add("schema_version_mediator", p.SchemaVersionMediator)
 	add("payload_transformer", p.PayloadTransformer)
 	add("key_manager", p.KeyManager)
 	add("payload_store", p.PayloadStore)

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -478,9 +478,11 @@ func loadSchemaVersionMediator(ctx context.Context, mgr PluginManager, manifestL
 	if manifestLoader == nil {
 		return nil, fmt.Errorf("failed to load SchemaVersionMediator plugin (%s): ManifestLoader plugin not configured", cfg.ID)
 	}
-	// Inject subscriberID as nodeId so the operator does not need to repeat it in
-	// plugin YAML config. cfg is owned by this handler's single construction call
-	// so mutating it in place is safe.
+	// Inject subscriberID as nodeId for the plugin's cold-start manifest lookup
+	// in New. nodeId is not an operator-facing config field — the plugin reads it
+	// only at boot time to check whether the local node manifest is published.
+	// cfg is owned by this handler's single construction call so mutating it in
+	// place is safe.
 	if cfg.Config == nil {
 		cfg.Config = make(map[string]string)
 	}

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -37,8 +37,9 @@ type stdHandler struct {
 	manifestLoader     definition.ManifestLoader
 	km                 definition.KeyManager
 	schemaValidator    definition.SchemaValidator
-	policyChecker      definition.PolicyChecker
-	router             definition.Router
+	policyChecker         definition.PolicyChecker
+	schemaVersionMediator definition.SchemaVersionMediator
+	router                definition.Router
 	publisher          definition.Publisher
 	transportWrapper   definition.TransportWrapper
 	payloadTransformer definition.Step
@@ -469,6 +470,29 @@ func loadPolicyChecker(ctx context.Context, mgr PluginManager, manifestLoader de
 	return checker, nil
 }
 
+func loadSchemaVersionMediator(ctx context.Context, mgr PluginManager, manifestLoader definition.ManifestLoader, subscriberID string, cfg *plugin.Config) (definition.SchemaVersionMediator, error) {
+	if cfg == nil {
+		log.Debug(ctx, "Skipping SchemaVersionMediator plugin: not configured")
+		return nil, nil
+	}
+	if manifestLoader == nil {
+		return nil, fmt.Errorf("failed to load SchemaVersionMediator plugin (%s): ManifestLoader plugin not configured", cfg.ID)
+	}
+	// Inject subscriberID as nodeId so the operator does not need to repeat it in
+	// plugin YAML config. cfg is owned by this handler's single construction call
+	// so mutating it in place is safe.
+	if cfg.Config == nil {
+		cfg.Config = make(map[string]string)
+	}
+	cfg.Config["nodeId"] = subscriberID
+	mediator, err := mgr.SchemaVersionMediator(ctx, manifestLoader, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load SchemaVersionMediator plugin (%s): %w", cfg.ID, err)
+	}
+	log.Debugf(ctx, "Loaded SchemaVersionMediator plugin: %s", cfg.ID)
+	return mediator, nil
+}
+
 func loadPayloadTransformerStep(ctx context.Context, mgr PluginManager, cfg *plugin.Config) (definition.Step, error) {
 	if cfg == nil {
 		log.Debug(ctx, "Skipping PayloadTransformer plugin: not configured")
@@ -521,6 +545,9 @@ func (h *stdHandler) initPlugins(ctx context.Context, mgr PluginManager, cfg *Pl
 		return err
 	}
 	if h.policyChecker, err = loadPolicyChecker(ctx, mgr, h.manifestLoader, cfg.PolicyChecker); err != nil {
+		return err
+	}
+	if h.schemaVersionMediator, err = loadSchemaVersionMediator(ctx, mgr, h.manifestLoader, h.SubscriberID, cfg.SchemaVersionMediator); err != nil {
 		return err
 	}
 	if h.payloadTransformer, err = loadPayloadTransformerStep(ctx, mgr, cfg.PayloadTransformer); err != nil {
@@ -595,6 +622,8 @@ func (h *stdHandler) initSteps(ctx context.Context, mgr PluginManager, cfg *Conf
 			s, err = newAddRouteStep(h.router, h.basePath)
 		case "checkPolicy":
 			s, err = newCheckPolicyStep(h.policyChecker)
+		case "mediateSchema":
+			s, err = newMediateSchemaStep(h.schemaVersionMediator)
 		case "transformPayload":
 			if h.payloadTransformer == nil {
 				return fmt.Errorf("invalid config: PayloadTransformer plugin not configured")

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -158,6 +158,9 @@ func (noopPluginManager) TransportWrapper(context.Context, *plugin.Config) (defi
 func (noopPluginManager) SchemaValidator(context.Context, *plugin.Config) (definition.SchemaValidator, error) {
 	return nil, nil
 }
+func (noopPluginManager) SchemaVersionMediator(context.Context, definition.ManifestLoader, *plugin.Config) (definition.SchemaVersionMediator, error) {
+	return nil, nil
+}
 func (noopPluginManager) PayloadStore(_ context.Context, _ definition.Cache, _ string, _ *plugin.Config) (definition.PayloadStore, error) {
 	return nil, nil
 }
@@ -213,6 +216,67 @@ func TestLoadManifestLoader_RequiresRegistryMetadataLookup(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "does not implement RegistryMetadataLookup") {
 		t.Fatalf("expected RegistryMetadataLookup error, got %v", err)
 	}
+}
+
+func TestLoadSchemaVersionMediator_NilCfg_Skipped(t *testing.T) {
+	svm, err := loadSchemaVersionMediator(context.Background(), noopPluginManager{}, nil, "sub1", nil)
+	if err != nil {
+		t.Fatalf("expected nil error when cfg is nil, got %v", err)
+	}
+	if svm != nil {
+		t.Error("expected nil SchemaVersionMediator when cfg is nil")
+	}
+}
+
+func TestLoadSchemaVersionMediator_RequiresManifestLoader(t *testing.T) {
+	_, err := loadSchemaVersionMediator(context.Background(), noopPluginManager{}, nil, "sub1", &plugin.Config{ID: "translationmapmediator"})
+	if err == nil || !strings.Contains(err.Error(), "ManifestLoader plugin not configured") {
+		t.Fatalf("expected ManifestLoader error, got %v", err)
+	}
+}
+
+func TestLoadSchemaVersionMediator_InjectsNodeId(t *testing.T) {
+	var capturedCfg map[string]string
+	mgr := &injectCaptureMgr{
+		schemaVersionMediatorFunc: func(_ context.Context, _ definition.ManifestLoader, cfg *plugin.Config) (definition.SchemaVersionMediator, error) {
+			capturedCfg = cfg.Config
+			return nil, nil
+		},
+	}
+	loader := &stubManifestLoader{}
+	_, err := loadSchemaVersionMediator(context.Background(), mgr, loader, "my-subscriber-id", &plugin.Config{ID: "translationmapmediator"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedCfg["nodeId"] != "my-subscriber-id" {
+		t.Errorf("expected nodeId=my-subscriber-id, got %q", capturedCfg["nodeId"])
+	}
+}
+
+// injectCaptureMgr is a PluginManager stub that captures the cfg passed to SchemaVersionMediator.
+type injectCaptureMgr struct {
+	noopPluginManager
+	schemaVersionMediatorFunc func(context.Context, definition.ManifestLoader, *plugin.Config) (definition.SchemaVersionMediator, error)
+}
+
+func (m *injectCaptureMgr) SchemaVersionMediator(ctx context.Context, loader definition.ManifestLoader, cfg *plugin.Config) (definition.SchemaVersionMediator, error) {
+	if m.schemaVersionMediatorFunc != nil {
+		return m.schemaVersionMediatorFunc(ctx, loader, cfg)
+	}
+	return nil, nil
+}
+
+// stubManifestLoader satisfies definition.ManifestLoader with no-op implementations.
+type stubManifestLoader struct{}
+
+func (stubManifestLoader) GetByNetworkID(context.Context, string) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+func (stubManifestLoader) GetBySubscriberID(context.Context, string) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+func (stubManifestLoader) GetByMetadata(context.Context, model.ManifestMetadata) (*model.ManifestDocument, error) {
+	return nil, nil
 }
 
 func TestNewHTTPClient(t *testing.T) {

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -518,6 +518,22 @@ func (s *checkPolicyStep) Run(ctx *model.StepContext) error {
 	return s.checker.CheckPolicy(ctx)
 }
 
+// mediateSchemaStep adapts SchemaVersionMediator into the Step interface.
+type mediateSchemaStep struct {
+	mediator definition.SchemaVersionMediator
+}
+
+func newMediateSchemaStep(mediator definition.SchemaVersionMediator) (definition.Step, error) {
+	if mediator == nil {
+		return nil, fmt.Errorf("invalid config: SchemaVersionMediator plugin not configured")
+	}
+	return &mediateSchemaStep{mediator: mediator}, nil
+}
+
+func (s *mediateSchemaStep) Run(ctx *model.StepContext) error {
+	return s.mediator.Mediate(ctx)
+}
+
 // storePayloadStep adapts PayloadStore into the Step interface.
 type storePayloadStep struct {
 	store definition.PayloadStore

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -89,6 +89,10 @@ func (m *mockPluginManager) PayloadStore(_ context.Context, _ definition.Cache, 
 	return nil, nil
 }
 
+func (m *mockPluginManager) SchemaVersionMediator(_ context.Context, _ definition.ManifestLoader, _ *plugin.Config) (definition.SchemaVersionMediator, error) {
+	return nil, nil
+}
+
 // PolicyChecker returns a mock policy checker implementation.
 func (m *mockPluginManager) PolicyChecker(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *plugin.Config) (definition.PolicyChecker, error) {
 	if m.policyCheckerFunc != nil {

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -362,6 +362,10 @@ func (p *provider) New(ctx context.Context, loader definition.ManifestLoader, cf
 	// Cold-start check: attempt to load the local node manifest. If it is
 	// absent or has no schemaObjects, mark as not onboarded so Mediate rejects
 	// every inbound call with a clear error rather than silently pass-through.
+	//
+	// nodeId is not an operator-facing config field. The handler injects the
+	// handler-level subscriberId here before calling New so that the cold-start
+	// lookup can run at boot time, before any StepContext is available.
 	nodeID := cfg["nodeId"]
 	if nodeID == "" {
 		m.notOnboarded = true

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -274,6 +274,26 @@ func (m *Manager) PolicyChecker(ctx context.Context, manifestLoader definition.M
 	return checker, nil
 }
 
+// SchemaVersionMediator returns a SchemaVersionMediator instance based on the provided configuration.
+func (m *Manager) SchemaVersionMediator(ctx context.Context, manifestLoader definition.ManifestLoader, cfg *Config) (definition.SchemaVersionMediator, error) {
+	pp, err := provider[definition.SchemaVersionMediatorProvider](m.plugins, cfg.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load provider for %s: %w", cfg.ID, err)
+	}
+	mediator, closer, err := pp.New(ctx, manifestLoader, cfg.Config)
+	if err != nil {
+		return nil, err
+	}
+	if closer != nil {
+		m.closers = append(m.closers, func() {
+			if err := closer(); err != nil {
+				panic(err)
+			}
+		})
+	}
+	return mediator, nil
+}
+
 // Cache returns a Cache instance based on the provided configuration.
 // It registers a cleanup function for resource management.
 func (m *Manager) Cache(ctx context.Context, cfg *Config) (definition.Cache, error) {


### PR DESCRIPTION
## Summary

- Adds `SchemaVersionMediator` to `PluginManager` interface and `PluginCfg` struct (`schemaVersionMediator` YAML key, omitempty — no breaking change to existing configs)
- `Manager.SchemaVersionMediator` in `pkg/plugin/manager.go` — loads provider from `.so`, calls `New` with `ManifestLoader` dependency, registers closer
- `loadSchemaVersionMediator` helper in `stdHandler.go` — guards nil cfg (skip) and nil manifestLoader (error); injects `h.SubscriberID` as `nodeId` transparently so operators do not configure it in plugin YAML
- `mediateSchemaStep` in `step.go` — adapts `SchemaVersionMediator.Mediate` into the `Step` interface; errors propagate as-is to `sendNack`
- `schema_version_mediator` added to `PluginEntries` for observability gauge completeness

## Step ordering

`validateSchema → mediateSchema` is correct for both caller and receiver handler configs. Schema definitions are publicly versioned and resolvable via `@context` URLs — the validator can handle any version. Translating before validation would leave `@context` pointing at the source version while the field structure reflects the target, which extended schema validation would misread.

## Example config

```yaml
plugins:
  manifestLoader:
    id: manifestloader        # ships on main; backed by dediregistry
    config:
      cacheTTL: 5m
  schemaVersionMediator:
    id: translationmapmediator
    config:
      action: translate       # reject | translate (default: translate)
      onFailure: reject       # reject | passThrough (default: reject)

steps:
  - validateSign
  - validateSchema            # validate source payload before translation
  - mediateSchema             # translate domain schema objects
  - addRoute
```

`nodeId` is **not** an operator-facing config field. The handler injects `subscriberId` from the handler-level config automatically before calling `New`.

## Test plan

- [ ] `go test ./core/...` passes
- [ ] `TestLoadSchemaVersionMediator_NilCfg_Skipped` — nil cfg skipped cleanly
- [ ] `TestLoadSchemaVersionMediator_RequiresManifestLoader` — nil loader produces clear error
- [ ] `TestLoadSchemaVersionMediator_InjectsNodeId` — subscriberID arrives as `nodeId` in plugin cfg
- [ ] Existing handler and module tests unaffected

## Related

- Closes #792
- Part of epic #770
- Depends on #821 (inbound mediation loop — already merged into base branch)