### PR TITLE
feat(auditlog): emit ACK/NACK response body as second audit record

### DIFF
--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -43,7 +43,7 @@ type preV2Response struct {
 // All other versions use the pre-v2 envelope:
 //
 //	{"message":{"ack":{"status":"ACK"}}}
-func sendAck(ctx context.Context, w http.ResponseWriter) {
+func sendAck(ctx context.Context, w http.ResponseWriter) []byte {
 	var data []byte
 	if isAtLeastV2(ctx) {
 		resp := &model.Response{
@@ -66,6 +66,7 @@ func sendAck(ctx context.Context, w http.ResponseWriter) {
 	if _, err := w.Write(data); err != nil {
 		http.Error(w, "failed to write response", http.StatusInternalServerError)
 	}
+	return data
 }
 
 // nackBecknError maps an error to its Beckn model.Error representation, HTTP
@@ -151,9 +152,10 @@ func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, htt
 }
 
 // sendNack maps err to its Beckn error type and sends the appropriate response.
-func sendNack(ctx context.Context, w http.ResponseWriter, err error) {
+func sendNack(ctx context.Context, w http.ResponseWriter, err error) []byte {
 	becknErr, httpStatus, bodyStatus := nackBecknError(ctx, err)
 	nack(ctx, w, becknErr, httpStatus, bodyStatus)
+	return nackBodyBytes(ctx, becknErr, bodyStatus)
 }
 
 // isAtLeastV2 reports whether the request uses Beckn protocol v2.0.0 or later.

--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -141,7 +141,7 @@ func nackBytes(ctx context.Context, err error) []byte {
 // All other versions:
 //
 //	{"message":{"ack":{"status":"<bodyStatus>"},"error":{...}}}
-func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, httpStatus int, bodyStatus model.Status) {
+func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, httpStatus int, bodyStatus model.Status) []byte {
 	data := nackBodyBytes(ctx, becknErr, bodyStatus)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
@@ -149,13 +149,13 @@ func nack(ctx context.Context, w http.ResponseWriter, becknErr *model.Error, htt
 		log.Debugf(ctx, "Error writing response: %v, MessageID: %s", er, ctx.Value(model.ContextKeyMsgID))
 		http.Error(w, fmt.Sprintf("Internal server error, MessageID: %s", ctx.Value(model.ContextKeyMsgID)), http.StatusInternalServerError)
 	}
+	return data
 }
 
 // sendNack maps err to its Beckn error type and sends the appropriate response.
 func sendNack(ctx context.Context, w http.ResponseWriter, err error) []byte {
 	becknErr, httpStatus, bodyStatus := nackBecknError(ctx, err)
-	nack(ctx, w, becknErr, httpStatus, bodyStatus)
-	return nackBodyBytes(ctx, becknErr, bodyStatus)
+	return nack(ctx, w, becknErr, httpStatus, bodyStatus)
 }
 
 // isAtLeastV2 reports whether the request uses Beckn protocol v2.0.0 or later.

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -101,13 +101,16 @@ func TestSendAck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			sendAck(tt.ctx, rr)
+			got := sendAck(tt.ctx, rr)
 
 			if rr.Code != http.StatusOK {
 				t.Errorf("wanted status code %d, got %d", http.StatusOK, rr.Code)
 			}
 			if rr.Body.String() != tt.expected {
 				t.Errorf("body = %s, want %s", rr.Body.String(), tt.expected)
+			}
+			if string(got) != tt.expected {
+				t.Errorf("return value = %s, want %s", got, tt.expected)
 			}
 		})
 	}
@@ -212,7 +215,7 @@ func TestSendNack(t *testing.T) {
 			}
 			rr := httptest.NewRecorder()
 
-			sendNack(ctx, rr, tt.err)
+			got := sendNack(ctx, rr, tt.err)
 
 			if rr.Code != tt.status {
 				t.Errorf("wanted status code %d, got %d", tt.status, rr.Code)
@@ -233,13 +236,16 @@ func TestSendNack(t *testing.T) {
 			if !compareJSON(expected, actual) {
 				t.Errorf("err.Error() = %s, want %s", actual, expected)
 			}
+			if string(got) != rr.Body.String() {
+				t.Errorf("return value = %s, want %s", got, rr.Body.String())
+			}
 		})
 	}
 
 	for _, tt := range v2Tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			sendNack(v2Context, rr, tt.err)
+			got := sendNack(v2Context, rr, tt.err)
 
 			if rr.Code != tt.status {
 				t.Errorf("wanted status code %d, got %d", tt.status, rr.Code)
@@ -255,6 +261,9 @@ func TestSendNack(t *testing.T) {
 			}
 			if !compareJSON(expected, actual) {
 				t.Errorf("body = %s, want %s", rr.Body.String(), tt.expected)
+			}
+			if string(got) != rr.Body.String() {
+				t.Errorf("return value = %s, want %s", got, rr.Body.String())
 			}
 		})
 	}

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -359,7 +359,6 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 			return fmt.Errorf("modifyResponse: failed to read upstream response body: %w", err)
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(body))
-		*responseBody = body
 		rctx := &model.ResponseStepContext{
 			StatusCode: resp.StatusCode,
 			Header:     resp.Header,
@@ -370,6 +369,10 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 				return err
 			}
 		}
+		// Capture only after all response steps succeed — if a step fails the
+		// ReverseProxy error handler writes a 502, so the upstream body is not
+		// what the caller received.
+		*responseBody = body
 		return nil
 	}
 

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -170,6 +170,8 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Request(r.Context(), r, stepCtx.Body)
 
+	var responseBody []byte
+
 	defer func() {
 		span.SetAttributes(attribute.Int("http.response.status_code", wrapped.statusCode), attribute.String("http.request.error", errString(err)), attribute.String("observedTimeUnixNano", strconv.FormatInt(time.Now().UnixNano(), 10)))
 		if wrapped.statusCode < 200 || wrapped.statusCode >= 400 {
@@ -177,7 +179,10 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		body := stepCtx.Body
-		telemetry.EmitAuditLogs(r.Context(), body, r.Header, auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
+		telemetry.EmitAuditLogs(r.Context(), body, r.Header, auditlog.String("audit.direction", "request"), auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
+		if len(responseBody) > 0 {
+			telemetry.EmitAuditLogs(r.Context(), responseBody, nil, auditlog.String("audit.direction", "response"), auditlog.Int("http.response.status_code", wrapped.statusCode), auditlog.String("http.request.error", errString(err)), auditlog.String("sender.id", senderID), auditlog.String("receiver.id", receiverID))
+		}
 		span.End()
 	}()
 
@@ -188,7 +193,7 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Errorf(stepCtx, pipelineErr, "%T.run():%v", step, pipelineErr)
 			// Sign the NACK before writing HTTP headers (NFH-007 CON-004-02).
 			h.signNackResponse(stepCtx, pipelineErr)
-			sendNack(stepCtx, wrapped, pipelineErr)
+			responseBody = sendNack(stepCtx, wrapped, pipelineErr)
 			break
 		}
 	}
@@ -206,15 +211,15 @@ func (h *stdHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					// ackSignerStep itself failed — sign the NACK body if
 					// a different signing mechanism is available, or send unsigned.
 					h.signNackResponse(stepCtx, err)
-					sendNack(stepCtx, wrapped, err)
+					responseBody = sendNack(stepCtx, wrapped, err)
 					return
 				}
 			}
-			sendAck(stepCtx, wrapped)
+			responseBody = sendAck(stepCtx, wrapped)
 			return
 		}
 		// Handle routing based on the defined route type.
-		route(stepCtx, r, wrapped, h.publisher, h.httpClient, h.responseSteps, h.signNackResponse)
+		route(stepCtx, r, wrapped, h.publisher, h.httpClient, h.responseSteps, h.signNackResponse, &responseBody)
 	}
 }
 
@@ -282,7 +287,9 @@ func (h *stdHandler) subID(ctx context.Context) string {
 	return h.SubscriberID
 }
 
-var proxyFunc = proxy
+var proxyFunc = func(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep, responseBody *[]byte) {
+	proxy(ctx, r, w, httpClient, responseSteps, responseBody)
+}
 
 // nackSignerFunc is the function type used to sign NACK responses before they
 // are written to the wire. On Receiver modules h.signNackResponse is passed;
@@ -290,26 +297,26 @@ var proxyFunc = proxy
 type nackSignerFunc func(ctx *model.StepContext, err error)
 
 // route handles request forwarding or message publishing based on the routing type.
-func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client, responseSteps []definition.ResponseStep, signNack nackSignerFunc) {
+func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb definition.Publisher, httpClient *http.Client, responseSteps []definition.ResponseStep, signNack nackSignerFunc, responseBody *[]byte) {
 	log.Debugf(ctx, "Routing to ctx.Route to %#v", ctx.Route)
 	switch ctx.Route.TargetType {
 	case "url":
 		log.Infof(ctx.Context, "Forwarding request to URL: %s", ctx.Route.URL)
-		proxyFunc(ctx, r, w, httpClient, responseSteps)
+		proxyFunc(ctx, r, w, httpClient, responseSteps, responseBody)
 		return
 	case "publisher":
 		if pb == nil {
 			err := fmt.Errorf("publisher plugin not configured")
 			log.Errorf(ctx.Context, err, "Invalid configuration:%v", err)
 			signNack(ctx, err)
-			sendNack(ctx, w, err)
+			*responseBody = sendNack(ctx, w, err)
 			return
 		}
 		log.Infof(ctx.Context, "Publishing message to: %s", ctx.Route.PublisherID)
 		if err := pb.Publish(ctx, ctx.Route.PublisherID, ctx.Body); err != nil {
 			log.Errorf(ctx.Context, err, "Failed to publish message")
 			signNack(ctx, err)
-			sendNack(ctx, w, err)
+			*responseBody = sendNack(ctx, w, err)
 			return
 		}
 		// Publisher path: ONIX writes the ACK. Run response steps with resp=nil.
@@ -317,7 +324,7 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 			if err := step.RunOnResponse(ctx, nil); err != nil {
 				log.Errorf(ctx.Context, err, "response step failed: %v", err)
 				signNack(ctx, err)
-				sendNack(ctx, w, err)
+				*responseBody = sendNack(ctx, w, err)
 				return
 			}
 		}
@@ -325,13 +332,13 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 		err := fmt.Errorf("unknown route type: %s", ctx.Route.TargetType)
 		log.Errorf(ctx.Context, err, "Invalid configuration:%v", err)
 		signNack(ctx, err)
-		sendNack(ctx, w, err)
+		*responseBody = sendNack(ctx, w, err)
 		return
 	}
-	sendAck(ctx, w)
+	*responseBody = sendAck(ctx, w)
 }
 
-func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep) {
+func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep, responseBody *[]byte) {
 	target := ctx.Route.URL
 	r.Header.Set("X-Forwarded-Host", r.Host)
 
@@ -352,6 +359,7 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 			return fmt.Errorf("modifyResponse: failed to read upstream response body: %w", err)
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(body))
+		*responseBody = body
 		rctx := &model.ResponseStepContext{
 			StatusCode: resp.StatusCode,
 			Header:     resp.Header,

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -803,6 +803,63 @@ func TestProxy_ModifyResponse_202_InvokesResponseSteps(t *testing.T) {
 	if rr.Body.String() != ackBody {
 		t.Errorf("expected upstream body to be relayed unchanged: got %q", rr.Body.String())
 	}
+	if string(responseBody) != ackBody {
+		t.Errorf("responseBody = %q, want %q", responseBody, ackBody)
+	}
+}
+
+// TestProxy_ResponseBodyPopulatedOnSuccess verifies that the responseBody pointer
+// is set to the upstream body when the proxy call succeeds and all response steps pass.
+func TestProxy_ResponseBodyPopulatedOnSuccess(t *testing.T) {
+	upstreamBody := `{"message":{"ack":{"status":"ACK"}}}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(upstreamBody))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Route:   &model.Route{TargetType: "url", URL: upstreamURL},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	rr := httptest.NewRecorder()
+
+	var responseBody []byte
+	proxy(stepCtx, req, rr, http.DefaultClient, nil, &responseBody)
+
+	if string(responseBody) != upstreamBody {
+		t.Errorf("responseBody = %q, want %q", responseBody, upstreamBody)
+	}
+}
+
+// TestProxy_ResponseBodyEmptyWhenResponseStepFails verifies that responseBody is
+// not populated when a response step fails — the wire response in that case is a
+// 502 from the ReverseProxy error handler, not the upstream body.
+func TestProxy_ResponseBodyEmptyWhenResponseStepFails(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message":{"ack":{"status":"ACK"}}}`))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, _ := url.Parse(upstream.URL)
+	stepCtx := &model.StepContext{
+		Context: context.Background(),
+		Route:   &model.Route{TargetType: "url", URL: upstreamURL},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	rr := httptest.NewRecorder()
+
+	failingStep := &mockResponseStep{err: fmt.Errorf("response step failure")}
+	var responseBody []byte
+	proxy(stepCtx, req, rr, http.DefaultClient, []definition.ResponseStep{failingStep}, &responseBody)
+
+	if len(responseBody) != 0 {
+		t.Errorf("expected responseBody to be empty on response step failure, got %q", responseBody)
+	}
 }
 
 // stubPayloadStore is a minimal PayloadStore for storePayloadStep unit tests.

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -791,7 +791,8 @@ func TestProxy_ModifyResponse_202_InvokesResponseSteps(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/bpp/receiver/", strings.NewReader(`{}`))
 	rr := httptest.NewRecorder()
 
-	proxy(stepCtx, req, rr, http.DefaultClient, []definition.ResponseStep{respStep})
+	var responseBody []byte
+	proxy(stepCtx, req, rr, http.DefaultClient, []definition.ResponseStep{respStep}, &responseBody)
 
 	if rr.Code != http.StatusAccepted {
 		t.Errorf("expected upstream 202 to be relayed, got %d", rr.Code)
@@ -892,7 +893,8 @@ func TestProxy_QueryParamsForwardedToUpstream(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
 	rr := httptest.NewRecorder()
 
-	proxy(stepCtx, req, rr, http.DefaultClient, nil)
+	var responseBody []byte
+	proxy(stepCtx, req, rr, http.DefaultClient, nil, &responseBody)
 
 	if capturedRawQuery != "subscriptionId=test123&page=2" {
 		t.Errorf("upstream received RawQuery = %q, want %q", capturedRawQuery, "subscriptionId=test123&page=2")


### PR DESCRIPTION
## Summary

Closes #817

When a Beckn message receives a NACK, only the HTTP status code was previously visible in the audit log. This change emits a second OTel audit log record per request carrying the synchronous ACK/NACK response body, so operators and network observers can see the full error content.

- Two audit records are now emitted per request: one for the inbound payload (`audit.direction=request`) and one for the outgoing ACK/NACK body (`audit.direction=response`)
- Both records share `transaction_id` and `message_id` for correlation
- The response body passes through the same `ProcessAuditPayload` pipeline (PII masking, full/selective mode) — no new config needed
- No impact on existing Grafana panels; operators using log-count queries should filter on `audit.direction="request"` to avoid double-counting

## Implementation approach

- `sendAck` / `sendNack` in `responsestep.go` now return the body bytes they write to the wire (no logic change, just surfacing what was already constructed)
- A `var responseBody []byte` local variable in `ServeHTTP` is populated at all three exit paths (pipeline-error NACK, publisher-path ACK/NACK, proxy `modifyResponse`)
- `proxy` and `route` accept a `*[]byte` to write through; the `defer` reads it and conditionally emits the second audit record
- All existing tests pass; two test call-sites updated for the new `proxy` signature

## Test plan

- [ ] Run `go test ./core/...` — all pass
- [ ] Deploy with `enableLogs: true` and trigger a schema validation failure — confirm two audit records appear in Loki with matching `transaction_id`, one with `audit.direction=request` and one with `audit.direction=response` containing the NACK error body
- [ ] Confirm ACK path also produces a response record with `{"message":{"status":"ACK",...}}`
- [ ] Confirm no regression on proxy path (routed requests) — response body from upstream appears as the response audit record