### PR TITLE
feat(telemetry): capture Beckn signature headers in audit log records

### DIFF
--- a/config/audit-fields.yaml
+++ b/config/audit-fields.yaml
@@ -43,6 +43,12 @@ maskRules:
   - keys: [paymentURL, txnRef, paidAt]
     pattern: sensitive
 
+# captureSignatureHeaders — when true, the HTTP Authorization and X-Request-Id
+# headers are captured verbatim as attributes on every audit log record.
+# These carry the Beckn Ed25519 signature and are intentionally verifiable —
+# no masking is applied. Defaults to false.
+captureSignatureHeaders: false
+
 # pathOverrides — use sparingly.
 # These bind masking to a specific dot-path and are harder to maintain as schemas
 # evolve. Prefer maskRules (key-name matching) wherever possible.

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -177,7 +177,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		body := stepCtx.Body
-		telemetry.EmitAuditLogs(r.Context(), body, auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
+		telemetry.EmitAuditLogs(r.Context(), body, r.Header, auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
 		span.End()
 	}()
 

--- a/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
+++ b/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
@@ -398,6 +398,17 @@ These fields are always present regardless of mode or field selection:
 | `sender.id` | Sender subscriber ID |
 | `receiver.id` | Receiver subscriber ID |
 
+### Optional signature header attributes
+
+When `captureSignatureHeaders: true` is set in the audit-fields config, the following HTTP request headers are captured verbatim as additional attributes on every audit log record:
+
+| Attribute | HTTP header | Description |
+|---|---|---|
+| `http.request.header.authorization` | `Authorization` | Beckn Ed25519 signature (`Signature keyId=...`) |
+| `http.request.header.x-request-id` | `X-Request-Id` | Request correlation ID |
+
+These headers are intentionally not masked — the Beckn `Authorization` header carries a cryptographic signature that is verifiable by anyone with the sender's public key. Capturing it enables post-hoc payload verification and non-repudiation from the audit trail alone.
+
 ### Audit pipeline: modes and masking
 
 The audit configuration file (`config/audit-fields.yaml`) controls a single-pass pipeline applied to every payload before the record is emitted:
@@ -445,6 +456,11 @@ maskRules:
     pattern: account
   - keys: [paymentURL, txnRef, paidAt]
     pattern: sensitive
+
+# captureSignatureHeaders — when true, Authorization and X-Request-Id headers
+# are captured verbatim as audit log attributes (no masking applied).
+# Enables post-hoc signature verification and non-repudiation. Default: false.
+captureSignatureHeaders: false
 
 # Path-override masking — use sparingly, prefer maskRules
 pathOverrides: []

--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
+	"strings"
 	"time"
 
 	logger "github.com/beckn-one/beckn-onix/pkg/log"
@@ -15,7 +17,7 @@ import (
 
 const auditLoggerName = "Beckn_ONIX"
 
-func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
+func EmitAuditLogs(ctx context.Context, body []byte, header http.Header, attrs ...log.KeyValue) {
 	// global.GetLoggerProvider() always returns a no-op provider (never nil),
 	// so a nil-check on the provider is ineffective. Instead we rely on the
 	// logEnabled atomic flag, which otelsetup sets to true after calling
@@ -54,6 +56,14 @@ func EmitAuditLogs(ctx context.Context, body []byte, attrs ...log.KeyValue) {
 
 	if len(attrs) > 0 {
 		record.AddAttributes(attrs...)
+	}
+
+	if cfg := GetCompiledConfig(); cfg != nil && cfg.CaptureSignatureHeaders() && header != nil {
+		for _, name := range signatureHeaders {
+			if val := header.Get(name); val != "" {
+				record.AddAttributes(log.String("http.request.header."+strings.ToLower(name), val))
+			}
+		}
 	}
 
 	auditlog.Emit(ctx, record)

--- a/pkg/telemetry/audit.go
+++ b/pkg/telemetry/audit.go
@@ -58,9 +58,17 @@ func EmitAuditLogs(ctx context.Context, body []byte, header http.Header, attrs .
 		record.AddAttributes(attrs...)
 	}
 
+	// cfg was already read above via ProcessAuditPayload → GetCompiledConfig, but we
+	// re-read here to avoid threading the value through. The RWMutex is uncontended
+	// on the read path so the cost is negligible; if that changes, snapshot once at
+	// the top of this function instead.
 	if cfg := GetCompiledConfig(); cfg != nil && cfg.CaptureSignatureHeaders() && header != nil {
 		for _, name := range signatureHeaders {
 			if val := header.Get(name); val != "" {
+				// strings.ToLower is intentional: OTel semantic conventions require
+				// header attribute keys to be lowercase (e.g. "x-request-id").
+				// header.Get uses canonical MIME casing internally, so lookup is
+				// case-insensitive regardless of how name is cased in signatureHeaders.
 				record.AddAttributes(log.String("http.request.header."+strings.ToLower(name), val))
 			}
 		}

--- a/pkg/telemetry/audit_fields.go
+++ b/pkg/telemetry/audit_fields.go
@@ -34,11 +34,12 @@ type pathOverrideDef struct {
 }
 
 type auditConfig struct {
-	Mode           string                `yaml:"mode"`           // "full" | "selective"
-	Patterns       map[string]patternDef `yaml:"patterns"`
-	MaskRules      []maskRule            `yaml:"maskRules"`
-	PathOverrides  []pathOverrideDef     `yaml:"pathOverrides"`
-	SelectedFields map[string][]string   `yaml:"selectedFields"` // action → field paths; "default" is the fallback
+	Mode                    string                `yaml:"mode"`           // "full" | "selective"
+	Patterns                map[string]patternDef `yaml:"patterns"`
+	MaskRules               []maskRule            `yaml:"maskRules"`
+	PathOverrides           []pathOverrideDef     `yaml:"pathOverrides"`
+	SelectedFields          map[string][]string   `yaml:"selectedFields"` // action → field paths; "default" is the fallback
+	CaptureSignatureHeaders bool                  `yaml:"captureSignatureHeaders"`
 }
 
 // ── Compiled config ──────────────────────────────────────────────────────────
@@ -49,13 +50,19 @@ type CompiledPattern struct {
 	Mask     string // literal mask for MaskType "replace"
 }
 
+// signatureHeaders is the fixed set of HTTP headers captured when
+// captureSignatureHeaders is enabled. These headers carry the Beckn Ed25519
+// signature and are intentionally verifiable, not secret credentials.
+var signatureHeaders = []string{"Authorization", "X-Request-Id"}
+
 // CompiledConfig is the compiled, query-ready form of auditConfig.
 // All lookups are O(1) map operations so the per-request cost is minimal.
 type CompiledConfig struct {
-	mode          string                         // "full" or "selective"
-	keyToPattern  map[string]*CompiledPattern    // field name → pattern (from maskRules)
-	pathOverrides map[string]*CompiledPattern    // full dot-path → pattern
-	keepPaths     map[string]map[string]struct{} // action → set of paths to keep/traverse (selective only)
+	mode                    string                         // "full" or "selective"
+	keyToPattern            map[string]*CompiledPattern    // field name → pattern (from maskRules)
+	pathOverrides           map[string]*CompiledPattern    // full dot-path → pattern
+	keepPaths               map[string]map[string]struct{} // action → set of paths to keep/traverse (selective only)
+	captureSignatureHeaders bool
 }
 
 var (
@@ -198,11 +205,18 @@ func compile(ctx context.Context, cfg *auditConfig) (*CompiledConfig, error) {
 	}
 
 	return &CompiledConfig{
-		mode:          mode,
-		keyToPattern:  keyToPattern,
-		pathOverrides: pathOverrides,
-		keepPaths:     keepPaths,
+		mode:                    mode,
+		keyToPattern:            keyToPattern,
+		pathOverrides:           pathOverrides,
+		keepPaths:               keepPaths,
+		captureSignatureHeaders: cfg.CaptureSignatureHeaders,
 	}, nil
+}
+
+// CaptureSignatureHeaders reports whether Beckn signature headers should be
+// included as attributes on audit log records.
+func (c *CompiledConfig) CaptureSignatureHeaders() bool {
+	return c.captureSignatureHeaders
 }
 
 // buildKeepSet expands dot-paths into a set containing each path AND all its

--- a/pkg/telemetry/audit_test.go
+++ b/pkg/telemetry/audit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 	"os"
 	"testing"
 
@@ -89,6 +90,78 @@ func TestEmitAuditLogs_Enabled(t *testing.T) {
 	assert.True(t, hasChecksum, "audit record should include checkSum attribute")
 	assert.True(t, hasLogUUID, "audit record should include log_uuid attribute")
 	assert.True(t, hasExtraKey, "audit record should include caller-supplied extra_key attribute")
+}
+
+func TestEmitAuditLogs_CaptureSignatureHeaders(t *testing.T) {
+	ctx := context.Background()
+	provider, exporter, err := NewTestProviderWithLogs(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(ctx)
+
+	// Enable captureSignatureHeaders via compiled config.
+	compiledCfgMu.Lock()
+	prev := compiledCfg
+	compiledCfg = &CompiledConfig{captureSignatureHeaders: true}
+	compiledCfgMu.Unlock()
+	t.Cleanup(func() {
+		compiledCfgMu.Lock()
+		compiledCfg = prev
+		compiledCfgMu.Unlock()
+	})
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", `Signature keyId="bap.example.com",algorithm="ed25519",signature="abc123"`)
+	hdr.Set("X-Request-Id", "req-abc-123")
+
+	EmitAuditLogs(ctx, []byte(`{}`), hdr)
+
+	records := exporter.Records()
+	require.Len(t, records, 1, "exactly one log record should be emitted")
+
+	var hasAuth, hasReqID bool
+	records[0].WalkAttributes(func(kv log.KeyValue) bool {
+		switch kv.Key {
+		case "http.request.header.authorization":
+			hasAuth = true
+		case "http.request.header.x-request-id":
+			hasReqID = true
+		}
+		return true
+	})
+	assert.True(t, hasAuth, "authorization header should be captured as an audit attribute")
+	assert.True(t, hasReqID, "x-request-id header should be captured as an audit attribute")
+}
+
+func TestEmitAuditLogs_CaptureSignatureHeaders_Disabled(t *testing.T) {
+	ctx := context.Background()
+	provider, exporter, err := NewTestProviderWithLogs(ctx)
+	require.NoError(t, err)
+	defer provider.Shutdown(ctx)
+
+	// Ensure captureSignatureHeaders is explicitly false.
+	compiledCfgMu.Lock()
+	prev := compiledCfg
+	compiledCfg = &CompiledConfig{captureSignatureHeaders: false}
+	compiledCfgMu.Unlock()
+	t.Cleanup(func() {
+		compiledCfgMu.Lock()
+		compiledCfg = prev
+		compiledCfgMu.Unlock()
+	})
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", `Signature keyId="bap.example.com"`)
+
+	EmitAuditLogs(ctx, []byte(`{}`), hdr)
+
+	records := exporter.Records()
+	require.Len(t, records, 1)
+
+	records[0].WalkAttributes(func(kv log.KeyValue) bool {
+		assert.NotEqual(t, "http.request.header.authorization", kv.Key,
+			"authorization header must not appear when captureSignatureHeaders is false")
+		return true
+	})
 }
 
 func TestNewTestProviderWithLogs_ShutdownResetsFlag(t *testing.T) {

--- a/pkg/telemetry/audit_test.go
+++ b/pkg/telemetry/audit_test.go
@@ -44,7 +44,7 @@ func TestEmitAuditLogs_Disabled(t *testing.T) {
 	os.Stdout = w
 
 	require.NotPanics(t, func() {
-		EmitAuditLogs(context.Background(), []byte(`{"message":"test"}`))
+		EmitAuditLogs(context.Background(), []byte(`{"message":"test"}`), nil)
 	}, "EmitAuditLogs should not panic when logs are disabled")
 
 	w.Close()
@@ -65,7 +65,7 @@ func TestEmitAuditLogs_Enabled(t *testing.T) {
 	require.True(t, LogsEnabled(), "LogsEnabled should be true after NewTestProviderWithLogs")
 
 	require.NotPanics(t, func() {
-		EmitAuditLogs(ctx, []byte(`{"message":"audit-test"}`), log.String("extra_key", "extra_value"))
+		EmitAuditLogs(ctx, []byte(`{"message":"audit-test"}`), nil, log.String("extra_key", "extra_value"))
 	}, "EmitAuditLogs should not panic when logs are enabled")
 
 	// One log record must be emitted regardless of how selectAuditPayload


### PR DESCRIPTION
Closes #826

## Summary

- Adds `captureSignatureHeaders: true` flag to the audit-fields YAML config
- When enabled, `Authorization` and `X-Request-Id` headers are emitted as OTel log attributes (`http.request.header.authorization`, `http.request.header.x-request-id`) on every audit log record
- Defaults to `false` — no behaviour change for existing deployments

## Motivation

The Beckn `Authorization` header carries the sender's Ed25519 cryptographic signature. Without it, audit logs record *what* was sent but not *who signed it*, breaking non-repudiation and making post-hoc payload verification impossible. No masking is applied — the signature is intentionally verifiable, not a secret credential.

## Changes

| File | Change |
|---|---|
| `pkg/telemetry/audit_fields.go` | Added `captureSignatureHeaders` to `auditConfig` and `CompiledConfig`; added `signatureHeaders` fixed list; added `CaptureSignatureHeaders()` accessor |
| `pkg/telemetry/audit.go` | `EmitAuditLogs` accepts `http.Header`; emits signature headers when flag is on |
| `core/module/handler/stdHandler.go` | Pass `r.Header` to `EmitAuditLogs` |
| `pkg/telemetry/audit_test.go` | Updated call sites for new signature |

## Test plan

- [ ] `go test ./pkg/telemetry/... ./core/...` passes
- [ ] Deploy with `captureSignatureHeaders: false` (or absent) — confirm no change in emitted attributes
- [ ] Deploy with `captureSignatureHeaders: true` — confirm `http.request.header.authorization` appears in OTel log records