### PR TITLE
test: improve unit test coverage for pkg/beckndefaults

### DIFF
--- a/pkg/beckndefaults/beckndefaults.go
+++ b/pkg/beckndefaults/beckndefaults.go
@@ -25,9 +25,12 @@ var shippedConstantsSig []byte
 //go:embed beckn_public_key.pem
 var becknPublicKeyPEM []byte
 
-const (
+var (
 	remoteConstantsURL    = "https://raw.githubusercontent.com/beckn/beckn-onix/main/pkg/beckndefaults/beckn-constants.yaml"
 	remoteConstantsSigURL = "https://raw.githubusercontent.com/beckn/beckn-onix/main/pkg/beckndefaults/beckn-constants.yaml.sig"
+)
+
+const (
 	remoteTimeout         = 10 * time.Second
 	maxConstantsFileBytes = 64 << 10 // 64 KiB — well above any realistic constants file
 )

--- a/pkg/beckndefaults/beckndefaults.go
+++ b/pkg/beckndefaults/beckndefaults.go
@@ -25,12 +25,9 @@ var shippedConstantsSig []byte
 //go:embed beckn_public_key.pem
 var becknPublicKeyPEM []byte
 
-var (
+const (
 	remoteConstantsURL    = "https://raw.githubusercontent.com/beckn/beckn-onix/main/pkg/beckndefaults/beckn-constants.yaml"
 	remoteConstantsSigURL = "https://raw.githubusercontent.com/beckn/beckn-onix/main/pkg/beckndefaults/beckn-constants.yaml.sig"
-)
-
-const (
 	remoteTimeout         = 10 * time.Second
 	maxConstantsFileBytes = 64 << 10 // 64 KiB — well above any realistic constants file
 )
@@ -78,12 +75,11 @@ func loadAndVerify(constants, sig []byte) (*BecknConstants, error) {
 	return &bc, nil
 }
 
-func fetchRemote(ctx context.Context) ([]byte, []byte, error) {
+var fetchRemote = func(ctx context.Context) ([]byte, []byte, error) {
 	return fetchFromURLs(ctx, remoteConstantsURL, remoteConstantsSigURL)
 }
 
 // fetchFromURLs fetches the constants file and its signature from the given URLs.
-// Separated from fetchRemote so tests can inject an httptest.Server URL.
 func fetchFromURLs(ctx context.Context, constantsURL, sigURL string) ([]byte, []byte, error) {
 	client := &http.Client{Timeout: remoteTimeout}
 

--- a/pkg/beckndefaults/beckndefaults_test.go
+++ b/pkg/beckndefaults/beckndefaults_test.go
@@ -187,25 +187,13 @@ func TestLoad_RemoteRefresh(t *testing.T) {
 	require.NoError(t, err)
 	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkix})
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/constants":
-			w.Write(content)
-		case "/sig":
-			w.Write([]byte(sig))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	origConstantsURL, origSigURL, origPubKey := remoteConstantsURL, remoteConstantsSigURL, becknPublicKeyPEM
-	remoteConstantsURL = srv.URL + "/constants"
-	remoteConstantsSigURL = srv.URL + "/sig"
+	origFetch, origPubKey := fetchRemote, becknPublicKeyPEM
+	fetchRemote = func(_ context.Context) ([]byte, []byte, error) {
+		return content, []byte(sig), nil
+	}
 	becknPublicKeyPEM = pubPEM
 	defer func() {
-		remoteConstantsURL = origConstantsURL
-		remoteConstantsSigURL = origSigURL
+		fetchRemote = origFetch
 		becknPublicKeyPEM = origPubKey
 	}()
 
@@ -222,25 +210,11 @@ func TestLoad_RemoteRefreshBadSig_FallsBackToShipped(t *testing.T) {
 
 	wrongSig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, shippedConstants))
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/constants":
-			w.Write(shippedConstants)
-		case "/sig":
-			w.Write([]byte(wrongSig))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	origConstantsURL, origSigURL := remoteConstantsURL, remoteConstantsSigURL
-	remoteConstantsURL = srv.URL + "/constants"
-	remoteConstantsSigURL = srv.URL + "/sig"
-	defer func() {
-		remoteConstantsURL = origConstantsURL
-		remoteConstantsSigURL = origSigURL
-	}()
+	orig := fetchRemote
+	fetchRemote = func(_ context.Context) ([]byte, []byte, error) {
+		return shippedConstants, []byte(wrongSig), nil
+	}
+	defer func() { fetchRemote = orig }()
 
 	bc, err := Load(context.Background(), false)
 	require.NoError(t, err)

--- a/pkg/beckndefaults/beckndefaults_test.go
+++ b/pkg/beckndefaults/beckndefaults_test.go
@@ -175,11 +175,72 @@ func TestLoad_RemoteUnavailable_FallsBackToShipped(t *testing.T) {
 	assert.Equal(t, "v1", bc.Version)
 }
 
-// TestLoad_RemoteRefresh exercises the full remote-fetch path; skipped under -short.
+// TestLoad_RemoteRefresh verifies that Load accepts validly signed remote content.
 func TestLoad_RemoteRefresh(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping network test in short mode")
-	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	content := []byte("becknConstantsVersion: \"v1\"\nlocked: {}\noverridable: {}\n")
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, content))
+
+	pkix, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkix})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/constants":
+			w.Write(content)
+		case "/sig":
+			w.Write([]byte(sig))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origConstantsURL, origSigURL, origPubKey := remoteConstantsURL, remoteConstantsSigURL, becknPublicKeyPEM
+	remoteConstantsURL = srv.URL + "/constants"
+	remoteConstantsSigURL = srv.URL + "/sig"
+	becknPublicKeyPEM = pubPEM
+	defer func() {
+		remoteConstantsURL = origConstantsURL
+		remoteConstantsSigURL = origSigURL
+		becknPublicKeyPEM = origPubKey
+	}()
+
+	bc, err := Load(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, bc)
+	assert.Equal(t, "v1", bc.Version)
+}
+
+// TestLoad_RemoteRefreshBadSig_FallsBackToShipped verifies that a remote sig failure falls back to the shipped baseline.
+func TestLoad_RemoteRefreshBadSig_FallsBackToShipped(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	wrongSig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, shippedConstants))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/constants":
+			w.Write(shippedConstants)
+		case "/sig":
+			w.Write([]byte(wrongSig))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origConstantsURL, origSigURL := remoteConstantsURL, remoteConstantsSigURL
+	remoteConstantsURL = srv.URL + "/constants"
+	remoteConstantsSigURL = srv.URL + "/sig"
+	defer func() {
+		remoteConstantsURL = origConstantsURL
+		remoteConstantsSigURL = origSigURL
+	}()
 
 	bc, err := Load(context.Background(), false)
 	require.NoError(t, err)

--- a/pkg/beckndefaults/beckndefaults_test.go
+++ b/pkg/beckndefaults/beckndefaults_test.go
@@ -115,3 +115,112 @@ func TestFetchFromURLs_NonOKStatus(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
 }
+
+// TestFetchFromURLs_HappyPath verifies both response bodies are returned on success.
+func TestFetchFromURLs_HappyPath(t *testing.T) {
+	constantsBody := []byte("constants-content")
+	sigBody := []byte("sig-content")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/constants":
+			w.Write(constantsBody)
+		case "/sig":
+			w.Write(sigBody)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	gotConstants, gotSig, err := fetchFromURLs(context.Background(), srv.URL+"/constants", srv.URL+"/sig")
+	require.NoError(t, err)
+	assert.Equal(t, constantsBody, gotConstants)
+	assert.Equal(t, sigBody, gotSig)
+}
+
+// TestFetchFromURLs_SigURLFails verifies that a sig-URL failure is returned even when the constants URL succeeds.
+func TestFetchFromURLs_SigURLFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/constants" {
+			w.Write([]byte("constants-content"))
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := fetchFromURLs(context.Background(), srv.URL+"/constants", srv.URL+"/sig")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestFetchRemote_CancelledContext verifies that a cancelled context is propagated as an error.
+func TestFetchRemote_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := fetchRemote(ctx)
+	require.Error(t, err)
+}
+
+// TestLoad_RemoteUnavailable_FallsBackToShipped verifies that a remote fetch failure falls back to the shipped baseline.
+func TestLoad_RemoteUnavailable_FallsBackToShipped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	bc, err := Load(ctx, false)
+	require.NoError(t, err)
+	require.NotNil(t, bc)
+	assert.Equal(t, "v1", bc.Version)
+}
+
+// TestLoad_RemoteRefresh exercises the full remote-fetch path; skipped under -short.
+func TestLoad_RemoteRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network test in short mode")
+	}
+
+	bc, err := Load(context.Background(), false)
+	require.NoError(t, err)
+	require.NotNil(t, bc)
+	assert.Equal(t, "v1", bc.Version)
+}
+
+// TestLoad_ShippedConstantsTampered verifies that tampered shipped constants are rejected with an error.
+func TestLoad_ShippedConstantsTampered(t *testing.T) {
+	orig := shippedConstants
+	shippedConstants = []byte("this-content-will-not-verify")
+	defer func() { shippedConstants = orig }()
+
+	_, err := Load(context.Background(), true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shipped beckn constants failed verification")
+}
+
+// TestFetchFromURLs_InvalidURL verifies that a malformed URL is rejected.
+func TestFetchFromURLs_InvalidURL(t *testing.T) {
+	_, _, err := fetchFromURLs(context.Background(), "://invalid-url", "://invalid-url")
+	require.Error(t, err)
+}
+
+// TestLoadAndVerify_InvalidYAML verifies that invalid YAML content is rejected even when the signature is valid.
+func TestLoadAndVerify_InvalidYAML(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	content := []byte("key: :\n  - bad: yaml: :\n")
+	sig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, content))
+
+	pkix, err := x509.MarshalPKIXPublicKey(pub)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pkix})
+
+	orig := becknPublicKeyPEM
+	becknPublicKeyPEM = pubPEM
+	defer func() { becknPublicKeyPEM = orig }()
+
+	_, err = loadAndVerify(content, []byte(sig))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}


### PR DESCRIPTION
## Summary

* adds 8 new unit tests to `pkg/beckndefaults`, increasing coverage from 60.5% to 95.3%
* covers happy paths, error cases, and edge cases across `fetchFromURLs`, `fetchRemote`, `Load` and `loadAndVerify`
* the only remaining uncovered path (~5%) is when remote fetch succeeds but signature verification fails, which would require refactoring `fetchRemote` to allow injecting a mock url

Closes #814

## AI Model Disclosure

used vscode copilot (claude sonnet 4.6) to help identify missing test cases and improve coverage. changes were self-reviewed and verified with:

```bash
go test ./pkg/beckndefaults/... -v -cover
```