### PR TITLE
feat(schemaversionmediator): plugin entrypoint, build registration, README, and CONFIG docs (#793)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -512,9 +512,12 @@ modules:
 **Description**: Ordered list of processing steps to execute for each request.  
 **Common Steps**:
 - `validateSign` - Validate digital signature
-- `addRoute` - Determine routing destination
 - `validateSchema` - Validate against JSON schema
+- `mediateSchema` - Translate schema objects for cross-version interoperability
+- `addRoute` - Determine routing destination
 - `sign` - Sign outgoing request
+- `storePayload` - Record request payload in cache
+- `transformPayload` - Apply JSONata payload transformation
 - `publish` - Publish to message queue
 
 **Example**:
@@ -949,7 +952,101 @@ The sample illustrates how a single mapping file can convert `search` requests a
 
 ---
 
-#### 13. PayloadStore Plugin
+#### 13. SchemaVersionMediator Plugin
+
+**Purpose**: Mediate schema version differences between Beckn participants. When a BAP and BPP declare different schema object versions in their node manifests, this plugin fetches JSONata translation artifacts from the network's artifact registry and transforms the payload so each side receives data in the version it expects.
+
+**Requirements**: A `manifestLoader` plugin must be configured in the same handler.
+
+```yaml
+schemaVersionMediator:
+  id: schemaversionmediator
+  config:
+    action: translate
+    onFailure: reject
+    fetchTimeoutMs: "5000"
+    positiveCacheTTL: "1h"
+    negativeCacheTTL: "5m"
+    maxCacheEntries: "1000"
+```
+
+**Parameters**:
+
+| Key | Values | Default | Description |
+|---|---|---|---|
+| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `schemaIncompatible` immediately. |
+| `onFailure` | `reject` \| `passThrough` | `reject` | Applied when `action=translate` but no artifact can be fetched. `passThrough` forwards the untranslated payload — operator escape hatch only, not for production. |
+| `fetchTimeoutMs` | integer string | `"5000"` | HTTP timeout in milliseconds for artifact fetch. |
+| `positiveCacheTTL` | duration string | `"1h"` | How long to cache successfully fetched translation artifacts. |
+| `negativeCacheTTL` | duration string | `"5m"` | How long to cache artifact-not-found responses. |
+| `maxCacheEntries` | integer string | `"1000"` | Maximum entries in the artifact cache. |
+
+> **`nodeId` is not an operator-facing config field.** The handler automatically injects the adapter's `subscriberId` as `nodeId` before calling the plugin. Do not set this manually.
+
+**Step ordering — `validateSchema` must come before `mediateSchema`:**
+
+```yaml
+steps:
+  - validateSign
+  - validateSchema      # validates source payload in its declared schema version
+  - mediateSchema       # translates domain schema objects if versions differ
+  - addRoute
+```
+
+This order is universal for both caller and receiver handlers. Schema definitions are publicly available and versioned, so the schema validator can validate any version payload via `@context` URL resolution. Translating before validation would leave `@context` pointing at the source version while the field structure reflects the target — an inconsistency that extended schema validation (`extendedSchema_enabled: "true"`) would misread.
+
+**Minimal example — receiver handler with schema mediation enabled:**
+
+```yaml
+modules:
+  - name: bapTxnReceiver
+    path: /bap/receiver/
+    handler:
+      type: std
+      role: bap
+      subscriberId: "bap.example.com"
+      plugins:
+        registry:
+          id: dediregistry
+          config:
+            url: "https://fabric.nfh.global/registry/dedi"
+        manifestLoader:
+          id: manifestloader
+          config:
+            url: "https://fabric.nfh.global/registry/dedi"
+            positiveCacheTTL: "1h"
+            negativeCacheTTL: "5m"
+        schemaVersionMediator:
+          id: schemaversionmediator
+          config:
+            action: translate
+            onFailure: reject
+        signValidator:
+          id: signvalidator
+        schemaValidator:
+          id: schemav2validator
+          config:
+            type: url
+            location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
+            extendedSchema_enabled: "true"
+      steps:
+        - validateSign
+        - validateSchema
+        - mediateSchema
+        - addRoute
+```
+
+**Error codes returned by `mediateSchema` step:**
+
+| Code | Cause |
+|---|---|
+| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
+| `schemaIncompatible` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
+| `schemaTranslationDataLoss` | Translation artifact dropped fields present in the source payload. Review the artifact. |
+
+---
+
+#### 14. PayloadStore Plugin
 
 **Purpose**: Record every inbound request payload processed by the handler, indexed by `message_id` and `transaction_id`, with TTL-based expiration via the cache backend. Provides the stateful foundation for plugins that need transaction history.
 

--- a/install/build-plugins.sh
+++ b/install/build-plugins.sh
@@ -26,6 +26,7 @@ plugins=(
     "signvalidator"
     "opapolicychecker"
     "payloadstore"
+    "schemaversionmediator"
 )
 
 for plugin in "${plugins[@]}"; do

--- a/pkg/plugin/implementation/schemaversionmediator/README.md
+++ b/pkg/plugin/implementation/schemaversionmediator/README.md
@@ -1,0 +1,149 @@
+# SchemaVersionMediator Plugin
+
+`schemaversionmediator` mediates schema version differences between Beckn participants. When a BAP and a BPP declare different schema object versions in their node manifests, this plugin fetches translation artifacts from the network's artifact registry, executes them, and patches the payload so that each side receives data in the schema version it expects.
+
+---
+
+## Table of Contents
+
+1. [How It Works](#how-it-works)
+2. [Plugin ID and Dependencies](#plugin-id-and-dependencies)
+3. [Configuration Reference](#configuration-reference)
+4. [Step Ordering](#step-ordering)
+5. [Cold-Start Behaviour](#cold-start-behaviour)
+6. [Error Codes](#error-codes)
+7. [Translation Artifacts](#translation-artifacts)
+8. [Data-Loss Detection](#data-loss-detection)
+9. [Known Limitations](#known-limitations)
+
+---
+
+## How It Works
+
+On every inbound request, `Mediate` runs the following sequence:
+
+1. **Cold-start guard** — if the local node manifest was absent or had no `schemaObjects` at startup, every call is rejected immediately with `subscriberNotOnboarded`.
+2. **Identity extraction** — reads `networkId`/`network_id` from the payload `context` block; reads the counterparty subscriber ID from `ContextKeyRemoteID` (set by `reqpreprocessor`).
+3. **Counterparty manifest lookup** — calls `ManifestLoader.GetBySubscriberID` to fetch the counterparty's node manifest from DeDi.
+4. **Compatibility check** — walks the payload for `@context`+`@type` pairs and compares them against the counterparty manifest's `schemaObjects`. If all match, the payload passes through unchanged.
+5. **Artifact fetch** — for each incompatible schema object, fetches a translation artifact from the URL derived from the counterparty manifest's `contextUrl`.
+6. **Translation** — composes the fetched artifacts into a single JSONata expression and executes it against the `message` subtree of the payload.
+7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `schemaTranslationDataLoss`.
+8. **Patch** — replaces the `message` field in `ctx.Body` with the translated output.
+
+---
+
+## Plugin ID and Dependencies
+
+```yaml
+plugins:
+  manifestLoader:
+    id: manifestloader          # required — backed by dediregistry
+  schemaVersionMediator:
+    id: schemaversionmediator
+    config:
+      action: translate         # see Configuration Reference
+      onFailure: reject
+```
+
+**Required dependencies:**
+
+| Dependency | Why |
+|---|---|
+| `manifestLoader` | Fetches counterparty node manifests from DeDi for compatibility checks |
+| `dediregistry` (backing the manifestLoader) | Resolves subscriber manifest URLs |
+
+`nodeId` is **not** an operator-facing config field. The handler injects the adapter's `subscriberId` automatically before calling `New` so the cold-start manifest lookup can run at boot time.
+
+---
+
+## Configuration Reference
+
+| Key | Values | Default | Description |
+|---|---|---|---|
+| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible |
+| `onFailure` | `reject` \| `passThrough` | `reject` | What to do when `action=translate` but an artifact cannot be fetched |
+| `fetchTimeoutMs` | integer | `5000` | HTTP timeout for artifact fetch in milliseconds |
+| `positiveCacheTTL` | duration string | `1h` | How long to cache successfully fetched artifacts |
+| `negativeCacheTTL` | duration string | `5m` | How long to cache artifact-not-found responses |
+| `maxCacheEntries` | integer | `1000` | Maximum number of entries in the artifact cache |
+
+**`action` values:**
+
+- `translate` — attempt translation for each incompatible schema object; apply `onFailure` if any artifact is unavailable.
+- `reject` — return `schemaIncompatible` immediately without attempting translation.
+
+**`onFailure` values (only evaluated when `action=translate`):**
+
+- `reject` — return `schemaIncompatible` when an artifact cannot be fetched.
+- `passThrough` — forward the untranslated payload. Operator escape hatch for false-mismatch situations (e.g. stale local manifest during rollout). Not recommended for production.
+
+---
+
+## Step Ordering
+
+`validateSchema → mediateSchema` is the correct order for **both caller and receiver** handler configs.
+
+```yaml
+steps:
+  - validateSign
+  - validateSchema      # validate source payload in its declared schema version
+  - mediateSchema       # translate domain schema objects if versions differ
+  - addRoute
+```
+
+**Why this order works universally:**
+
+Schema definitions are publicly available and versioned. The schema validator resolves `@context` URLs directly, so it can validate any version payload regardless of what the local node runs. Translating before validation would leave `@context` URLs pointing at the source version while the field structure reflects the target — an inconsistency that extended schema validation would misread.
+
+> **Artifact authoring note:** Translation expressions should update `@context` URLs as part of the translation to keep the translated payload internally consistent. This is a requirement for translation artifact authors, not enforced by the plugin.
+
+---
+
+## Cold-Start Behaviour
+
+At startup, `New` calls `ManifestLoader.GetBySubscriberID` for the local node's subscriber ID. If the manifest is absent, unreachable, or contains no `schemaObjects`, the mediator sets an internal `notOnboarded` flag.
+
+While `notOnboarded` is set, every `Mediate` call returns `subscriberNotOnboarded` immediately. The adapter must be restarted after the local node manifest is published to DeDi and becomes resolvable.
+
+---
+
+## Error Codes
+
+All errors returned by `Mediate` are of type `*MediationError`, which carries a camelCase `Code` field. The handler uses this to build a structured Beckn NACK response.
+
+| Code | Cause | Resolution |
+|---|---|---|
+| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
+| `schemaIncompatible` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
+| `schemaTranslationDataLoss` | Translation dropped fields present in the source payload | Review translation artifact — it must not remove fields from the source |
+
+Plain (non-`MediationError`) errors may also be returned for malformed payloads (e.g. missing `message` field). The handler treats these as HTTP 400 Bad Request with a generic error body — distinct from the structured NACK produced by `MediationError`.
+
+---
+
+## Translation Artifacts
+
+Translation artifacts are external files fetched at runtime from URLs derived from the counterparty's node manifest `contextUrl` field. The artifact URL is constructed by replacing the schema version segment in the `contextUrl` path.
+
+Currently supported content type: `application/jsonata`.
+
+Artifacts are cached in memory with configurable positive and negative TTLs. The cache is per-mediator-instance and is not shared across handlers.
+
+---
+
+## Data-Loss Detection
+
+After translation, the plugin compares the flattened dot-notation key paths of the source `message` subtree against the translated output. Any key present in the source but absent in the output is considered a dropped field.
+
+**Current behaviour:** data loss always causes rejection with `schemaTranslationDataLoss`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
+
+**Array handling:** array elements are treated as opaque leaf values. Element-level drops within an array are not detected — only object key presence is compared.
+
+---
+
+## Known Limitations
+
+- Non-JSONata translator types are not yet supported. The translation dispatch layer is in place; additional content types will be wired in future releases.
+- Observed seeding (auto-updating the local node manifest from live traffic) is not implemented. Tracked in [#822](https://github.com/beckn/beckn-onix/issues/822).
+- `RunOnResponse` is not implemented — Beckn responses arrive as separate inbound requests and are mediated by `Mediate` on the receiver handler, not via a response hook.

--- a/pkg/plugin/implementation/schemaversionmediator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemaversionmediator/cmd/plugin.go
@@ -1,0 +1,19 @@
+// Package main provides the plugin entry point for the SchemaVersionMediator plugin.
+// This file is compiled as a Go plugin (.so) and loaded by beckn-onix at runtime.
+package main
+
+import (
+	"context"
+
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/schemaversionmediator"
+)
+
+type mediatorProvider struct{}
+
+func (p mediatorProvider) New(ctx context.Context, loader definition.ManifestLoader, cfg map[string]string) (definition.SchemaVersionMediator, func() error, error) {
+	return schemaversionmediator.New(ctx, loader, cfg)
+}
+
+// Provider is the exported symbol that beckn-onix plugin manager looks up.
+var Provider = mediatorProvider{}

--- a/pkg/plugin/implementation/schemaversionmediator/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/cmd/plugin_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+)
+
+// stubLoader is a no-op ManifestLoader for smoke-testing provider construction.
+type stubLoader struct{}
+
+func (stubLoader) GetByNetworkID(context.Context, string) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+func (stubLoader) GetBySubscriberID(context.Context, string) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+func (stubLoader) GetByMetadata(context.Context, model.ManifestMetadata) (*model.ManifestDocument, error) {
+	return nil, nil
+}
+
+func TestProvider_SymbolType(t *testing.T) {
+	// Verify the exported Provider symbol satisfies SchemaVersionMediatorProvider.
+	// This mirrors the type assertion the plugin manager performs at runtime.
+	var _ definition.SchemaVersionMediatorProvider = Provider
+}
+
+func TestProvider_New_ReturnsMediator(t *testing.T) {
+	mediator, closer, err := Provider.New(context.Background(), stubLoader{}, map[string]string{
+		"nodeId": "nfh.global/subscribers.beckn.one/bap.example.com",
+	})
+	if err != nil {
+		t.Fatalf("Provider.New() error = %v", err)
+	}
+	if mediator == nil {
+		t.Fatal("expected non-nil SchemaVersionMediator")
+	}
+	if closer == nil {
+		t.Fatal("expected non-nil closer")
+	}
+	if err := closer(); err != nil {
+		t.Fatalf("closer() error = %v", err)
+	}
+}
+
+func TestProvider_New_InvalidAction_ReturnsError(t *testing.T) {
+	_, _, err := Provider.New(context.Background(), stubLoader{}, map[string]string{
+		"nodeId": "nfh.global/subscribers.beckn.one/bap.example.com",
+		"action": "passThrough",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid action=passThrough, got nil")
+	}
+}

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -326,6 +326,11 @@ type mediator struct {
 	notOnboarded    bool // set at New() when local manifest is absent or has no schemaObjects
 }
 
+// New is the package-level constructor used by the plugin entrypoint.
+func New(ctx context.Context, loader definition.ManifestLoader, cfg map[string]string) (definition.SchemaVersionMediator, func() error, error) {
+	return (&provider{}).New(ctx, loader, cfg)
+}
+
 // provider is the factory for mediator instances. It implements
 // definition.SchemaVersionMediatorProvider.
 type provider struct{}


### PR DESCRIPTION
## Summary

- Adds the `cmd/plugin.go` entrypoint that exports the `Provider` symbol loaded by the beckn-onix plugin manager at runtime
- Adds a package-level `New()` shim in `schemaversionmediator.go` so the entrypoint can delegate to the unexported `provider` struct
- Adds `cmd/plugin_test.go` with three smoke tests: symbol type assertion, successful construction, and invalid-action rejection
- Registers `schemaversionmediator` in `install/build-plugins.sh`
- Adds `README.md` at `pkg/plugin/implementation/schemaversionmediator/` covering plugin purpose, config reference, step ordering rationale (`validateSchema → mediateSchema` universal), cold-start behaviour, error codes, translation artifacts, data-loss detection, and known limitations
- Adds `SchemaVersionMediator` section to root `CONFIG.md` with parameter table, `nodeId` note, step ordering rationale, minimal end-to-end YAML example, and error codes table; adds `mediateSchema` to the common steps list

## Step ordering rationale (captured in README and CONFIG)

`validateSchema → mediateSchema` is the correct order for both caller and receiver handlers. Schema definitions are publicly available and versioned, so the validator resolves `@context` URLs directly for any version. Translating first would leave `@context` pointing at the source version while the field structure reflects the target — an inconsistency that extended schema validation would misread.

## Test plan

- [ ] `go test ./pkg/plugin/implementation/schemaversionmediator/...` passes (both package and cmd)
- [ ] `install/build-plugins.sh` builds `schemaversionmediator.so` without error
- [ ] README step ordering section reviewed
- [ ] CONFIG.md SchemaVersionMediator section reviewed