### PR TITLE
docs: rewrite SETUP.md for clarity, audience flow, and current tooling

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -405,6 +405,8 @@ spec:
         env:
         - name: REDIS_ADDR
           value: redis-cnode.beckn-onix.svc.cluster.local:6379
+        # The following three vars are only needed if using the keymanager plugin (Vault-backed keys).
+        # Remove them if using simplekeymanager.
         - name: VAULT_ADDR
           valueFrom:
             secretKeyRef:

--- a/SETUP.md
+++ b/SETUP.md
@@ -666,7 +666,7 @@ Check that `REDIS_ADDR` in the container environment matches the Redis service n
 
 - Confirm the correct key pair is configured — the public key registered with the network registry must match the private key in `simplekeymanager` or Vault
 - Check clock synchronization between nodes; the signature includes a `created` timestamp and the validator applies a clock-skew tolerance
-- Confirm the `subscriber_id` in the config matches what is registered in the network registry
+- Confirm the `subscriber_id` and `key_id` in the config match what is registered in the network registry
 
 ### Vault authentication failures
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -25,7 +25,7 @@ This document covers only how to get ONIX running. Three companion documents:
 
 ## 1. The Fastest Path: NFH Fabric Starter Kit
 
-The [Beckn Starter Kit](https://github.com/beckn/beckn-onix-starter-kit) provisions a complete working network in a single command: two ONIX adapters (Consumer Node + Provider Node), sandbox applications, and the NFH fabric services that tie them together. No prior ONIX experience required.
+The [Beckn Starter Kit](https://github.com/beckn/starter-kit) provisions a complete working network in a single command: two ONIX adapters (Consumer Node + Provider Node), sandbox applications, and the NFH fabric services that tie them together. No prior ONIX experience required.
 
 Follow the starter kit's own README for setup instructions. Everything in this document targets operators who need to go beyond the starter kit — custom deployment topology, production hardening, or custom plugins.
 
@@ -275,7 +275,7 @@ In a production deployment, ONIX and Redis run as containers alongside your appl
 
 ### 4.2 Docker Compose
 
-For VM-based deployments, extend your existing docker-compose file to include ONIX and Redis alongside your application containers. The starter kit's docker-compose is a good starting point — see the [starter kit](https://github.com/beckn/beckn-onix-starter-kit) for a complete working example.
+For VM-based deployments, extend your existing docker-compose file to include ONIX and Redis alongside your application containers. The starter kit's docker-compose is a good starting point — see the [starter kit](https://github.com/beckn/starter-kit) for a complete working example.
 
 A production-oriented compose file adds dedicated Redis instances per node and removes dev-only services:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,1180 +1,363 @@
 # Beckn-ONIX Setup Guide
 
-This comprehensive guide walks you through setting up Beckn-ONIX from development to production deployment.
+## Reading Guide
+
+[docs.nfh.global](https://docs.nfh.global) is the primary documentation site for the NFH fabric — it covers the full network, participant roles, protocol lifecycle, and how all components work together. ONIX is the protocol adapter that any network participant (Consumer Node or Provider Node) runs to connect their application to the fabric; start there if you are new to the network.
+
+This document covers only how to get ONIX running. Three companion documents:
+
+- **[README.md](README.md)** — what ONIX is, its architecture, plugin inventory, and API surface
+- **[CONFIG.md](CONFIG.md)** — every configuration parameter, module/handler/step/plugin concepts, and deployment scenarios
+- **This document** — how to run, build, and deploy ONIX
+
+---
 
 ## Table of Contents
 
-1. [Prerequisites](#prerequisites)
-2. [Development Setup](#development-setup)
-3. [Production Setup](#production-setup)
-4. [Configuration Guide](#configuration-guide)
-5. [External Services Setup](#external-services-setup)
-6. [GUI Component Setup](#gui-component-setup)
-7. [Docker Deployment](#docker-deployment)
-8. [Kubernetes Deployment](#kubernetes-deployment)
-9. [Observability](#observability)
-10. [Testing Your Setup](#testing-your-setup)
-11. [Troubleshooting](#troubleshooting)
-12. [Sample Payloads](#sample-payloads)
+1. [The Fastest Path: NFH Fabric Starter Kit](#1-the-fastest-path-nfh-fabric-starter-kit)
+2. [Running ONIX with Docker](#2-running-onix-with-docker)
+3. [Building Your Own ONIX Image](#3-building-your-own-onix-image)
+4. [Production Setup](#4-production-setup)
+5. [Observability](#5-observability)
+6. [Troubleshooting](#6-troubleshooting)
 
 ---
 
-## Prerequisites
+## 1. The Fastest Path: NFH Fabric Starter Kit
 
-### System Requirements
+The [Beckn Starter Kit](https://github.com/beckn/beckn-onix-starter-kit) provisions a complete working network in a single command: two ONIX adapters (Consumer Node + Provider Node), sandbox applications, and the NFH fabric services that tie them together. No prior ONIX experience required.
 
-- **Operating System**: Linux, macOS, or Windows (with WSL2)
-- **CPU**: 2+ cores recommended
-- **RAM**: 4GB minimum, 8GB recommended
-- **Disk Space**: 2GB free space
+Follow the starter kit's own README for setup instructions. Everything in this document targets operators who need to go beyond the starter kit — custom deployment topology, production hardening, or custom plugins.
 
-### Software Requirements
+---
 
-#### Required
-- **Go 1.23+**: [Download Go](https://golang.org/dl/)
-- **Git**: [Download Git](https://git-scm.com/downloads)
-- **Redis 6.0+**: For caching functionality
+## 2. Running ONIX with Docker
 
-#### Optional (for production)
-- **Docker 20.10+**: For containerized deployment
-- **HashiCorp Vault 1.12+**: For secrets management
-- **RabbitMQ 3.10+**: For async messaging
-- **Kubernetes 1.25+**: For orchestrated deployment
+### 2.1 Using the Pre-built Image
 
-### Verify Installation
+The starter kit's docker-compose is the canonical reference for how to wire an ONIX container correctly. A minimal service definition for a Consumer Node adapter:
+
+```yaml
+services:
+  # Consumer Node adapter — handles outbound calls to the network
+  # and receives inbound callbacks from network participants.
+  # Name this after the role it serves in your deployment.
+  onix-cnode:
+    image: fidedocker/onix-adapter   # use your own image tag if running a custom-built version
+    container_name: onix-cnode
+    platform: linux/amd64
+    ports:
+      - "8081:8081"
+    restart: unless-stopped
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      REDIS_ADDR: redis:6379          # required only if the config uses the cache plugin
+    volumes:
+      - ../config:/app/config         # adapter reads its config from this mount
+    # The --config flag is the primary entry point into all adapter behaviour:
+    # which handlers run, which plugins load, which steps execute, and how
+    # each plugin is configured. See CONFIG.md for the full reference.
+    command: ["./server", "--config=/app/config/generic-cnode.yaml"]
+    networks:
+      - beckn_network
+```
+
+**Environment variables** — ONIX reads very few. Most configuration lives in the YAML config file mounted above, not in the environment:
+
+| Variable | When required | Example |
+|---|---|---|
+| `REDIS_ADDR` | `cache` plugin is configured | `redis:6379` |
+| `VAULT_ADDR` | `keymanager` plugin is configured | `http://vault:8200` |
+| `VAULT_ROLE_ID` | `keymanager` with AppRole auth | `<role-id>` |
+| `VAULT_SECRET_ID` | `keymanager` with AppRole auth | `<secret-id>` |
+| `RABBITMQ_ADDR` | `publisher` plugin is configured | `rabbitmq:5672` |
+| `RABBITMQ_USER` | `publisher` plugin is configured | `admin` |
+| `RABBITMQ_PASS` | `publisher` plugin is configured | `admin123` |
+
+No other environment variables are needed. The config path is always passed as the `--config` flag in the command, not as an environment variable.
+
+Verify the adapter is up:
 
 ```bash
-# Check Go version
-go version
-# Expected: go version go1.23.x
+curl http://localhost:8081/health
+# {"status":"ok","service":"beckn-adapter"}
+```
 
-# Check Git
-git --version
+Or check the container logs — the adapter logs a listening message when it is ready:
 
-# Check Docker (optional)
-docker --version
+```bash
+docker logs onix-cnode 2>&1 | tail -5
+# ...
+# {"level":"info","message":"Server listening on :8081"}
+```
 
-# Check Redis
-redis-cli --version
+### 2.2 Running Multiple Handlers on One Instance
+
+A single ONIX process can serve multiple handlers simultaneously — for example, acting as both Consumer Node and Provider Node adapter within one container, or serving two Consumer Nodes for different Beckn networks. This works like a reverse proxy: the same port serves different endpoint paths, and each path is handled by a separately configured handler.
+
+Each handler is declared as a separate module in the config file with its own path, plugins, and processing steps:
+
+```
+http://localhost:8081/cnode/caller/    →  Consumer Node outbound handler
+http://localhost:8081/cnode/receiver/  →  Consumer Node inbound handler
+http://localhost:8081/pnode/caller/    →  Provider Node outbound handler
+http://localhost:8081/pnode/receiver/  →  Provider Node inbound handler
+```
+
+All four paths are served by one process on one port — the path prefix determines which handler and which plugin pipeline processes the request. See [CONFIG.md](CONFIG.md) for how to declare modules and handlers in a config file.
+
+The `config/` directory includes ready-made configurations for common topologies:
+
+```
+config/
+├── local-simple.yaml        # Combined Consumer + Provider Node, dev, embedded keys
+├── local-dev.yaml           # Combined Consumer + Provider Node, dev, Vault keys
+├── onix/adapter.yaml        # Combined Consumer + Provider Node, production
+├── onix-bap/adapter.yaml    # Consumer Node only
+└── onix-bpp/adapter.yaml    # Provider Node only
+```
+
+Alternatively, run dedicated containers for each role as the starter kit does:
+
+```yaml
+services:
+  onix-cnode:                          # Consumer Node adapter
+    image: fidedocker/onix-adapter
+    command: ["./server", "--config=/app/config/onix-bap/adapter.yaml"]
+    ports:
+      - "8081:8081"
+
+  onix-pnode:                          # Provider Node adapter
+    image: fidedocker/onix-adapter
+    command: ["./server", "--config=/app/config/onix-bpp/adapter.yaml"]
+    ports:
+      - "8082:8082"
+```
+
+### 2.3 Redis: One Instance per ONIX Node
+
+Each ONIX instance should have its own dedicated Redis rather than sharing one across multiple adapter instances.
+
+The cache plugin keys cached responses on `message_id`. When two ONIX adapters share a Redis instance, a cached response from one node can be incorrectly served to the other, causing hard-to-diagnose correctness bugs under load.
+
+For local development the starter kit shares a single Redis for simplicity, which is fine when load is low and collisions are unlikely. For production, give each node its own Redis:
+
+```yaml
+services:
+  redis-cnode:
+    image: redis:alpine
+    container_name: redis-cnode
+
+  redis-pnode:
+    image: redis:alpine
+    container_name: redis-pnode
+
+  onix-cnode:
+    image: fidedocker/onix-adapter
+    environment:
+      REDIS_ADDR: redis-cnode:6379
+    depends_on:
+      redis-cnode:
+        condition: service_healthy
+
+  onix-pnode:
+    image: fidedocker/onix-adapter
+    environment:
+      REDIS_ADDR: redis-pnode:6379
+    depends_on:
+      redis-pnode:
+        condition: service_healthy
 ```
 
 ---
 
-## Quick Start (Recommended)
+## 3. Building Your Own ONIX Image
 
-### Option 1: ONIX Adapter Only (Fastest)
+If neither of the following applies, use the pre-built image from section 2 — there is no benefit to building your own.
 
-For just the ONIX adapter with Redis (no Vault required):
+Build your own image when:
 
-```bash
-# Clone the repository
-git clone https://github.com/beckn/beckn-onix.git
-cd beckn-onix/install
+1. **You have custom plugins** — you have written a new `.so` plugin and need it bundled into the image alongside the standard set.
+2. **You want to cherry-pick plugins** — the official image bundles all plugins from this repository. However, various organisations and cloud providers publish their own ONIX plugins (for managed key stores, proprietary registries, custom policy engines, etc.), and a network participant may want an image that combines a specific subset of standard plugins with one or more third-party ones, rather than carrying everything.
 
-# Run the automated setup
-chmod +x setup.sh
-./setup.sh
-```
+### Prerequisites
 
-This will automatically:
-- Start Redis container
-- Build all plugins
-- Build adapter server
-- Start ONIX adapter in Docker using `local-simple.yaml` (with `simplekeymanager`)
-- Create .env file
+- **Go** — check `go.mod` at the root of this repository for the required version and install that exact version from [golang.org/dl](https://golang.org/dl/)
+- Git
+- Docker
+- Redis — only needed at runtime if the `cache` plugin is configured
 
-**Services Started:**
-- Redis: localhost:6379
-- ONIX Adapter: http://localhost:8081
+### Build Steps
 
-**Key Management:** Uses `simplekeymanager` with embedded keys - no Vault setup required!
-
-**Note:** 
-- **Schema Validation**: Extract schemas before running: `unzip schemas.zip` (required for `schemavalidator` plugin)
-- **Alternative**: You can use `schemav2validator` plugin instead, which fetches schemas from a URL and doesn't require local schema extraction. See [CONFIG.md](CONFIG.md) for more configuration details.
-- **Optional**: Before running the automated setup, build the adapter image and update `docker-compose-adapter.yaml` to use the correct image
-
-```bash
-# from the repository root
-docker build -f Dockerfile.adapter-with-plugins -t beckn-onix:latest .
-```
-
-### Option 2: Beckn One Network Setup
-
-For a local setup using Beckn One with DeDI-Registry and Catalog Discovery:
-
-```bash
-cd beckn-onix/install
-chmod +x beckn-onix.sh
-./beckn-onix.sh
-
-# Choose option 3: "Set up a network on local machine with Beckn One (DeDI-Registry, Catalog Discovery)"
-```
-
-This will automatically:
-- Install required packages (Docker, docker-compose, jq)
-- Build ONIX adapter plugins
-- Start Redis
-- Start ONIX adapters for BAP and BPP with Beckn One configuration
-- Start Sandbox containers for BAP and BPP
-
-**Services Started:**
-- Redis: localhost:6379
-- ONIX Adapter (BAP): http://localhost:8081
-- ONIX Adapter (BPP): http://localhost:8082
-- Sandbox BAP: http://localhost:3001
-- Sandbox BPP: http://localhost:3002
-
-**Key Features:**
-- Uses Beckn One (DeDI-Registry) for registry services
-- Pre-configured keys in YAML configuration files
-- No local registry or gateway deployment required
-
-**Note:** 
-- **Schema Validation**: Extract schemas before running: `unzip schemas.zip` (required for `schemavalidator` plugin)
-- **Alternative**: You can use `schemav2validator` plugin instead, which fetches schemas from a URL and doesn't require local schema extraction. See [CONFIG.md](CONFIG.md) for more configuration details.
-
-### Option 3: Complete Beckn Network
-
-
-For a full local Beckn network with all components:
-
-```bash
-cd beckn-onix/install
-chmod +x beckn-onix.sh
-./beckn-onix.sh
-
-# Choose option 4: "Set up a network on local machine with local registry and gateway (without Beckn One)"
-
-```
-
-This will automatically:
-- Install and configure Registry service
-- Install and configure Gateway service
-- Create BAP Protocol Server registry entries
-- Create BPP Protocol Server registry entries
-- Build ONIX adapter plugins
-- **Detect config file** from `docker-compose-adapter.yml`
-- **Extract keys** from protocol server configs (`bap-client.yml`, `bpp-client.yml`)
-- **Auto-update simplekeymanager** in the detected config file with extracted keys
-- Start ONIX Adapter with Redis
-
-**Services Started:**
-- Registry: http://localhost:3030
-- Gateway: http://localhost:4030  
-- Sandbox API: http://localhost:3000 
-- ONIX Adapter: http://localhost:8081
-- Redis: localhost:6379
-
-**Note:** 
-- **Schema Validation**: Extract schemas before running: `unzip schemas.zip` (required for `schemavalidator` plugin)
-- **Alternative**: You can use `schemav2validator` plugin instead, which fetches schemas from a URL and doesn't require local schema extraction. See [CONFIG.md](CONFIG.md) for more configuration details.
-- **Optional**: Before running the automated full-network setup, build the adapter image and update `docker-compose-adapter.yaml` to use the correct image
-
-```bash
-# from the repository root
-docker build -f Dockerfile.adapter-with-plugins -t beckn-onix:latest .
-```
-
-**Intelligent Key Management:**
-The script reads `docker-compose-adapter.yml` to detect which config file is being used (default: `local-simple.yaml`), extracts keys from protocol server configs, and automatically updates the `simplekeymanager` section in that config file - no manual configuration needed!
-
-**Note:** Update `docker-compose-adapter.yml` to use the correct config file and correct image (optional):
-- For combined setup (simplekeymanager): `CONFIG_FILE: "/app/config/local-simple.yaml"`
-- For combined setup (keymanager with Vault): `CONFIG_FILE: "/app/config/local-dev.yaml"`
-- For combined setup (production): `CONFIG_FILE: "/app/config/onix/adapter.yaml"`
-- For BAP only: `CONFIG_FILE: "/app/config/onix-bap/adapter.yaml"`
-- For BPP only: `CONFIG_FILE: "/app/config/onix-bpp/adapter.yaml"`
-
-The script will automatically detect and configure whichever file you specify.
-
----
-
-## Development Setup (Manual)
-
-### Step 1: Clone the Repository
+**Clone and fetch dependencies:**
 
 ```bash
 git clone https://github.com/beckn/beckn-onix.git
 cd beckn-onix
-```
-
-### Step 2: Install Dependencies
-
-```bash
-# Download Go dependencies
 go mod download
-
-# Verify dependencies
-go mod verify
 ```
 
-### Step 3: Build the Application
+**Build plugins:**
 
 ```bash
-# Build the main server binary
+# Build all plugins — produces .so files in plugins/
+./install/build-plugins.sh
+```
+
+For the **cherry-pick** case, open `install/build-plugins.sh` and remove the `go build` lines for plugins you do not need before running it. Each plugin's build line is clearly labelled in the script.
+
+For **custom plugins**, add your plugin's `go build -buildmode=plugin` line to the script, or run it directly:
+
+```bash
+go build -buildmode=plugin \
+  -o plugins/myplugin.so \
+  ./pkg/plugin/implementation/myplugin/cmd/plugin.go
+```
+
+**Build the adapter binary:**
+
+```bash
 go build -o server cmd/adapter/main.go
-
-# Make it executable
-chmod +x server
 ```
 
-### Step 4: Build Plugins
-
-The application uses a plugin architecture. Build all plugins:
+**Build and tag the Docker image:**
 
 ```bash
-# Make the build script executable
-chmod +x install/build-plugins.sh
+docker build \
+  -f Dockerfile.adapter-with-plugins \
+  -t my-org/beckn-onix:1.6.0 .
 
-# Build all plugins (run from project root)
-./install/build-plugins.sh
+docker push my-org/beckn-onix:1.6.0
 ```
 
-This creates `.so` files in the `plugins/` directory:
-- `cache.so` - Redis caching
-- `router.so` - Request routing
-- `signer.so` - Message signing
-- `signvalidator.so` - Signature validation
-- `schemavalidator.so` - JSON schema validation
-- `schemav2validator.so` - OpenAPI 3.x schema validation
-- `keymanager.so` - Vault integration
-- `simplekeymanager.so` - Simple key management (no Vault)
-- `publisher.so` - RabbitMQ publishing
-- `registry.so` - Registry lookup
-- `dediregistry.so` - registry type plugin for public key lookup
-- `encrypter.so` / `decrypter.so` - Encryption/decryption
-- `reqpreprocessor.so` - Request preprocessing
-
-### Step 5: Setup Redis (Local)
-
-#### Option A: Using Docker
-```bash
-docker run -d \
-  --name redis-onix \
-  -p 6379:6379 \
-  redis:alpine
-```
-
-#### Option B: Native Installation
-
-**macOS:**
-```bash
-brew install redis
-brew services start redis
-```
-
-**Ubuntu/Debian:**
-```bash
-sudo apt update
-sudo apt install redis-server
-sudo systemctl start redis-server
-sudo systemctl enable redis-server
-```
-
-**Verify Redis:**
-```bash
-redis-cli ping
-# Expected: PONG
-```
-
-### Step 6: Setup Schemas
-
-```bash
-# Create schemas directory
-mkdir -p schemas
-
-# Extract schemas from the provided schemas.zip
-unzip schemas.zip
-
-# Create logs directory (optional)
-mkdir -p logs
-```
-
-**Note:** The `schemas.zip` file is included in the repository. You must extract it before running the adapter for schema validation to work.
-
-### Step 7: Configure for Local Development
-
-For local development, use the existing `config/local-simple.yaml` which includes:
-- All 4 modules (BAP + BPP)
-- Simple key management (no Vault required)
-- Redis caching
-- Basic routing configuration
-
-The file is pre-configured with embedded sample keys and ready to use for standalone testing.
-
-**Note:** When using `beckn-onix.sh` (Option 2 in Quick Start), the script automatically extracts keys from protocol server configs and updates the `simplekeymanager` section in this file - no manual configuration needed!
-
-### Step 8: Configuration Files Overview
-
-The `config/` directory contains deployment configurations:
-
-```
-config/
-├── local-dev.yaml                      # Local development with Vault
-├── local-simple.yaml                   # Local development (no Vault)
-├── local-routing.yaml                  # Local routing rules
-├── local-simple-routing.yaml           # Simple routing rules
-├── local-simple-routing-BAPCaller.yaml # BAP caller routing
-├── local-simple-routing-BPPReceiver.yaml # BPP receiver routing
-├── onix/                               # Combined BAP+BPP deployment
-│   ├── adapter.yaml
-│   ├── plugin.yaml
-│   ├── bapTxnCaller-routing.yaml
-│   ├── bapTxnReciever-routing.yaml
-│   ├── bppTxnCaller-routing.yaml
-│   └── bppTxnReciever-routing.yaml
-├── onix-bap/                           # BAP-only deployment
-│   ├── adapter.yaml
-│   ├── plugin.yaml
-│   ├── bapTxnCaller-routing.yaml
-│   └── bapTxnReciever-routing.yaml
-└── onix-bpp/                           # BPP-only deployment
-    ├── adapter.yaml
-    ├── plugin.yaml
-    ├── bppTxnCaller-routing.yaml
-    └── bppTxnReciever-routing.yaml
-```
-
-Routing configuration files for local-simple are already provided and referenced in `local-simple.yaml`.
-
-
-### Step 9: Run the Application
-
-**Choose your key management approach:**
-
-#### Option A: Simple Key Manager (Recommended for Local Development)
-
-**No Vault setup required!** Use this for quick local testing.
-
-```bash
-# Run with local-simple.yaml (uses simplekeymanager plugin)
-./server --config=config/local-simple.yaml
-
-# Or run with go
-go run cmd/adapter/main.go --config=config/local-simple.yaml
-```
-
-The `local-simple.yaml` config uses `simplekeymanager` plugin with embedded keys - no external dependencies needed.
-
-**With Docker:**
-```bash
-cd install
-docker compose -f docker-compose-adapter.yml up -d onix-adapter
-```
-
-The server will start on `http://localhost:8081`
-
----
-
-#### Option B: HashiCorp Vault (Production-like Setup)
-
-**Only use this if your config has `keymanager` plugin (not `simplekeymanager`).**
-
-Configs that require Vault:
-- `config/local-dev.yaml` - uses `keymanager` plugin
-- `config/onix/adapter.yaml` - uses `secretskeymanager` plugin
-
-#### Quick Setup (Recommended)
-
-**Note:** Make sure Redis is already running from Step 5.
-
-```bash
-# Make the script executable
-chmod +x start-vault.sh
-
-# Run the automated setup script
-./start-vault.sh
-
-# This creates a .env.vault file with your credentials
-# Source it and run the server
-source .env.vault && ./server --config=config/local-dev.yaml
-```
-
-That's it! The script handles everything automatically.
-
-#### Manual Setup (Advanced)
-
-If you prefer to set up Vault manually or need custom configuration:
-
-```bash
-# 1. Start Vault container
-docker run -d \
-  --name vault-dev \
-  --cap-add=IPC_LOCK \
-  -p 8200:8200 \
-  -e 'VAULT_DEV_ROOT_TOKEN_ID=root' \
-  hashicorp/vault:latest
-
-# 2. Configure Vault (run the setup script)
-chmod +x config/setup-vault.sh
-./config/setup-vault.sh
-
-# 3. Export the displayed credentials
-export VAULT_ROLE_ID=<displayed-role-id>
-export VAULT_SECRET_ID=<displayed-secret-id>
-
-# 4. Run the server
-./server --config=config/local-dev.yaml
-```
-
-#### What the Setup Does
-
-- Starts Vault in development mode on port 8200
-- Enables AppRole authentication
-- Creates necessary policies and roles  
-- Sets up the KV secrets engine at path `beckn`
-- Stores sample keys for both BAP and BPP
-- Generates and saves credentials to `.env.vault`
-
-#### Accessing Vault UI
-
-- **URL:** http://localhost:8200
-- **Token:** root
-
-#### Troubleshooting
-
-If you get "invalid role or secret ID" error, the SECRET_ID has expired. Simply run:
-```bash
-./start-vault.sh
-source .env.vault
-```
-
-**Alternative: Simple Docker Run Command**
-
-```bash
-# Start Vault in dev mode with initial setup
-docker run -d \
-  --name vault-dev \
-  --cap-add=IPC_LOCK \
-  -p 8200:8200 \
-  -e 'VAULT_DEV_ROOT_TOKEN_ID=root' \
-  -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' \
-  hashicorp/vault:latest
-
-# Wait for Vault to be ready
-sleep 3
-
-# Setup Vault using a single command
-docker exec vault-dev sh -c "
-  export VAULT_ADDR='http://127.0.0.1:8200' &&
-  export VAULT_TOKEN='root' &&
-  vault secrets enable -path=beckn kv-v2 &&
-  vault kv put beckn/keys/bap private_key='sample_bap_private_key' public_key='sample_bap_public_key' &&
-  vault kv put beckn/keys/bpp private_key='sample_bpp_private_key' public_key='sample_bpp_public_key'
-"
-```
-
-**Step 9b: Set Environment Variables and Run**
-
-```bash
-# Get the AppRole credentials from Vault container logs
-docker logs vault-dev | grep "VAULT_ROLE_ID\|VAULT_SECRET_ID"
-
-# Copy the displayed credentials and export them
-# They will look something like this:
-export VAULT_ROLE_ID='<role-id-from-logs>'
-export VAULT_SECRET_ID='<secret-id-from-logs>'
-
-# Run the server
-./server --config=config/local-dev.yaml
-
-# Or using go run
-go run cmd/adapter/main.go --config=config/local-dev.yaml
-```
-
-**Note:** The Vault address is already configured in `config/local-dev.yaml` as `http://localhost:8200`. The docker-compose automatically sets up AppRole authentication and displays the credentials in the logs.
-
-**Alternative: Create a startup script**
-
-Create `run-with-vault.sh`:
-
-```bash
-#!/bin/bash
-# Set Vault environment variables
-export VAULT_ADDR=${VAULT_ADDR:-"http://localhost:8200"}
-export VAULT_TOKEN=${VAULT_TOKEN:-"root"}  # For dev mode
-
-# Or use AppRole auth for production-like setup
-# export VAULT_ROLE_ID=${VAULT_ROLE_ID:-"beckn-role-id"}
-# export VAULT_SECRET_ID=${VAULT_SECRET_ID:-"beckn-secret-id"}
-
-echo "Starting Beckn-ONIX with Vault key management..."
-echo "Vault Address: $VAULT_ADDR"
-
-# Check if Vault is accessible
-if ! curl -s "$VAULT_ADDR/v1/sys/health" > /dev/null 2>&1; then
-    echo "Error: Cannot reach Vault at $VAULT_ADDR"
-    echo "Please start Vault first with: vault server -dev -dev-root-token-id='root'"
-    exit 1
-fi
-
-# Run the server
-./server --config=config/local-dev.yaml
-```
-
-Make it executable and run:
-```bash
-chmod +x run-with-vault.sh
-./run-with-vault.sh
-```
-
-The server will start on `http://localhost:8081`
-
-### Step 10: Verify Setup
-
-```bash
-# Check health endpoint
-curl http://localhost:8081/health
-
-# Check if modules are loaded
-curl http://localhost:8081/bap/receiver/
-# Expected: 404 with proper error (means module is loaded)
-```
-
----
-
-
-## Production Setup
-
-### Integrating with Public cloud providers
-
-Public cloud providers have built integration plugins and other tools to deploy Beckn ONIX easily. They provide specialized plugins that integrate with managed services on those platforms. Network participants can choose to consume them.
-
-1. [Google Cloud Platform](https://github.com/GoogleCloudPlatform/dpi-accelerator-beckn-onix)
-2. [Amazon Web Services](https://github.com/beckn/onix-aws-cdk)
-
-The rest of the document focuses on how to deploy ONIX in Production with cloud agnostic plugins and tools.
-
-### Additional Requirements for Production
-
-1. **HashiCorp Vault** for key management
-2. **RabbitMQ** for message queuing (needed for async flows)
-3. **TLS certificates** for secure communication
-4. **Load balancer** for high availability
-
-### Step 1: Setup HashiCorp Vault
-
-#### Install Vault
-```bash
-# Download and install
-wget https://releases.hashicorp.com/vault/1.15.0/vault_1.15.0_linux_amd64.zip
-unzip vault_1.15.0_linux_amd64.zip
-sudo mv vault /usr/local/bin/
-```
-
-#### Configure Vault
-```bash
-# Start Vault in dev mode (for testing only)
-vault server -dev -dev-root-token-id="root"
-
-# In production, use proper configuration
-cat > vault-config.hcl <<EOF
-storage "file" {
-  path = "/opt/vault/data"
-}
-
-listener "tcp" {
-  address     = "0.0.0.0:8200"
-  tls_disable = 0
-  tls_cert_file = "/opt/vault/tls/cert.pem"
-  tls_key_file  = "/opt/vault/tls/key.pem"
-}
-
-api_addr = "https://vault.example.com:8200"
-cluster_addr = "https://vault.example.com:8201"
-ui = true
-EOF
-
-vault server -config=vault-config.hcl
-```
-
-#### Setup Keys in Vault
-```bash
-# Login to Vault
-export VAULT_ADDR='http://localhost:8200'
-vault login token=root
-
-# Enable KV secrets engine
-vault secrets enable -path=beckn kv-v2
-
-# Store signing keys
-vault kv put beckn/keys/bap \
-  private_key="$(cat bap_private_key.pem)" \
-  public_key="$(cat bap_public_key.pem)"
-
-vault kv put beckn/keys/bpp \
-  private_key="$(cat bpp_private_key.pem)" \
-  public_key="$(cat bpp_public_key.pem)"
-```
-
-### Step 2: Setup RabbitMQ
-
-#### Using Docker
-```bash
-docker run -d \
-  --name rabbitmq-onix \
-  -p 5672:5672 \
-  -p 15672:15672 \
-  -e RABBITMQ_DEFAULT_USER=admin \
-  -e RABBITMQ_DEFAULT_PASS=admin123 \
-  rabbitmq:3-management
-```
-
-#### Configure Exchange and Queues
-```bash
-# Access RabbitMQ management UI
-# http://localhost:15672 (admin/admin123)
-
-# Or use CLI
-docker exec rabbitmq-onix rabbitmqctl add_exchange beckn_exchange topic
-docker exec rabbitmq-onix rabbitmqctl add_queue search_queue
-docker exec rabbitmq-onix rabbitmqctl bind_queue search_queue beckn_exchange "*.search"
-```
-
-### Step 3: Production Configuration
-
-Create `config/production.yaml`:
+**Use your image in docker-compose** by replacing the `image:` field:
 
 ```yaml
-appName: "beckn-onix-prod"
-log:
-  level: info
-  destinations:
-    - type: file
-      config:
-        filename: /var/log/beckn-onix/app.log
-        maxSize: 100  # MB
-        maxBackups: 10
-        maxAge: 30    # days
-    - type: stdout
-  contextKeys:
-    - transaction_id
-    - message_id
-    - subscriber_id
-    - module_id
-    - domain
-    - action
-http:
-  port: 8080
-  timeout:
-    read: 60
-    write: 60
-    idle: 120
-  tls:
-    enabled: true
-    certFile: /etc/ssl/certs/server.crt
-    keyFile: /etc/ssl/private/server.key
-pluginManager:
-  root: ./plugins
-modules:
-  - name: bapTxnReceiver
-    path: /bap/receiver/
-    handler:
-      type: std
-      role: bap
-      registryUrl: https://registry.ondc.org/lookup
-      plugins:
-        keyManager:
-          id: keymanager
-          config:
-            projectID: ${PROJECT_ID}
-            vaultAddr: ${VAULT_ADDR}
-            kvVersion: v2
-        cache:
-          id: cache
-          config:
-            addr: ${REDIS_ADDR}
-            password: ${REDIS_PASSWORD}
-            db: 0
-            poolSize: 100
-        schemaValidator:
-          id: schemavalidator
-          config:
-            schemaDir: ./schemas
-            strictMode: true
-        signValidator:
-          id: signvalidator
-          config:
-            publicKeyPath: beckn/keys
-        router:
-          id: router
-          config:
-            routingConfig: ./config/routing-prod.yaml
-        publisher:
-          id: publisher
-          config:
-            addr: ${RABBITMQ_ADDR}
-            username: ${RABBITMQ_USER}
-            password: ${RABBITMQ_PASS}
-            exchange: beckn_exchange
-            durable: true
-            useTLS: true
-        middleware:
-          - id: reqpreprocessor
-            config:
-              uuidKeys: transaction_id,message_id
-              role: bap
-      steps:
-        - validateSign
-        - addRoute
-        - validateSchema
-        - cache
-        - publish
-  
-  # Add similar configuration for other modules...
-```
-
-### Step 4: Environment Variables
-
-Create `.env.production`:
-
-```bash
-# Vault Configuration
-VAULT_ADDR=https://vault.example.com:8200
-VAULT_ROLE_ID=your-role-id
-VAULT_SECRET_ID=your-secret-id
-PROJECT_ID=beckn-onix-prod
-
-# Redis Configuration
-REDIS_ADDR=redis.example.com:6379
-REDIS_PASSWORD=strong-redis-password
-
-# RabbitMQ Configuration
-RABBITMQ_ADDR=rabbitmq.example.com:5671
-RABBITMQ_USER=beckn_user
-RABBITMQ_PASS=strong-rabbitmq-password
-
-# Application Configuration
-LOG_LEVEL=info
-CONFIG_FILE=/app/config/production.yaml
-```
-
-### Step 5: Systemd Service (Linux)
-
-Create `/etc/systemd/system/beckn-onix.service`:
-
-```ini
-[Unit]
-Description=Beckn ONIX Adapter
-After=network.target redis.service
-
-[Service]
-Type=simple
-User=beckn
-Group=beckn
-WorkingDirectory=/opt/beckn-onix
-EnvironmentFile=/opt/beckn-onix/.env.production
-ExecStart=/opt/beckn-onix/server --config=${CONFIG_FILE}
-Restart=always
-RestartSec=10
-StandardOutput=append:/var/log/beckn-onix/stdout.log
-StandardError=append:/var/log/beckn-onix/stderr.log
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Enable and start:
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable beckn-onix
-sudo systemctl start beckn-onix
-sudo systemctl status beckn-onix
-```
-
----
-
-## Configuration Guide
-
-### Configuration Hierarchy
-
-```
-config/
-├── local-dev.yaml                      # Local development with Vault
-├── local-simple.yaml                   # Local development (no Vault)
-├── local-routing.yaml                  # Local routing rules
-├── local-simple-routing.yaml           # Simple routing rules
-├── local-simple-routing-BAPCaller.yaml # BAP caller routing
-├── local-simple-routing-BPPReceiver.yaml # BPP receiver routing
-├── onix/                               # Combined BAP+BPP deployment
-│   ├── adapter.yaml
-│   ├── plugin.yaml
-│   ├── bapTxnCaller-routing.yaml
-│   ├── bapTxnReciever-routing.yaml
-│   ├── bppTxnCaller-routing.yaml
-│   └── bppTxnReciever-routing.yaml
-├── onix-bap/                           # BAP-only deployment
-│   ├── adapter.yaml
-│   ├── plugin.yaml
-│   ├── bapTxnCaller-routing.yaml
-│   └── bapTxnReciever-routing.yaml
-└── onix-bpp/                           # BPP-only deployment
-    ├── adapter.yaml
-    ├── plugin.yaml
-    ├── bppTxnCaller-routing.yaml
-    └── bppTxnReciever-routing.yaml
-```
-
-### Module Configuration
-
-Each module needs:
-- **name**: Unique identifier
-- **path**: HTTP endpoint path
-- **handler**: Processing configuration
-  - **type**: Handler type (usually "std")
-  - **role**: "bap" or "bpp"
-  - **plugins**: Plugin configurations
-  - **steps**: Processing pipeline steps
-
-### Plugin Configuration
-
-#### Cache Plugin (Redis)
-```yaml
-cache:
-  id: cache
-  config:
-    addr: localhost:6379
-    password: ""  # Optional
-    db: 0
-    poolSize: 50
-    minIdleConns: 10
-    maxRetries: 3
-```
-
-#### KeyManager Plugin (Vault)
-```yaml
-keyManager:
-  id: keymanager
-  config:
-    projectID: beckn-project
-    vaultAddr: http://localhost:8200
-    kvVersion: v2
-    mountPath: beckn
-    namespace: ""  # Optional for Vault Enterprise
-```
-
-#### Publisher Plugin (RabbitMQ)
-```yaml
-publisher:
-  id: publisher
-  config:
-    addr: localhost:5672
-    username: guest
-    password: guest
-    exchange: beckn_exchange
-    exchangeType: topic
-    durable: true
-    autoDelete: false
-    useTLS: false
-    tlsConfig:
-      certFile: ""
-      keyFile: ""
-      caFile: ""
-```
-
-#### SchemaValidator Plugin
-```yaml
-schemaValidator:
-  id: schemavalidator
-  config:
-    schemaDir: ./schemas
-    strictMode: false
-    downloadSchemas: true
-    schemaURL: https://schemas.beckn.org
-```
-
-#### Schema2Validator Plugin
-
-**Remote URL Configuration:**
-```yaml
-schemaValidator:
-  id: schemav2validator
-  config:
-    type: url
-    location: https://raw.githubusercontent.com/beckn/protocol-specifications-v2/refs/tags/core-v2.0.0-lts/api/v2.0.0/beckn.yaml
-    cacheTTL: "3600"
-```
-
-**Local File Configuration:**
-```yaml
-schemaValidator:
-  id: schemav2validator
-  config:
-    type: file
-    location: ./schemas/beckn-protocol-api.yaml
-    cacheTTL: "3600"
-```
-
-#### Router Plugin
-```yaml
-router:
-  id: router
-  config:
-    routingConfig: ./config/routing.yaml
-    defaultTimeout: 30
-    retryCount: 3
-    retryDelay: 1000  # milliseconds
-```
-
-### Routing Rules Configuration
-
-**For complete routing configuration documentation including v2 domain-agnostic routing, see [CONFIG.md - Routing Configuration](CONFIG.md#routing-configuration).**
-
-Basic example:
-
-```yaml
-routingRules:
-  # v1.x.x - domain is required
-  - domain: "ONDC:RET10"
-    version: "1.0.0"
-    targetType: "url"  # or "publisher"
-    target:
-      url: "https://seller.example.com/beckn"
-    endpoints:
-      - search
-      - select
-      - init
-      - confirm
-
-  # v2.x.x - domain is optional (domain-agnostic routing)
-  - version: "2.0.0"
-    targetType: "url"
-    target:
-      url: "https://seller.example.com/v2/beckn"
-    endpoints:
-      - search
-      - select
-```
-
-**Key Points**:
-- **v1.x.x**: Domain field is required and used for routing
-- **v2.x.x**: Domain field is optional and ignored (domain-agnostic)
-- See CONFIG.md for target types: `url`, `bpp`, `bap`, `publisher`
-
-### Processing Steps
-
-Available steps for configuration:
-- **validateSign**: Validate incoming signatures
-- **addRoute**: Determine routing based on rules
-- **validateSchema**: Validate against JSON schemas
-- **sign**: Sign outgoing requests
-- **cache**: Cache requests/responses
-- **publish**: Publish to message queue
-- **encrypt**: Encrypt sensitive data
-- **decrypt**: Decrypt encrypted data
-
----
-
-## External Services Setup
-
-### Redis Cluster (Production)
-
-```yaml
-# Redis cluster configuration
-cache:
-  id: cache
-  config:
-    clusterAddrs:
-      - redis-node1:6379
-      - redis-node2:6379
-      - redis-node3:6379
-    password: ${REDIS_PASSWORD}
-    poolSize: 100
-    readTimeout: 3s
-    writeTimeout: 3s
-```
-
-### Vault High Availability
-
-```yaml
-# Vault HA configuration
-keyManager:
-  id: keymanager
-  config:
-    vaultAddrs:
-      - https://vault1.example.com:8200
-      - https://vault2.example.com:8200
-      - https://vault3.example.com:8200
-    roleID: ${VAULT_ROLE_ID}
-    secretID: ${VAULT_SECRET_ID}
-    renewToken: true
-    tokenTTL: 3600
-```
-
-### RabbitMQ Cluster
-
-```yaml
-# RabbitMQ cluster configuration
-publisher:
-  id: publisher
-  config:
-    clusterAddrs:
-      - amqp://user:pass@rabbitmq1:5672
-      - amqp://user:pass@rabbitmq2:5672
-      - amqp://user:pass@rabbitmq3:5672
-    haPolicy: all  # all, exactly, nodes
-    connectionTimeout: 10s
-    channelMax: 2047
-```
-
----
-
-## GUI Component Setup
-
-The GUI component provides a web interface for monitoring and management.
-
-### Prerequisites
-- Node.js 18+ and npm
-
-### Installation
-
-```bash
-cd onix-gui/GUI
-
-# Install dependencies
-npm install
-
-# Development mode
-npm run dev
-
-# Production build
-npm run build
-npm start
-```
-
-### Features
-- **Dashboard**: Real-time metrics and status
-- **Configuration Editor**: Visual YAML editor
-- **Request Monitor**: Live request/response tracking
-- **Plugin Manager**: Enable/disable plugins
-- **Routing Rules**: Visual routing configuration
-- **Logs Viewer**: Centralized log viewing
-
-### Configuration
-
-Create `onix-gui/GUI/.env.local`:
-
-```bash
-NEXT_PUBLIC_API_URL=http://localhost:8081
-NEXT_PUBLIC_REFRESH_INTERVAL=5000
-```
-
-### Access
-Open `http://localhost:3000` in your browser.
-
----
-
-## Docker Deployment
-
-### Build Docker Image
-
-```bash
-# Build the image
-docker build -f Dockerfile.adapter -t beckn-onix:latest .
-
-# Tag for registry (optional)
-docker tag beckn-onix:latest registry.example.com/beckn-onix:v1.0.0
-```
-
-### Docker Compose Setup
-
-**Important: Create docker.yaml config and plugins bundle first**
-```bash
-# Create symlink to existing config
-cd config
-ln -s onix/adapter.yaml docker.yaml
-cd ..
-
-# Build plugins first
-./install/build-plugins.sh
-
-# Create plugins bundle for Docker
-cd plugins
-zip -r plugins_bundle.zip *.so
-cd ..
-```
-
-Create `docker-compose.yml`:
-
-```yaml
-version: '3.8'
-
 services:
-  redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis-data:/data
-    command: redis-server --appendonly yes
+  onix-cnode:
+    image: my-org/beckn-onix:1.6.0
+```
 
-  vault:
-    image: hashicorp/vault:latest
-    ports:
-      - "8200:8200"
-    environment:
-      VAULT_DEV_ROOT_TOKEN_ID: root
-      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
-    cap_add:
-      - IPC_LOCK
-    volumes:
-      - vault-data:/vault/file
+---
 
-  rabbitmq:
-    image: rabbitmq:3-management
-    ports:
-      - "5672:5672"
-      - "15672:15672"
-    environment:
-      RABBITMQ_DEFAULT_USER: admin
-      RABBITMQ_DEFAULT_PASS: admin123
-    volumes:
-      - rabbitmq-data:/var/lib/rabbitmq
+## 4. Production Setup
 
-  beckn-onix:
-    image: beckn-onix:latest
+### 4.1 Deployment Topology
+
+ONIX must be reachable on the public internet for inbound calls from other Beckn network participants — that is how the protocol works. Its outbound calls to other participants also traverse the public internet. All of these messages are cryptographically signed; the signature is the trust boundary, not network isolation.
+
+The interface between ONIX and your own application, however, should be private. Keeping it internal to your VPC removes an unnecessary exposure.
+
+```
+[NFH fabric / other Beckn participants]
+              │
+        (public internet)
+        (signed Beckn messages)
+              │
+       ┌──────▼──────┐
+       │ Load Balancer│  ← public IP
+       └──────┬───────┘
+              │ (private, within VPC)
+       ┌──────▼───────┐
+       │     ONIX     │
+       └──┬───────┬───┘
+          │       │ (private, within VPC)
+       ┌──▼──┐  ┌─▼────────┐
+       │Redis│  │ Your App │
+       └─────┘  └──────────┘
+```
+
+ONIX, Redis, and your application all run within the same private network. ONIX's public port is exposed through a load balancer, not directly.
+
+In a production deployment, ONIX and Redis run as containers alongside your application's own containers — either via Docker Compose on a VM, or as workloads in a Kubernetes cluster. The following two sub-sections cover both approaches.
+
+### 4.2 Docker Compose
+
+For VM-based deployments, extend your existing docker-compose file to include ONIX and Redis alongside your application containers. The starter kit's docker-compose is a good starting point — see the [starter kit](https://github.com/beckn/beckn-onix-starter-kit) for a complete working example.
+
+A production-oriented compose file adds dedicated Redis instances per node and removes dev-only services:
+
+```yaml
+services:
+  redis-cnode:
+    image: redis:alpine
+    container_name: redis-cnode
+    restart: unless-stopped
+    networks:
+      - beckn_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  redis-pnode:
+    image: redis:alpine
+    container_name: redis-pnode
+    restart: unless-stopped
+    networks:
+      - beckn_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  onix-cnode:
+    image: fidedocker/onix-adapter
+    container_name: onix-cnode
+    platform: linux/amd64
+    restart: unless-stopped
     ports:
       - "8081:8081"
-    depends_on:
-      - redis
-      - vault
-      - rabbitmq
     environment:
-      VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: root
-      REDIS_ADDR: redis:6379
-      RABBITMQ_ADDR: rabbitmq:5672
-      RABBITMQ_USER: admin
-      RABBITMQ_PASS: admin123
+      REDIS_ADDR: redis-cnode:6379
     volumes:
       - ./config:/app/config
-      - ./schemas:/app/schemas
-      - ./plugins:/mnt/gcs/plugins
-    command: ["./server", "--config=/app/config/docker.yaml"]
+    command: ["./server", "--config=/app/config/onix-bap/adapter.yaml"]
+    depends_on:
+      redis-cnode:
+        condition: service_healthy
+    networks:
+      - beckn_network
 
-volumes:
-  redis-data:
-  vault-data:
-  rabbitmq-data:
+  onix-pnode:
+    image: fidedocker/onix-adapter
+    container_name: onix-pnode
+    platform: linux/amd64
+    restart: unless-stopped
+    ports:
+      - "8082:8082"
+    environment:
+      REDIS_ADDR: redis-pnode:6379
+    volumes:
+      - ./config:/app/config
+    command: ["./server", "--config=/app/config/onix-bpp/adapter.yaml"]
+    depends_on:
+      redis-pnode:
+        condition: service_healthy
+    networks:
+      - beckn_network
+
+  your-app:
+    image: your-org/your-app:latest
+    # ... your app's config
+    networks:
+      - beckn_network
+
+networks:
+  beckn_network:
+    driver: bridge
 ```
 
-**Important: Build the image first**
-```bash
-# Build the beckn-onix image before running docker-compose
-docker build -f Dockerfile.adapter -t beckn-onix:latest .
+### 4.3 Kubernetes
 
-# Then run docker-compose
-docker-compose up -d
-```
+For Kubernetes deployments, ONIX and Redis run as workloads in the same cluster and namespace as your application.
 
----
+**Namespace:**
 
-## Kubernetes Deployment
-
-### Kubernetes Manifests
-
-Create namespace:
 ```yaml
 apiVersion: v1
 kind: Namespace
@@ -1182,63 +365,74 @@ metadata:
   name: beckn-onix
 ```
 
-ConfigMap for configuration:
+**ConfigMap** (mount your adapter config):
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: beckn-onix-config
+  name: onix-cnode-config
   namespace: beckn-onix
 data:
   adapter.yaml: |
-    # Your configuration here
+    # your adapter config here
 ```
 
-Deployment:
+**Deployment:**
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: beckn-onix
+  name: onix-cnode
   namespace: beckn-onix
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
-      app: beckn-onix
+      app: onix-cnode
   template:
     metadata:
       labels:
-        app: beckn-onix
+        app: onix-cnode
     spec:
       containers:
-      - name: beckn-onix
-        image: registry.example.com/beckn-onix:v1.0.0
+      - name: onix-cnode
+        image: fidedocker/onix-adapter
+        command: ["./server", "--config=/app/config/adapter.yaml"]
         ports:
-        - containerPort: 8080
+        - containerPort: 8081
         env:
+        - name: REDIS_ADDR
+          value: redis-cnode.beckn-onix.svc.cluster.local:6379
         - name: VAULT_ADDR
           valueFrom:
             secretKeyRef:
               name: beckn-secrets
               key: vault-addr
-        - name: REDIS_ADDR
-          value: redis-service:6379
+        - name: VAULT_ROLE_ID
+          valueFrom:
+            secretKeyRef:
+              name: beckn-secrets
+              key: vault-role-id
+        - name: VAULT_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              name: beckn-secrets
+              key: vault-secret-id
         volumeMounts:
         - name: config
           mountPath: /app/config
-        - name: plugins
-          mountPath: /app/plugins
         livenessProbe:
           httpGet:
             path: /health
-            port: 8080
-          initialDelaySeconds: 30
+            port: 8081
+          initialDelaySeconds: 15
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 8080
+            path: /health
+            port: 8081
           initialDelaySeconds: 5
           periodSeconds: 5
         resources:
@@ -1251,867 +445,258 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: beckn-onix-config
-      - name: plugins
-        persistentVolumeClaim:
-          claimName: plugins-pvc
+          name: onix-cnode-config
 ```
 
-Service:
+**Service:**
+
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: beckn-onix-service
+  name: onix-cnode-service
   namespace: beckn-onix
 spec:
   selector:
-    app: beckn-onix
+    app: onix-cnode
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
+      targetPort: 8081
   type: LoadBalancer
 ```
 
-### Helm Chart
+Repeat the Deployment and Service for `onix-pnode`, pointing at its own config and its own Redis cluster service.
 
-For easier deployment, use the Helm chart:
+### 4.4 Key Management
+
+ONIX ships two key manager plugins. The choice is a devops decision based on your operational preferences — not driven by how many instances you run.
+
+**`simplekeymanager`** — Ed25519 keys are embedded directly in the adapter config file. No external dependencies. Choose this when:
+- You are comfortable managing key files and rotating them via a config update + restart
+- You do not operate a Vault cluster and do not want to
+
+**`keymanager` (Vault-backed)** — keys are stored in HashiCorp Vault and fetched at runtime. Choose this when:
+- Your organisation already operates Vault
+- You require a full audit trail on key access
+- Your compliance posture mandates centralized secrets management
+- You need to rotate keys without restarting the adapter
+
+**Setting up Vault when chosen:**
 
 ```bash
-# Add repo
-helm repo add beckn https://charts.beckn.org
+# Enable the KV secrets engine
+export VAULT_ADDR='https://vault.example.com:8200'
+vault login token=<root-token>
+vault secrets enable -path=beckn kv-v2
 
-# Install
-helm install beckn-onix beckn/onix \
-  --namespace beckn-onix \
-  --create-namespace \
-  --values values.yaml
+# Store node signing keys
+vault kv put beckn/keys/node \
+  private_key="$(cat node_private_key.pem)" \
+  public_key="$(cat node_public_key.pem)"
+
+# Enable AppRole auth and create a policy
+vault auth enable approle
+vault policy write beckn-policy - <<EOF
+path "beckn/data/keys/*" {
+  capabilities = ["read"]
+}
+EOF
+vault write auth/approle/role/beckn-role \
+  token_policies="beckn-policy" \
+  token_ttl=1h \
+  token_max_ttl=4h
+
+# Retrieve credentials — pass these as VAULT_ROLE_ID and VAULT_SECRET_ID env vars
+vault read auth/approle/role/beckn-role/role-id
+vault write -f auth/approle/role/beckn-role/secret-id
 ```
 
-Example `values.yaml`:
+**Key rotation:**
+- `simplekeymanager`: update the key values in the config file and restart the adapter.
+- `keymanager` (Vault): write a new key version with `vault kv put beckn/keys/node ...`; the adapter picks up the new version on its next key fetch without a restart.
+
+See [CONFIG.md](CONFIG.md) for the full plugin configuration reference for both key managers.
+
+### 4.5 Async Message Publishing with RabbitMQ
+
+By default ONIX processes each request synchronously — it calls the upstream participant, waits for a response, and returns. For high-volume deployments, or when your application consumes Beckn callbacks from a queue rather than via a direct webhook, use the `publisher` plugin to route messages through RabbitMQ instead.
+
+**When to use it:**
+- Your application cannot guarantee low-latency webhook handling
+- You need to decouple Beckn message receipt from your application's processing
+- You want durable delivery and retry semantics for inbound callbacks
+
+**Add RabbitMQ to your compose or cluster:**
+
 ```yaml
-replicaCount: 3
-
-image:
-  repository: registry.example.com/beckn-onix
-  tag: v1.0.0
-  pullPolicy: IfNotPresent
-
-service:
-  type: LoadBalancer
-  port: 80
-
-ingress:
-  enabled: true
-  hostname: beckn-onix.example.com
-  tls: true
-
-redis:
-  enabled: true
-  auth:
-    enabled: true
-    password: secretpassword
-
-vault:
-  enabled: true
-  server:
-    dev:
-      enabled: false
-    ha:
-      enabled: true
-      replicas: 3
-
-rabbitmq:
-  enabled: true
-  auth:
-    username: beckn
-    password: secretpassword
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 250m
-    memory: 256Mi
-
-autoscaling:
-  enabled: true
-  minReplicas: 2
-  maxReplicas: 10
-  targetCPUUtilizationPercentage: 80
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"   # management UI at http://localhost:15672
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin123
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - beckn_network
 ```
+
+**Create exchange and queue:**
+
+```bash
+docker exec rabbitmq rabbitmqadmin declare exchange \
+  name=beckn_exchange type=topic durable=true
+
+docker exec rabbitmq rabbitmqadmin declare queue \
+  name=beckn_callbacks durable=true
+
+docker exec rabbitmq rabbitmqadmin declare binding \
+  source=beckn_exchange destination=beckn_callbacks \
+  routing_key="on_*"
+```
+
+**Pass credentials to ONIX:**
+
+```yaml
+environment:
+  RABBITMQ_ADDR: rabbitmq:5672
+  RABBITMQ_USER: admin
+  RABBITMQ_PASS: admin123
+```
+
+Wire the `publisher` plugin in your adapter config and add `publish` to the relevant handler's steps — see [CONFIG.md](CONFIG.md) for full plugin parameters.
+
+### 4.6 Systemd Service
+
+For bare-metal or VM deployments without Docker, run the adapter directly as a systemd service.
+
+Create `/etc/systemd/system/beckn-onix.service`:
+
+```ini
+[Unit]
+Description=Beckn ONIX Adapter
+After=network.target
+
+[Service]
+Type=simple
+User=beckn
+WorkingDirectory=/opt/beckn-onix
+EnvironmentFile=/opt/beckn-onix/.env
+ExecStart=/opt/beckn-onix/server --config=/opt/beckn-onix/config/adapter.yaml
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable beckn-onix
+sudo systemctl start beckn-onix
+sudo systemctl status beckn-onix
+```
+
+### 4.7 Cloud Provider Integrations
+
+Public cloud providers maintain integration plugins and deployment tooling for ONIX targeting their managed services:
+
+- [Google Cloud Platform](https://github.com/GoogleCloudPlatform/dpi-accelerator-beckn-onix)
+- [Amazon Web Services](https://github.com/beckn/onix-aws-cdk)
 
 ---
 
-## Observability
+## 5. Observability
 
-Beckn-ONIX has a built-in observability stack based entirely on [OpenTelemetry](https://opentelemetry.io). Every signal — metrics, traces, and structured audit logs — is emitted using the OTel Go SDK and exported over OTLP, which means any OTLP-compatible backend (open-source or commercial) works without changing the adapter.
+Beckn-ONIX emits metrics, distributed traces, and structured audit logs via the `otelsetup` plugin using the OpenTelemetry SDK over OTLP. A reference two-tier collector stack (node-level + network-level) with Grafana and Loki is included in `install/network-observability/`.
 
-### Two consumers
-
-The observability architecture is designed to serve two distinct consumers simultaneously from the same signal stream:
-
-- **The node operator** (the network participant running the adapter) receives full-fidelity metrics, traces, and logs for their own node through a companion OTLP Collector deployed alongside the adapter.
-- **The network observer** (the central governing entity) receives a filtered subset of cross-node signals — traffic flows, participant plugin inventory, and distributed traces stitched across BAP and BPP nodes — through a shared network-level collector.
-
-### Enabling observability
-
-Add an `otelsetup` block under `plugins` in your config file. Omit it to run without telemetry.
-
-```yaml
-plugins:
-  otelsetup:
-    id: otelsetup
-    config:
-      serviceName: "beckn-onix"
-      serviceVersion: "1.0.0"
-      environment: "development"
-      otlpEndpoint: "localhost:4317"   # OTLP/gRPC endpoint of your collector
-      enableMetrics: "true"
-      enableTracing: "true"
-      enableLogs: "true"
-      auditFieldsConfig: "/app/config/audit-fields.yaml"
-```
-
-### Reference stack
-
-`install/network-observability/` contains a Docker Compose file that starts a complete two-tier stack (companion collectors, network-level collector, and open-source backends) alongside the BAP and BPP adapters:
-
-```bash
-# From the repository root
-docker compose -f install/network-observability/docker-compose.yml up -d
-```
-
-### Full documentation
-
-For the complete architecture, all emitted metrics and traces, audit log configuration, OTEL Collector configs, and guidance on connecting alternative backends, see:
+Full architecture, signal catalogue, audit log configuration, collector setup, and backend integration guidance:
 
 **[pkg/plugin/implementation/otelsetup/OBSERVABILITY.md](pkg/plugin/implementation/otelsetup/OBSERVABILITY.md)**
 
 ---
 
-## Testing Your Setup
+## 6. Troubleshooting
 
-### Health Check
+### Plugin loading failures
 
-```bash
-# Basic health check
-curl http://localhost:8081/health
-
-# Expected response
-{
-  "status": "healthy",
-  "timestamp": "2024-01-15T10:30:00Z",
-  "version": "1.0.0"
-}
-```
-
-### Test Search Request
+**Error:** `failed to load plugin: plugin.Open: plugin.so: cannot open shared object file`
 
 ```bash
-# Create a test search request (no Authorization header needed - ONIX auto-generates it)
-curl -X POST http://localhost:8081/bap/caller/search \
-  -H "Content-Type: application/json" \
-  -d '{
-    "context": {
-      "domain": "nic2004:52110",
-      "country": "IND",
-      "city": "std:080",
-      "action": "search",
-      "version": "1.0.0",
-      "bap_id": "test.bap.com",
-      "bap_uri": "https://test.bap.com/beckn",
-      "transaction_id": "'$(uuidgen)'",
-      "message_id": "'$(uuidgen)'",
-      "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")'",
-      "ttl": "PT30S"
-    },
-    "message": {
-      "intent": {
-        "item": {
-          "descriptor": {
-            "name": "coffee"
-          }
-        },
-        "fulfillment": {
-          "end": {
-            "location": {
-              "gps": "12.9715987,77.5945627",
-              "area_code": "560001"
-            }
-          }
-        },
-        "payment": {
-          "buyer_app_finder_fee_type": "percent",
-          "buyer_app_finder_fee_amount": "3"
-        }
-      }
-    }
-  }'
-```
-
-### Load Testing
-
-Use Apache Bench or similar tools:
-
-```bash
-# Install ab
-sudo apt-get install apache2-utils
-
-# Simple load test (no Authorization header needed - ONIX auto-generates it)
-ab -n 1000 -c 10 -p search.json -T application/json \
-  http://localhost:8081/bap/caller/search
-```
-
-### Integration Testing
-
-Create test script `test_integration.sh`:
-
-```bash
-#!/bin/bash
-
-# Test BAP endpoints
-endpoints=(
-  "search"
-  "select"
-  "init"
-  "confirm"
-  "status"
-  "track"
-  "cancel"
-  "update"
-  "rating"
-  "support"
-)
-
-for endpoint in "${endpoints[@]}"; do
-  echo "Testing /bap/caller/$endpoint..."
-  response=$(curl -s -o /dev/null -w "%{http_code}" \
-    -X POST "http://localhost:8081/bap/caller/$endpoint" \
-    -H "Content-Type: application/json" \
-    -d @"test_payloads/${endpoint}.json")
-  
-  if [ "$response" -eq 200 ] || [ "$response" -eq 202 ]; then
-    echo "✅ $endpoint: SUCCESS"
-  else
-    echo "❌ $endpoint: FAILED (HTTP $response)"
-  fi
-done
-```
-
----
-
-## Troubleshooting
-
-### Common Issues and Solutions
-
-#### 1. Plugin Loading Failures
-
-**Error**: `failed to load plugin: plugin.Open: plugin.so: cannot open shared object file`
-
-**Solution**:
-```bash
-# Rebuild plugins from project root
+# Rebuild plugins from the project root
 ./install/build-plugins.sh
 
-# Check plugin files exist
+# Verify .so files are present
 ls -la plugins/
-
-# Verify plugin compatibility
-go version
-file plugins/cache.so
 ```
 
-**Error**: `plugin was built with a different version of package internal/godebugs`
+**Error:** `plugin was built with a different version of package internal/godebugs`
 
-**Solution**: Plugin version mismatch - rebuild with same Go version:
+The plugin was compiled with a different Go version than the server binary. Rebuild both:
+
 ```bash
-# Clean and rebuild plugins
+go version          # confirm the active version
 rm -rf plugins/*.so
 ./install/build-plugins.sh
-
-# Ensure same Go version for server and plugins
-go version
+go build -o server cmd/adapter/main.go
 ```
 
-#### 2. Redis Connection Issues
+### Redis connection refused
 
-**Error**: `dial tcp 127.0.0.1:6379: connect: connection refused`
+**Error:** `dial tcp 127.0.0.1:6379: connect: connection refused`
 
-**Solution**:
 ```bash
-# Check Redis is running
-redis-cli ping
-
-# Start Redis if not running
-sudo systemctl start redis
-
-# Check Redis configuration
-redis-cli CONFIG GET bind
-redis-cli CONFIG GET protected-mode
+# In Docker, verify the container is healthy
+docker ps | grep redis
+docker exec redis redis-cli ping
 ```
 
-#### 3. Signature Validation Failures
+Check that `REDIS_ADDR` in the container environment matches the Redis service name and port within your docker-compose network.
 
-**Error**: `signature validation failed: invalid signature`
+### Signature validation failures
 
-**Solution**:
-- Verify correct key pair is being used
-- Check timestamp synchronization between systems
-- Ensure signature includes all required headers
-- Validate Base64 encoding of signature
+**Error:** `signature validation failed: invalid signature`
 
-```bash
-# Generate test keys
-openssl genpkey -algorithm ed25519 -out private_key.pem
-openssl pkey -in private_key.pem -pubout -out public_key.pem
-```
+- Confirm the correct key pair is configured — the public key registered with the network registry must match the private key in `simplekeymanager` or Vault
+- Check clock synchronization between nodes; the signature includes a `created` timestamp and the validator applies a clock-skew tolerance
+- Confirm the `subscriber_id` in the config matches what is registered in the network registry
 
-#### 4. Schema Validation Errors
+### Vault authentication failures
 
-**Error**: `schema validation failed: required property 'context' not found`
+**Error:** `vault: authentication failed` or `invalid role or secret ID`
 
-**Solution**:
-- Verify schema files are in correct directory
-- Check schema version matches protocol version
-- Validate JSON structure
+Secret IDs from Vault's AppRole have a TTL and expire. Regenerate and update the env var:
 
 ```bash
-# Download latest schemas
-wget https://schemas.beckn.org/core/v1.0.0.zip
-unzip v1.0.0.zip -d schemas/
-```
+vault write -f auth/approle/role/beckn-role/secret-id
 
-#### 5. Port Already in Use
-
-**Error**: `listen tcp :8081: bind: address already in use`
-
-**Solution**:
-```bash
-# Find process using port
-lsof -i :8081
-
-# Kill process
-kill -9 <PID>
-
-# Or use different port in config
-```
-
-#### 6. Vault Authentication Issues
-
-**Error**: `vault: authentication failed`
-
-**Solution**:
-```bash
-# Check Vault status
-vault status
-
-# Verify authentication
+# Verify independently
 vault login -method=approle \
-  role_id=${VAULT_ROLE_ID} \
-  secret_id=${VAULT_SECRET_ID}
-
-# Check policy permissions
-vault policy read beckn-policy
+  role_id=$VAULT_ROLE_ID \
+  secret_id=$VAULT_SECRET_ID
 ```
 
-### Debug Mode
+### Port already in use
 
-Enable debug logging:
+**Error:** `listen tcp :8081: bind: address already in use`
+
+```bash
+lsof -i :8081
+kill -9 <PID>
+```
+
+### Debug logging
 
 ```yaml
 log:
   level: debug
   destinations:
     - type: stdout
-      config:
-        pretty: true
-        includeCalller: true
 ```
-
-Or via environment variable:
-```bash
-LOG_LEVEL=debug ./server --config=config/adapter.yaml
-```
-
-### Performance Tuning
-
-#### System Limits
-```bash
-# Increase file descriptors
-ulimit -n 65536
-
-# Add to /etc/security/limits.conf
-beckn soft nofile 65536
-beckn hard nofile 65536
-```
-
-#### Go Runtime
-```bash
-# Set GOMAXPROCS
-export GOMAXPROCS=8
-
-# Enable profiling
-./server --config=config/adapter.yaml --profile
-```
-
-#### Redis Optimization
-```bash
-# Redis configuration
-redis-cli CONFIG SET maxclients 10000
-redis-cli CONFIG SET tcp-keepalive 60
-redis-cli CONFIG SET timeout 300
-```
-
----
-
-## Sample Payloads
-
-### Search Request (Retail)
-
-```json
-{
-  "context": {
-    "domain": "nic2004:52110",
-    "country": "IND",
-    "city": "std:080",
-    "action": "search",
-    "version": "1.0.0",
-    "bap_id": "buyerapp.com",
-    "bap_uri": "https://buyerapp.com/beckn",
-    "transaction_id": "6d5f4c3b-2a1e-4b8c-9f7d-3e2a1b5c8d9f",
-    "message_id": "a9f8e7d6-c5b4-3a2e-1f0d-9e8c7b6a5d4f",
-    "timestamp": "2024-01-15T10:30:00.000Z",
-    "ttl": "PT30S"
-  },
-  "message": {
-    "intent": {
-      "item": {
-        "descriptor": {
-          "name": "Laptop"
-        }
-      },
-      "fulfillment": {
-        "type": "Delivery",
-        "end": {
-          "location": {
-            "gps": "12.9715987,77.5945627",
-            "area_code": "560001"
-          }
-        }
-      },
-      "payment": {
-        "buyer_app_finder_fee_type": "percent",
-        "buyer_app_finder_fee_amount": "3"
-      }
-    }
-  }
-}
-```
-
-### Select Request
-
-```json
-{
-  "context": {
-    "domain": "nic2004:52110",
-    "country": "IND",
-    "city": "std:080",
-    "action": "select",
-    "version": "1.0.0",
-    "bap_id": "buyerapp.com",
-    "bap_uri": "https://buyerapp.com/beckn",
-    "bpp_id": "sellerapp.com",
-    "bpp_uri": "https://sellerapp.com/beckn",
-    "transaction_id": "6d5f4c3b-2a1e-4b8c-9f7d-3e2a1b5c8d9f",
-    "message_id": "b8e7f6d5-c4a3-2b1e-0f9d-8e7c6b5a4d3f",
-    "timestamp": "2024-01-15T10:31:00.000Z",
-    "ttl": "PT30S"
-  },
-  "message": {
-    "order": {
-      "provider": {
-        "id": "P1",
-        "locations": [
-          {
-            "id": "L1"
-          }
-        ]
-      },
-      "items": [
-        {
-          "id": "I1",
-          "quantity": {
-            "count": 2
-          }
-        }
-      ],
-      "fulfillment": {
-        "end": {
-          "location": {
-            "gps": "12.9715987,77.5945627",
-            "address": {
-              "door": "21A",
-              "name": "ABC Apartments",
-              "building": "Tower 1",
-              "street": "100 Feet Road",
-              "locality": "Indiranagar",
-              "city": "Bengaluru",
-              "state": "Karnataka",
-              "country": "India",
-              "area_code": "560001"
-            }
-          },
-          "contact": {
-            "phone": "9876543210",
-            "email": "customer@example.com"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-### Init Request
-
-```json
-{
-  "context": {
-    "domain": "nic2004:52110",
-    "country": "IND",
-    "city": "std:080",
-    "action": "init",
-    "version": "1.0.0",
-    "bap_id": "buyerapp.com",
-    "bap_uri": "https://buyerapp.com/beckn",
-    "bpp_id": "sellerapp.com",
-    "bpp_uri": "https://sellerapp.com/beckn",
-    "transaction_id": "6d5f4c3b-2a1e-4b8c-9f7d-3e2a1b5c8d9f",
-    "message_id": "c7f6e5d4-b3a2-1e0f-9d8e-7c6b5a4d3e2f",
-    "timestamp": "2024-01-15T10:32:00.000Z",
-    "ttl": "PT30S"
-  },
-  "message": {
-    "order": {
-      "provider": {
-        "id": "P1",
-        "locations": [
-          {
-            "id": "L1"
-          }
-        ]
-      },
-      "items": [
-        {
-          "id": "I1",
-          "quantity": {
-            "count": 2
-          },
-          "fulfillment_id": "F1"
-        }
-      ],
-      "billing": {
-        "name": "John Doe",
-        "address": {
-          "door": "21A",
-          "name": "ABC Apartments",
-          "building": "Tower 1",
-          "street": "100 Feet Road",
-          "locality": "Indiranagar",
-          "city": "Bengaluru",
-          "state": "Karnataka",
-          "country": "India",
-          "area_code": "560001"
-        },
-        "email": "john.doe@example.com",
-        "phone": "9876543210",
-        "created_at": "2024-01-15T10:32:00.000Z",
-        "updated_at": "2024-01-15T10:32:00.000Z"
-      },
-      "fulfillment": {
-        "id": "F1",
-        "type": "Delivery",
-        "tracking": false,
-        "end": {
-          "location": {
-            "gps": "12.9715987,77.5945627",
-            "address": {
-              "door": "21A",
-              "name": "ABC Apartments",
-              "building": "Tower 1",
-              "street": "100 Feet Road",
-              "locality": "Indiranagar",
-              "city": "Bengaluru",
-              "state": "Karnataka",
-              "country": "India",
-              "area_code": "560001"
-            }
-          },
-          "contact": {
-            "phone": "9876543210",
-            "email": "customer@example.com"
-          }
-        }
-      },
-      "payment": {
-        "type": "ON-ORDER",
-        "collected_by": "BAP",
-        "buyer_app_finder_fee_type": "percent",
-        "buyer_app_finder_fee_amount": "3",
-        "settlement_details": [
-          {
-            "settlement_counterparty": "seller-app",
-            "settlement_phase": "sale-amount",
-            "settlement_type": "neft",
-            "settlement_bank_account_no": "1234567890",
-            "settlement_ifsc_code": "SBIN0001234",
-            "beneficiary_name": "Seller Name",
-            "bank_name": "State Bank of India",
-            "branch_name": "Koramangala"
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-### Confirm Request
-
-```json
-{
-  "context": {
-    "domain": "nic2004:52110",
-    "country": "IND",
-    "city": "std:080",
-    "action": "confirm",
-    "version": "1.0.0",
-    "bap_id": "buyerapp.com",
-    "bap_uri": "https://buyerapp.com/beckn",
-    "bpp_id": "sellerapp.com",
-    "bpp_uri": "https://sellerapp.com/beckn",
-    "transaction_id": "6d5f4c3b-2a1e-4b8c-9f7d-3e2a1b5c8d9f",
-    "message_id": "d8f7e6d5-c4b3-2a1e-0f9d-8e7c6b5a4d3f",
-    "timestamp": "2024-01-15T10:33:00.000Z",
-    "ttl": "PT30S"
-  },
-  "message": {
-    "order": {
-      "id": "ORDER123",
-      "state": "Created",
-      "provider": {
-        "id": "P1",
-        "locations": [
-          {
-            "id": "L1"
-          }
-        ]
-      },
-      "items": [
-        {
-          "id": "I1",
-          "fulfillment_id": "F1",
-          "quantity": {
-            "count": 2
-          }
-        }
-      ],
-      "quote": {
-        "price": {
-          "currency": "INR",
-          "value": "4000"
-        },
-        "breakup": [
-          {
-            "item_id": "I1",
-            "item_quantity": {
-              "count": 2
-            },
-            "title_type": "item",
-            "title": "Laptop",
-            "price": {
-              "currency": "INR",
-              "value": "3800"
-            }
-          },
-          {
-            "item_id": "F1",
-            "title_type": "delivery",
-            "title": "Delivery charges",
-            "price": {
-              "currency": "INR",
-              "value": "100"
-            }
-          },
-          {
-            "item_id": "F1",
-            "title_type": "packing",
-            "title": "Packing charges",
-            "price": {
-              "currency": "INR",
-              "value": "50"
-            }
-          },
-          {
-            "item_id": "I1",
-            "title_type": "tax",
-            "title": "Tax",
-            "price": {
-              "currency": "INR",
-              "value": "50"
-            }
-          }
-        ],
-        "ttl": "P1D"
-      },
-      "payment": {
-        "uri": "https://ondc.transaction.com/payment",
-        "tl_method": "http/get",
-        "params": {
-          "transaction_id": "TXN123456",
-          "amount": "4000",
-          "currency": "INR"
-        },
-        "type": "ON-ORDER",
-        "status": "PAID",
-        "collected_by": "BAP",
-        "buyer_app_finder_fee_type": "percent",
-        "buyer_app_finder_fee_amount": "3",
-        "settlement_details": [
-          {
-            "settlement_counterparty": "seller-app",
-            "settlement_phase": "sale-amount",
-            "settlement_type": "neft",
-            "settlement_bank_account_no": "1234567890",
-            "settlement_ifsc_code": "SBIN0001234",
-            "beneficiary_name": "Seller Name",
-            "bank_name": "State Bank of India",
-            "branch_name": "Koramangala"
-          }
-        ]
-      },
-      "fulfillment": {
-        "id": "F1",
-        "type": "Delivery",
-        "tracking": true,
-        "start": {
-          "location": {
-            "id": "L1",
-            "descriptor": {
-              "name": "Seller Store"
-            },
-            "gps": "12.9715987,77.5945627",
-            "address": {
-              "locality": "Koramangala",
-              "city": "Bengaluru",
-              "area_code": "560034",
-              "state": "Karnataka"
-            }
-          },
-          "time": {
-            "range": {
-              "start": "2024-01-15T11:00:00.000Z",
-              "end": "2024-01-15T12:00:00.000Z"
-            }
-          },
-          "contact": {
-            "phone": "9988776655",
-            "email": "seller@example.com"
-          }
-        },
-        "end": {
-          "location": {
-            "gps": "12.9715987,77.5945627",
-            "address": {
-              "door": "21A",
-              "name": "ABC Apartments",
-              "building": "Tower 1",
-              "street": "100 Feet Road",
-              "locality": "Indiranagar",
-              "city": "Bengaluru",
-              "state": "Karnataka",
-              "country": "India",
-              "area_code": "560001"
-            }
-          },
-          "time": {
-            "range": {
-              "start": "2024-01-15T14:00:00.000Z",
-              "end": "2024-01-15T18:00:00.000Z"
-            }
-          },
-          "person": {
-            "name": "John Doe"
-          },
-          "contact": {
-            "phone": "9876543210",
-            "email": "customer@example.com"
-          }
-        }
-      },
-      "created_at": "2024-01-15T10:33:00.000Z",
-      "updated_at": "2024-01-15T10:33:00.000Z"
-    }
-  }
-}
-```
-
-### Authorization Header Structure
-
-**Note:** ONIX adapter automatically generates and adds the Authorization signature header to outgoing requests. You don't need to manually create it when calling ONIX endpoints.
-
-For reference, the Authorization header format is:
-
-```
-Authorization: Signature keyId="{subscriber_id}|{key_id}|{algorithm}",algorithm="{algorithm}",created="{created}",expires="{expires}",headers="(created) (expires) digest",signature="{base64_signature}"
-```
-
-Example of how ONIX generates it internally:
-```bash
-#!/bin/bash
-
-# Variables
-SUBSCRIBER_ID="buyerapp.com"
-KEY_ID="key1"
-ALGORITHM="ed25519"
-CREATED=$(date +%s)
-EXPIRES=$((CREATED + 300))
-PRIVATE_KEY="path/to/private_key.pem"
-
-# Create string to sign
-STRING_TO_SIGN="(created): ${CREATED}
-(expires): ${EXPIRES}
-digest: SHA-256=${DIGEST}"
-
-# Sign with Ed25519
-SIGNATURE=$(echo -n "$STRING_TO_SIGN" | \
-  openssl pkeyutl -sign -inkey $PRIVATE_KEY -rawin | \
-  base64 -w 0)
-
-# Create header
-AUTH_HEADER="Signature keyId=\"${SUBSCRIBER_ID}|${KEY_ID}|${ALGORITHM}\",algorithm=\"${ALGORITHM}\",created=\"${CREATED}\",expires=\"${EXPIRES}\",headers=\"(created) (expires) digest\",signature=\"${SIGNATURE}\""
-
-echo $AUTH_HEADER
-```
-
----
-
-## Conclusion
-
-This setup guide covers all aspects of deploying Beckn-ONIX from local development to production. Key points:
-
-1. **Start Simple**: Begin with local development setup
-2. **Test Thoroughly**: Use provided test scripts and payloads
-3. **Scale Gradually**: Move from single instance to clustered deployment
-4. **Monitor Continuously**: Use logs and metrics for observability
-5. **Secure Always**: Implement proper authentication and encryption
-
-For additional help:
-- Check [GitHub Issues](https://github.com/beckn/beckn-onix/issues)
-- Join [Community Discussions](https://github.com/beckn/beckn-onix/discussions)
-- Review [API Documentation](https://docs.beckn.org)
-
-Happy deploying! 🚀


### PR DESCRIPTION
Closes #829

## Summary

- Adds a reading guide anchoring to docs.nfh.global, README, and CONFIG.md so readers know which doc to reach for
- Elevates the NFH Fabric Starter Kit as the fastest path (section 1), with the Docker-based path immediately after (section 2, previously section 7)
- Documents Redis isolation best practice: one dedicated Redis per ONIX node to avoid `message_id`-keyed cache collisions
- Section 3 (Building Your Own Image) classifies the two reasons to diverge from the pre-built image: custom plugins, or cherry-picking a subset of standard + third-party plugins
- Production setup (section 4) restructured: topology → Docker Compose → Kubernetes (folded in from standalone section) → Key Management → RabbitMQ → Systemd → Cloud integrations
- Key management section reframed as a devops decision; clarifies `simplekeymanager` is a valid production choice
- Observability reduced to a four-line pointer to `OBSERVABILITY.md`
- All BAP/BPP references replaced with Consumer Node / Provider Node
- Configuration reference, sample payloads, schema validation, and testing sections removed (covered by CONFIG.md and the starter kit respectively)

## Migration notes

No code changes. Documentation only.