### PR TITLE
fix: validate context.network_id against caller network memberships 

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -176,6 +176,18 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// ResolveNetworkID returns context.network_id from a parsed Beckn context map,
+// trying "network_id" (snake_case) then "networkId" (camelCase).
+// Returns "" when absent, empty, or not a string under either alias.
+func ResolveNetworkID(reqContext map[string]interface{}) string {
+	for _, k := range []string{"network_id", "networkId"} {
+		if v, ok := reqContext[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // ResolveCallerID returns the ID of the other party in a Beckn exchange — i.e. who
 // sent the inbound message — from a parsed Beckn context map.
 // For BPP role: the caller is the BAP (bap_id / bapId / senderId).

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -20,17 +20,17 @@ type Subscriber struct {
 
 // Subscription represents subscription details of a network participant.
 type Subscription struct {
-	Subscriber       `json:",inline"`
-	KeyID            string    `json:"key_id,omitzero" format:"uuid"`
-	SigningPublicKey string    `json:"signing_public_key,omitzero"`
-	EncrPublicKey    string    `json:"encr_public_key,omitzero"`
-	ValidFrom        time.Time `json:"valid_from,omitzero" format:"date-time"`
-	ValidUntil       time.Time `json:"valid_until,omitzero" format:"date-time"`
-	Status           string    `json:"status,omitzero" enum:"INITIATED,UNDER_SUBSCRIPTION,SUBSCRIBED,EXPIRED,UNSUBSCRIBED,INVALID_SSL"`
-	Created          time.Time `json:"created,omitzero" format:"date-time"`
-	Updated          time.Time `json:"updated,omitzero" format:"date-time"`
-	Nonce              string   `json:"nonce,omitzero"`
-	NetworkMemberships []string `json:"network_memberships,omitempty"`
+	Subscriber         `json:",inline"`
+	KeyID              string    `json:"key_id,omitzero" format:"uuid"`
+	SigningPublicKey   string    `json:"signing_public_key,omitzero"`
+	EncrPublicKey      string    `json:"encr_public_key,omitzero"`
+	ValidFrom          time.Time `json:"valid_from,omitzero" format:"date-time"`
+	ValidUntil         time.Time `json:"valid_until,omitzero" format:"date-time"`
+	Status             string    `json:"status,omitzero" enum:"INITIATED,UNDER_SUBSCRIPTION,SUBSCRIBED,EXPIRED,UNSUBSCRIBED,INVALID_SSL"`
+	Created            time.Time `json:"created,omitzero" format:"date-time"`
+	Updated            time.Time `json:"updated,omitzero" format:"date-time"`
+	Nonce              string    `json:"nonce,omitzero"`
+	NetworkMemberships []string  `json:"network_memberships,omitempty"`
 }
 
 // RegistryMetadata represents metadata configured on a registry itself rather than on a specific record.
@@ -241,12 +241,12 @@ type Keyset struct {
 // StepContext holds context information for a request processing step.
 type StepContext struct {
 	context.Context
-	Request         *http.Request
-	Body            []byte
-	Route           *Route
-	SubID           string
-	Role            Role
-	RespHeader      http.Header
+	Request              *http.Request
+	Body                 []byte
+	Route                *Route
+	SubID                string
+	Role                 Role
+	RespHeader           http.Header
 	ProtocolVersion      string // Protocol version parsed from context.version (e.g. "2.0.0")
 	MessageID            string // Message ID parsed from context.messageId in the request body
 	InboundAuthSignature string // Raw Base64 signature from the inbound Authorization header's signature="..." attribute

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -29,7 +29,8 @@ type Subscription struct {
 	Status           string    `json:"status,omitzero" enum:"INITIATED,UNDER_SUBSCRIPTION,SUBSCRIBED,EXPIRED,UNSUBSCRIBED,INVALID_SSL"`
 	Created          time.Time `json:"created,omitzero" format:"date-time"`
 	Updated          time.Time `json:"updated,omitzero" format:"date-time"`
-	Nonce            string    `json:"nonce,omitzero"`
+	Nonce              string   `json:"nonce,omitzero"`
+	NetworkMemberships []string `json:"network_memberships,omitempty"`
 }
 
 // RegistryMetadata represents metadata configured on a registry itself rather than on a specific record.
@@ -72,6 +73,10 @@ const (
 	// ContextKeyProtocolVersion is the context key for the Beckn protocol version
 	// extracted from context.version in the inbound request body.
 	ContextKeyProtocolVersion ContextKey = "protocol_version"
+
+	// ContextKeyNetworkID is the context key for the network identifier extracted from
+	// context.network_id (or context.networkId) in the inbound request body.
+	ContextKeyNetworkID ContextKey = "network_id"
 )
 
 // ProtocolVersionV2 is the Beckn protocol version string for the v2.0.0 release.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestResolveCallerID(t *testing.T) {
 	tests := []struct {
-		name    string
-		ctx     map[string]interface{}
-		role    Role
-		want    string
+		name string
+		ctx  map[string]interface{}
+		role Role
+		want string
 	}{
 		{
 			name: "BAP role returns bpp_id",
@@ -165,6 +165,29 @@ func TestResolveSubscriberID(t *testing.T) {
 			got := ResolveSubscriberID(tc.ctx, tc.role)
 			if got != tc.want {
 				t.Errorf("ResolveSubscriberID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveNetworkID(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  map[string]interface{}
+		want string
+	}{
+		{name: "snake_case key", ctx: map[string]interface{}{"network_id": "nfo1.com/retail"}, want: "nfo1.com/retail"},
+		{name: "camelCase key", ctx: map[string]interface{}{"networkId": "nfo1.com/retail"}, want: "nfo1.com/retail"},
+		{name: "snake_case takes precedence over camelCase", ctx: map[string]interface{}{"network_id": "nfo1.com/retail", "networkId": "nfo2.com/retail"}, want: "nfo1.com/retail"},
+		{name: "non-string snake_case falls through to camelCase", ctx: map[string]interface{}{"network_id": 12345, "networkId": "nfo1.com/retail"}, want: "nfo1.com/retail"},
+		{name: "absent returns empty", ctx: map[string]interface{}{}, want: ""},
+		{name: "empty string returns empty", ctx: map[string]interface{}{"network_id": ""}, want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveNetworkID(tc.ctx)
+			if got != tc.want {
+				t.Errorf("ResolveNetworkID() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -402,7 +402,16 @@ func extractContextNetworkID(ctx context.Context) string {
 		}
 		if err := json.Unmarshal(sc.Body, &payload); err == nil && payload.Context != nil {
 			for _, key := range []string{"network_id", "networkId"} {
-				if v, ok := payload.Context[key].(string); ok && v != "" {
+				val, exists := payload.Context[key]
+				if !exists {
+					continue
+				}
+				v, ok := val.(string)
+				if !ok {
+					log.Warnf(ctx, "context.%s is present but not a string (got %T); network_id check will be skipped", key, val)
+					break
+				}
+				if v != "" {
 					return v
 				}
 			}

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -408,8 +408,8 @@ func extractContextNetworkID(ctx context.Context) string {
 				}
 				v, ok := val.(string)
 				if !ok {
-					log.Warnf(ctx, "context.%s is present but not a string (got %T); network_id check will be skipped", key, val)
-					break
+					log.Warnf(ctx, "context.%s is present but not a string (got %T); ignoring this key", key, val)
+					continue
 				}
 				if v != "" {
 					return v

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -160,7 +160,7 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 		return nil, fmt.Errorf("key_id is required for DeDi lookup")
 	}
 
-	cacheKey := fmt.Sprintf("lookup_%s_%s", subscriberID, keyID)
+	cacheKey := fmt.Sprintf("dedi_lookup_%s_%s", subscriberID, keyID)
 	tracer := otel.Tracer(telemetry.ScopeName, trace.WithInstrumentationVersion(telemetry.ScopeVersion))
 
 	if c.cache != nil {

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -401,19 +401,8 @@ func extractContextNetworkID(ctx context.Context) string {
 			Context map[string]interface{} `json:"context"`
 		}
 		if err := json.Unmarshal(sc.Body, &payload); err == nil && payload.Context != nil {
-			for _, key := range []string{"network_id", "networkId"} {
-				val, exists := payload.Context[key]
-				if !exists {
-					continue
-				}
-				v, ok := val.(string)
-				if !ok {
-					log.Warnf(ctx, "context.%s is present but not a string (got %T); ignoring this key", key, val)
-					continue
-				}
-				if v != "" {
-					return v
-				}
+			if v := model.ResolveNetworkID(payload.Context); v != "" {
+				return v
 			}
 		}
 	}

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -381,7 +381,7 @@ func (c *DeDiRegistryClient) validateContextNetworkID(ctx context.Context, netwo
 	if !containsAny(networkMemberships, []string{networkID}) {
 		return fmt.Errorf("context.network_id %q is not in network_memberships of subscriber %q", networkID, subscriberID)
 	}
-	if len(c.config.AllowedNetworkIDs) > 0 && !containsAny(c.config.AllowedNetworkIDs, []string{networkID}) {
+	if len(c.config.AllowedNetworkIDs) > 0 && !containsAny([]string{networkID}, c.config.AllowedNetworkIDs) {
 		return fmt.Errorf("context.network_id %q is not in configured allowedNetworkIDs", networkID)
 	}
 	return nil

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -172,7 +172,7 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 				log.Debugf(ctx, "DeDi registry lookup cache hit for key: %s", cacheKey)
 				cacheSpan.End()
 				if len(results) > 0 {
-					if err := c.validateContextNetworkID(ctx, results[0].NetworkMemberships, req.Subscriber.SubscriberID); err != nil {
+					if err := c.validateMemberships(ctx, results[0].NetworkMemberships, results[0].Subscriber.SubscriberID); err != nil {
 						return nil, err
 					}
 				}
@@ -213,12 +213,7 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 
 	// Validate network memberships if configured.
 	networkMemberships := extractStringSlice(ctx, "network_memberships", data["network_memberships"])
-	if len(c.config.AllowedNetworkIDs) > 0 {
-		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
-			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
-		}
-	}
-	if err := c.validateContextNetworkID(ctx, networkMemberships, detailsSubscriberID); err != nil {
+	if err := c.validateMemberships(ctx, networkMemberships, detailsSubscriberID); err != nil {
 		return nil, err
 	}
 
@@ -361,6 +356,18 @@ func containsAny(values []string, allowed []string) bool {
 		}
 	}
 	return false
+}
+
+// validateMemberships runs both the static allowedNetworkIDs guard and the per-request
+// context.network_id check against the subscriber's network_memberships.
+// Called on both the cache-hit and HTTP paths.
+func (c *DeDiRegistryClient) validateMemberships(ctx context.Context, networkMemberships []string, subscriberID string) error {
+	if len(c.config.AllowedNetworkIDs) > 0 {
+		if len(networkMemberships) == 0 || !containsAny(networkMemberships, c.config.AllowedNetworkIDs) {
+			return fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", subscriberID)
+		}
+	}
+	return c.validateContextNetworkID(ctx, networkMemberships, subscriberID)
 }
 
 // validateContextNetworkID checks context.network_id (when present in the request body) against

--- a/pkg/plugin/implementation/dediregistry/dediregistry.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry.go
@@ -171,6 +171,11 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 			if err := json.Unmarshal([]byte(cached), &results); err == nil {
 				log.Debugf(ctx, "DeDi registry lookup cache hit for key: %s", cacheKey)
 				cacheSpan.End()
+				if len(results) > 0 {
+					if err := c.validateContextNetworkID(ctx, results[0].NetworkMemberships, req.Subscriber.SubscriberID); err != nil {
+						return nil, err
+					}
+				}
 				return results, nil
 			}
 		}
@@ -213,6 +218,9 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 			return nil, fmt.Errorf("registry entry with subscriber_id '%s' does not belong to any configured networks (registry.config.allowedNetworkIDs)", detailsSubscriberID)
 		}
 	}
+	if err := c.validateContextNetworkID(ctx, networkMemberships, detailsSubscriberID); err != nil {
+		return nil, err
+	}
 
 	// Extract encr_public_key if available (optional field)
 	encrPublicKey, _ := details["encr_public_key"].(string)
@@ -229,11 +237,12 @@ func (c *DeDiRegistryClient) Lookup(ctx context.Context, req *model.Subscription
 			Domain:       detailsDomain,
 			Type:         detailsType,
 		},
-		KeyID:            keyID, // Use original keyID from request
-		SigningPublicKey: signingPublicKey,
-		EncrPublicKey:    encrPublicKey, // May be empty if not provided
-		Created:          parseTime(createdAt),
-		Updated:          parseTime(updatedAt),
+		KeyID:              keyID, // Use original keyID from request
+		SigningPublicKey:   signingPublicKey,
+		EncrPublicKey:      encrPublicKey, // May be empty if not provided
+		Created:            parseTime(createdAt),
+		Updated:            parseTime(updatedAt),
+		NetworkMemberships: networkMemberships,
 	}
 
 	results := []model.Subscription{subscription}
@@ -352,4 +361,45 @@ func containsAny(values []string, allowed []string) bool {
 		}
 	}
 	return false
+}
+
+// validateContextNetworkID checks context.network_id (when present in the request body) against
+// the caller's network_memberships and the configured allowedNetworkIDs.
+// Returns nil when context.network_id is absent or empty.
+func (c *DeDiRegistryClient) validateContextNetworkID(ctx context.Context, networkMemberships []string, subscriberID string) error {
+	networkID := extractContextNetworkID(ctx)
+	if networkID == "" {
+		return nil
+	}
+	if !containsAny(networkMemberships, []string{networkID}) {
+		return fmt.Errorf("context.network_id %q is not in network_memberships of subscriber %q", networkID, subscriberID)
+	}
+	if len(c.config.AllowedNetworkIDs) > 0 && !containsAny(c.config.AllowedNetworkIDs, []string{networkID}) {
+		return fmt.Errorf("context.network_id %q is not in configured allowedNetworkIDs", networkID)
+	}
+	return nil
+}
+
+// extractContextNetworkID returns context.network_id from the request.
+// Primary path: reads the context value set by reqpreprocessor (survives any OTel wrapping depth).
+// Fallback path: type-asserts to *model.StepContext and parses Body directly — works when
+// simplekeymanager preserves *model.StepContext through its OTel span, and also with keymanager.
+// Checks both "network_id" (snake_case) and "networkId" (camelCase). Returns "" when absent.
+func extractContextNetworkID(ctx context.Context) string {
+	if v, _ := ctx.Value(model.ContextKeyNetworkID).(string); v != "" {
+		return v
+	}
+	if sc, ok := ctx.(*model.StepContext); ok && len(sc.Body) > 0 {
+		var payload struct {
+			Context map[string]interface{} `json:"context"`
+		}
+		if err := json.Unmarshal(sc.Body, &payload); err == nil && payload.Context != nil {
+			for _, key := range []string{"network_id", "networkId"} {
+				if v, ok := payload.Context[key].(string); ok && v != "" {
+					return v
+				}
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -103,8 +103,8 @@ func TestNew(t *testing.T) {
 
 	t.Run("should apply custom retry settings", func(t *testing.T) {
 		cfg := &Config{
-			URL:      "http://test.com",
-			RetryMax: 10,
+			URL:          "http://test.com",
+			RetryMax:     10,
 			RetryWaitMin: 100 * time.Millisecond,
 			RetryWaitMax: 1 * time.Second,
 		}
@@ -192,8 +192,8 @@ func TestLookup(t *testing.T) {
 		defer server.Close()
 
 		config := &Config{
-			URL:          server.URL + "/dedi",
-			Timeout:      30,
+			URL:     server.URL + "/dedi",
+			Timeout: 30,
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -368,7 +368,7 @@ func TestLookup(t *testing.T) {
 	// Test empty subscriber ID
 	t.Run("empty subscriber ID", func(t *testing.T) {
 		config := &Config{
-			URL:          "https://test.com/dedi",
+			URL: "https://test.com/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -395,7 +395,7 @@ func TestLookup(t *testing.T) {
 	// Test empty key ID
 	t.Run("empty key ID", func(t *testing.T) {
 		config := &Config{
-			URL:          "https://test.com/dedi",
+			URL: "https://test.com/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -428,7 +428,7 @@ func TestLookup(t *testing.T) {
 		defer server.Close()
 
 		config := &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -465,7 +465,7 @@ func TestLookup(t *testing.T) {
 		defer server.Close()
 
 		config := &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -495,7 +495,7 @@ func TestLookup(t *testing.T) {
 		defer server.Close()
 
 		config := &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -528,7 +528,7 @@ func TestLookup(t *testing.T) {
 		defer server.Close()
 
 		config := &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -552,8 +552,8 @@ func TestLookup(t *testing.T) {
 	// Test network error
 	t.Run("network error", func(t *testing.T) {
 		config := &Config{
-			URL:          "http://invalid-url-that-does-not-exist.local/dedi",
-			Timeout:      1,
+			URL:     "http://invalid-url-that-does-not-exist.local/dedi",
+			Timeout: 1,
 		}
 
 		client, closer, err := New(ctx, nil, config)
@@ -592,8 +592,8 @@ func TestLookupRegistry(t *testing.T) {
 				"data": map[string]interface{}{
 					"registry_name": "mobility-network",
 					"meta": map[string]interface{}{
-						"manifestUrl":                  "https://example.org/manifest.yaml",
-						"manifestSignatureUrl":        "https://example.org/manifest.yaml.sig",
+						"manifestUrl":               "https://example.org/manifest.yaml",
+						"manifestSignatureUrl":      "https://example.org/manifest.yaml.sig",
 						"signingPublicKeyLookupUrl": "https://example.org/keys/manifest",
 					},
 				},
@@ -604,7 +604,7 @@ func TestLookupRegistry(t *testing.T) {
 		defer server.Close()
 
 		client, closer, err := New(ctx, nil, &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -639,7 +639,7 @@ func TestLookupRegistry(t *testing.T) {
 		defer server.Close()
 
 		client, closer, err := New(ctx, nil, &Config{
-			URL:          server.URL,
+			URL: server.URL,
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -656,7 +656,7 @@ func TestLookupRegistry(t *testing.T) {
 			response := map[string]interface{}{
 				"data": map[string]interface{}{
 					"meta": map[string]interface{}{
-						"manifestUrl":   "https://example.org/manifest.yaml",
+						"manifestUrl":    "https://example.org/manifest.yaml",
 						"non_string_key": true,
 					},
 				},
@@ -667,7 +667,7 @@ func TestLookupRegistry(t *testing.T) {
 		defer server.Close()
 
 		client, closer, err := New(ctx, nil, &Config{
-			URL:          server.URL,
+			URL: server.URL,
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -691,7 +691,7 @@ func TestLookupRegistry(t *testing.T) {
 		defer server.Close()
 
 		client, closer, err := New(ctx, nil, &Config{
-			URL:          server.URL + "/dedi",
+			URL: server.URL + "/dedi",
 		})
 		if err != nil {
 			t.Fatalf("New() error = %v", err)
@@ -877,7 +877,7 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 	t.Run("cache hit allows matching context.network_id", func(t *testing.T) {
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
-			SigningPublicKey:    "cached-key",
+			SigningPublicKey:   "cached-key",
 			NetworkMemberships: []string{"commerce.org/prod"},
 		}}
 		cachedJSON, _ := json.Marshal(cached)
@@ -902,7 +902,7 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 	t.Run("cache hit blocks mismatched context.network_id", func(t *testing.T) {
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
-			SigningPublicKey:    "cached-key",
+			SigningPublicKey:   "cached-key",
 			NetworkMemberships: []string{"commerce.org/prod"},
 		}}
 		cachedJSON, _ := json.Marshal(cached)
@@ -930,7 +930,7 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 		// context.network_id=net2 is not in allowlist — validateContextNetworkID blocks it.
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
-			SigningPublicKey:    "cached-key",
+			SigningPublicKey:   "cached-key",
 			NetworkMemberships: []string{"nfo1.com/retail", "nfo2.com/retail"},
 		}}
 		cachedJSON, _ := json.Marshal(cached)
@@ -958,7 +958,7 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 	t.Run("cache hit enforces allowedNetworkIDs", func(t *testing.T) {
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
-			SigningPublicKey:    "cached-key",
+			SigningPublicKey:   "cached-key",
 			NetworkMemberships: []string{"commerce.org/prod"},
 		}}
 		cachedJSON, _ := json.Marshal(cached)
@@ -1018,10 +1018,10 @@ func registryHandlerWithMemberships(subscriberID, signingKey string, memberships
 
 func TestContextNetworkIDValidation(t *testing.T) {
 	const (
-		sub     = "np.example.com"
-		key     = "test-signing-key-base64="
-		net1    = "nfo1.com/retail"
-		net2    = "nfo2.com/retail"
+		sub  = "np.example.com"
+		key  = "test-signing-key-base64="
+		net1 = "nfo1.com/retail"
+		net2 = "nfo2.com/retail"
 	)
 
 	req := &model.Subscription{

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -733,7 +733,7 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 		Subscriber: model.Subscriber{SubscriberID: "sub.example.com"},
 		KeyID:      "key-1",
 	}
-	expectedCacheKey := "lookup_sub.example.com_key-1"
+	expectedCacheKey := "dedi_lookup_sub.example.com_key-1"
 
 	t.Run("cache hit skips HTTP call", func(t *testing.T) {
 		cached := []model.Subscription{{SigningPublicKey: "cached-key"}}

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -873,6 +873,34 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 			t.Errorf("expected HTTP result after corrupt cache, got %+v", results)
 		}
 	})
+
+	t.Run("cache hit enforces allowedNetworkIDs", func(t *testing.T) {
+		cached := []model.Subscription{{
+			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
+			SigningPublicKey:    "cached-key",
+			NetworkMemberships: []string{"commerce.org/prod"},
+		}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{
+			URL:               "http://unused",
+			AllowedNetworkIDs: []string{"other.org/prod"},
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.Lookup(ctx, sub)
+		if err == nil {
+			t.Error("expected error when cached memberships do not match allowedNetworkIDs")
+		}
+	})
 }
 
 // makeStepCtx returns a *model.StepContext with network_id stored as a context value

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -874,6 +874,56 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 		}
 	})
 
+	t.Run("cache hit allows matching context.network_id", func(t *testing.T) {
+		cached := []model.Subscription{{
+			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
+			SigningPublicKey:    "cached-key",
+			NetworkMemberships: []string{"commerce.org/prod"},
+		}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{URL: "http://unused"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.Lookup(makeStepCtx("commerce.org/prod"), sub)
+		if err != nil {
+			t.Errorf("expected allow when context.network_id matches cached memberships, got: %v", err)
+		}
+	})
+
+	t.Run("cache hit blocks mismatched context.network_id", func(t *testing.T) {
+		cached := []model.Subscription{{
+			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
+			SigningPublicKey:    "cached-key",
+			NetworkMemberships: []string{"commerce.org/prod"},
+		}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{URL: "http://unused"})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.Lookup(makeStepCtx("other.org/prod"), sub)
+		if err == nil {
+			t.Error("expected block when context.network_id is not in cached memberships")
+		}
+	})
+
 	t.Run("cache hit enforces allowedNetworkIDs", func(t *testing.T) {
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -874,3 +874,222 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 		}
 	})
 }
+
+// makeStepCtx returns a *model.StepContext with network_id stored as a context value
+// (matching the production flow where reqpreprocessor sets it before any OTel wrapping).
+func makeStepCtx(networkID string) *model.StepContext {
+	goCtx := context.Background()
+	if networkID != "" {
+		goCtx = context.WithValue(goCtx, model.ContextKeyNetworkID, networkID)
+	}
+	return &model.StepContext{Context: goCtx}
+}
+
+// registryHandlerWithMemberships returns an httptest.HandlerFunc that responds with
+// a DeDi-shaped payload carrying the given subscriber and network_memberships.
+func registryHandlerWithMemberships(subscriberID, signingKey string, memberships []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		resp := map[string]interface{}{
+			"message": "Record retrieved from registry cache",
+			"data": map[string]interface{}{
+				"details": map[string]interface{}{
+					"url":                "http://example.com/beckn",
+					"type":               "BAP",
+					"domain":             "retail",
+					"subscriber_id":      subscriberID,
+					"signing_public_key": signingKey,
+				},
+				"network_memberships": memberships,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}
+}
+
+func TestContextNetworkIDValidation(t *testing.T) {
+	const (
+		sub     = "np.example.com"
+		key     = "test-signing-key-base64="
+		net1    = "nfo1.com/retail"
+		net2    = "nfo2.com/retail"
+	)
+
+	req := &model.Subscription{
+		Subscriber: model.Subscriber{SubscriberID: sub},
+		KeyID:      "key-001",
+	}
+
+	type tc struct {
+		name        string
+		memberships []string
+		allowlist   []string
+		networkID   string // empty string means absent from body
+		wantErr     bool
+	}
+
+	cases := []tc{
+		// allow cases
+		{
+			name:        "allow — network_id matches memberships and allowlist",
+			memberships: []string{net1},
+			allowlist:   []string{net1},
+			networkID:   net1,
+			wantErr:     false,
+		},
+		{
+			name:        "allow — no allowlist, network_id matches memberships",
+			memberships: []string{net1},
+			allowlist:   nil,
+			networkID:   net1,
+			wantErr:     false,
+		},
+		{
+			name:        "allow — no network_id present, allowlist set",
+			memberships: []string{net1},
+			allowlist:   []string{net1},
+			networkID:   "",
+			wantErr:     false,
+		},
+		{
+			name:        "allow — no network_id present, no allowlist",
+			memberships: []string{net1},
+			allowlist:   nil,
+			networkID:   "",
+			wantErr:     false,
+		},
+		{
+			name:        "allow — network_id in memberships and in multi-entry allowlist",
+			memberships: []string{net1},
+			allowlist:   []string{net1, net2},
+			networkID:   net1,
+			wantErr:     false,
+		},
+		// block cases
+		{
+			name:        "block — network_id not in memberships (allowlist set)",
+			memberships: []string{net1},
+			allowlist:   []string{net1},
+			networkID:   net2,
+			wantErr:     true,
+		},
+		{
+			name:        "block — network_id not in memberships (no allowlist)",
+			memberships: []string{net1},
+			allowlist:   nil,
+			networkID:   net2,
+			wantErr:     true,
+		},
+		{
+			name:        "block — multi-membership, network_id not in allowlist",
+			memberships: []string{net1, net2},
+			allowlist:   []string{net1},
+			networkID:   net2,
+			wantErr:     true,
+		},
+		{
+			name:        "block — empty memberships, no allowlist, network_id present",
+			memberships: nil,
+			allowlist:   nil,
+			networkID:   net1,
+			wantErr:     true,
+		},
+		{
+			name:        "block — network_id in memberships but not in allowlist",
+			memberships: []string{net1},
+			allowlist:   []string{net1, net2},
+			networkID:   net2,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(registryHandlerWithMemberships(sub, key, tt.memberships))
+			defer server.Close()
+
+			cfg := &Config{
+				URL:               server.URL + "/dedi",
+				AllowedNetworkIDs: tt.allowlist,
+			}
+			client, closer, err := New(context.Background(), nil, cfg)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			defer closer()
+
+			ctx := makeStepCtx(tt.networkID)
+			_, err = client.Lookup(ctx, req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Lookup() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtractContextNetworkID(t *testing.T) {
+	// Primary path: context value set by reqpreprocessor.
+	t.Run("context value (primary path)", func(t *testing.T) {
+		goCtx := context.WithValue(context.Background(), model.ContextKeyNetworkID, "nfo1.com/retail")
+		sc := &model.StepContext{Context: goCtx}
+		if got := extractContextNetworkID(sc); got != "nfo1.com/retail" {
+			t.Errorf("got %q, want %q", got, "nfo1.com/retail")
+		}
+	})
+
+	t.Run("context value on plain context (no StepContext)", func(t *testing.T) {
+		goCtx := context.WithValue(context.Background(), model.ContextKeyNetworkID, "nfo1.com/retail")
+		if got := extractContextNetworkID(goCtx); got != "nfo1.com/retail" {
+			t.Errorf("got %q, want %q", got, "nfo1.com/retail")
+		}
+	})
+
+	t.Run("context value takes precedence over body", func(t *testing.T) {
+		goCtx := context.WithValue(context.Background(), model.ContextKeyNetworkID, "nfo1.com/retail")
+		sc := &model.StepContext{
+			Context: goCtx,
+			Body:    []byte(`{"context":{"network_id":"nfo2.com/retail"}}`),
+		}
+		if got := extractContextNetworkID(sc); got != "nfo1.com/retail" {
+			t.Errorf("context value should win: got %q, want %q", got, "nfo1.com/retail")
+		}
+	})
+
+	// Fallback path: body parsing when context value is absent.
+	t.Run("snake_case network_id in body (fallback)", func(t *testing.T) {
+		sc := &model.StepContext{
+			Context: context.Background(),
+			Body:    []byte(`{"context":{"network_id":"nfo1.com/retail"}}`),
+		}
+		if got := extractContextNetworkID(sc); got != "nfo1.com/retail" {
+			t.Errorf("got %q, want %q", got, "nfo1.com/retail")
+		}
+	})
+
+	t.Run("camelCase networkId in body (fallback)", func(t *testing.T) {
+		sc := &model.StepContext{
+			Context: context.Background(),
+			Body:    []byte(`{"context":{"networkId":"nfo2.com/retail"}}`),
+		}
+		if got := extractContextNetworkID(sc); got != "nfo2.com/retail" {
+			t.Errorf("got %q, want %q", got, "nfo2.com/retail")
+		}
+	})
+
+	// Absent / empty cases.
+	t.Run("absent from both context value and body", func(t *testing.T) {
+		sc := &model.StepContext{
+			Context: context.Background(),
+			Body:    []byte(`{"context":{}}`),
+		}
+		if got := extractContextNetworkID(sc); got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("plain context with no context value returns empty", func(t *testing.T) {
+		if got := extractContextNetworkID(context.Background()); got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+}

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -1227,6 +1227,16 @@ func TestExtractContextNetworkID(t *testing.T) {
 		}
 	})
 
+	t.Run("non-string network_id falls through to networkId alias", func(t *testing.T) {
+		sc := &model.StepContext{
+			Context: context.Background(),
+			Body:    []byte(`{"context":{"network_id":12345,"networkId":"nfo1.com/retail"}}`),
+		}
+		if got := extractContextNetworkID(sc); got != "nfo1.com/retail" {
+			t.Errorf("got %q, want %q", got, "nfo1.com/retail")
+		}
+	})
+
 	// Absent / empty cases.
 	t.Run("absent from both context value and body", func(t *testing.T) {
 		sc := &model.StepContext{

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -1079,6 +1079,48 @@ func TestContextNetworkIDValidation(t *testing.T) {
 			networkID:   net2,
 			wantErr:     true,
 		},
+		{
+			name:        "block — memberships disjoint from allowlist, network_id=net1",
+			memberships: []string{net1},
+			allowlist:   []string{net2},
+			networkID:   net1,
+			wantErr:     true,
+		},
+		{
+			name:        "block — memberships disjoint from allowlist, network_id=net2",
+			memberships: []string{net1},
+			allowlist:   []string{net2},
+			networkID:   net2,
+			wantErr:     true,
+		},
+		{
+			name:        "block — memberships disjoint from allowlist, network_id absent",
+			memberships: []string{net1},
+			allowlist:   []string{net2},
+			networkID:   "",
+			wantErr:     true,
+		},
+		{
+			name:        "allow — multi-membership, network_id is the one in allowlist",
+			memberships: []string{net1, net2},
+			allowlist:   []string{net1},
+			networkID:   net1,
+			wantErr:     false,
+		},
+		{
+			name:        "block — empty memberships, allowlist set, network_id present",
+			memberships: nil,
+			allowlist:   []string{net1},
+			networkID:   net1,
+			wantErr:     true,
+		},
+		{
+			name:        "allow — empty memberships, no allowlist, no network_id",
+			memberships: nil,
+			allowlist:   nil,
+			networkID:   "",
+			wantErr:     false,
+		},
 	}
 
 	for _, tt := range cases {

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -924,6 +924,37 @@ func TestDeDiRegistryClient_Lookup_Cache(t *testing.T) {
 		}
 	})
 
+	t.Run("cache hit blocks context.network_id not in allowlist (both guards active)", func(t *testing.T) {
+		// memberships=[net1,net2], allowlist=[net1], context.network_id=net2
+		// Static guard passes (net1 satisfies memberships∩allowlist), but
+		// context.network_id=net2 is not in allowlist — validateContextNetworkID blocks it.
+		cached := []model.Subscription{{
+			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},
+			SigningPublicKey:    "cached-key",
+			NetworkMemberships: []string{"nfo1.com/retail", "nfo2.com/retail"},
+		}}
+		cachedJSON, _ := json.Marshal(cached)
+
+		cache := &mockCache{
+			getFunc: func(ctx context.Context, key string) (string, error) {
+				return string(cachedJSON), nil
+			},
+		}
+		client, closer, err := New(ctx, cache, &Config{
+			URL:               "http://unused",
+			AllowedNetworkIDs: []string{"nfo1.com/retail"},
+		})
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer closer()
+
+		_, err = client.Lookup(makeStepCtx("nfo2.com/retail"), sub)
+		if err == nil {
+			t.Error("expected block when context.network_id is in memberships but not in allowlist")
+		}
+	})
+
 	t.Run("cache hit enforces allowedNetworkIDs", func(t *testing.T) {
 		cached := []model.Subscription{{
 			Subscriber:         model.Subscriber{SubscriberID: "sub.example.com"},

--- a/pkg/plugin/implementation/dediregistry/dediregistry_test.go
+++ b/pkg/plugin/implementation/dediregistry/dediregistry_test.go
@@ -1073,7 +1073,7 @@ func TestContextNetworkIDValidation(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "block — network_id in memberships but not in allowlist",
+			name:        "block — network_id not in memberships (multi-entry allowlist)",
 			memberships: []string{net1},
 			allowlist:   []string{net1, net2},
 			networkID:   net2,

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -111,8 +111,8 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				}
 				v, ok := val.(string)
 				if !ok {
-					log.Warnf(ctx, "context.%s is present but not a string (got %T); network_id check will be skipped", key, val)
-					break
+					log.Warnf(ctx, "context.%s is present but not a string (got %T); ignoring this key", key, val)
+					continue
 				}
 				if v != "" {
 					networkID = v

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -103,23 +103,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				ctx = context.WithValue(ctx, model.ContextKeyRemoteID, callerID)
 			}
 
-			var networkID string
-			for _, key := range []string{"network_id", "networkId"} {
-				val, exists := reqContext[key]
-				if !exists {
-					continue
-				}
-				v, ok := val.(string)
-				if !ok {
-					log.Warnf(ctx, "context.%s is present but not a string (got %T); ignoring this key", key, val)
-					continue
-				}
-				if v != "" {
-					networkID = v
-					break
-				}
-			}
-			if networkID != "" {
+			if networkID := model.ResolveNetworkID(reqContext); networkID != "" {
 				log.Debugf(ctx, "adding networkID to request:%s, %v", model.ContextKeyNetworkID, networkID)
 				ctx = context.WithValue(ctx, model.ContextKeyNetworkID, networkID)
 			}

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -105,7 +105,16 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 
 			var networkID string
 			for _, key := range []string{"network_id", "networkId"} {
-				if v, ok := reqContext[key].(string); ok && v != "" {
+				val, exists := reqContext[key]
+				if !exists {
+					continue
+				}
+				v, ok := val.(string)
+				if !ok {
+					log.Warnf(ctx, "context.%s is present but not a string (got %T); network_id check will be skipped", key, val)
+					break
+				}
+				if v != "" {
 					networkID = v
 					break
 				}

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -103,6 +103,18 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				ctx = context.WithValue(ctx, model.ContextKeyRemoteID, callerID)
 			}
 
+			var networkID string
+			for _, key := range []string{"network_id", "networkId"} {
+				if v, ok := reqContext[key].(string); ok && v != "" {
+					networkID = v
+					break
+				}
+			}
+			if networkID != "" {
+				log.Debugf(ctx, "adding networkID to request:%s, %v", model.ContextKeyNetworkID, networkID)
+				ctx = context.WithValue(ctx, model.ContextKeyNetworkID, networkID)
+			}
+
 			// Extract generic context keys (e.g. transaction_id, message_id).
 			// For each configured snake_case key, also try its camelCase equivalent
 			// so that a single config entry covers both beckn spec versions.

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -432,12 +432,12 @@ func TestCamelCaseContextKeys(t *testing.T) {
 // and that the static ParentID config value is still injected.
 func TestBodylessRequest(t *testing.T) {
 	tests := []struct {
-		name          string
-		method        string
-		path          string
-		role          string
-		parentID      string
-		wantParentID  bool
+		name         string
+		method       string
+		path         string
+		role         string
+		parentID     string
+		wantParentID bool
 	}{
 		{
 			name:   "GET catalog/subscription — bap role",
@@ -525,6 +525,72 @@ func TestBodylessRequest(t *testing.T) {
 			}
 			if !reached {
 				t.Error("expected next handler to be called, but it was not")
+			}
+		})
+	}
+}
+
+func TestNewPreProcessorAddsNetworkIDToContext(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        map[string]interface{}
+		wantNetwork string
+	}{
+		{
+			name: "snake_case network_id stored in context",
+			body: map[string]interface{}{"context": map[string]interface{}{
+				"bap_id": "bap.example.com", "network_id": "nfo1.com/retail",
+			}},
+			wantNetwork: "nfo1.com/retail",
+		},
+		{
+			name: "camelCase networkId stored in context",
+			body: map[string]interface{}{"context": map[string]interface{}{
+				"bap_id": "bap.example.com", "networkId": "nfo1.com/retail",
+			}},
+			wantNetwork: "nfo1.com/retail",
+		},
+		{
+			name: "non-string network_id falls through to networkId alias",
+			body: map[string]interface{}{"context": map[string]interface{}{
+				"bap_id": "bap.example.com", "network_id": 12345, "networkId": "nfo1.com/retail",
+			}},
+			wantNetwork: "nfo1.com/retail",
+		},
+		{
+			name: "absent network_id leaves context value unset",
+			body: map[string]interface{}{"context": map[string]interface{}{
+				"bap_id": "bap.example.com",
+			}},
+			wantNetwork: "",
+		},
+	}
+
+	cfg := &Config{Role: "bap"}
+	middleware, err := NewPreProcessor(cfg)
+	if err != nil {
+		t.Fatalf("NewPreProcessor: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyBytes, _ := json.Marshal(tc.body)
+			var got interface{}
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Context().Value(model.ContextKeyNetworkID)
+				w.WriteHeader(http.StatusOK)
+			})
+			req := httptest.NewRequest("POST", "/", bytes.NewReader(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			middleware(handler).ServeHTTP(httptest.NewRecorder(), req)
+			if tc.wantNetwork == "" {
+				if got != nil {
+					t.Errorf("expected no network_id in context, got %v", got)
+				}
+			} else {
+				if got != tc.wantNetwork {
+					t.Errorf("got %v, want %q", got, tc.wantNetwork)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -24,10 +24,10 @@ import (
 type Config struct {
 	SubscriberID      string `yaml:"subscriberId" json:"subscriberId"`
 	KeyID             string `yaml:"keyId" json:"keyId"`
-	SigningPrivateKey  string `yaml:"signingPrivateKey" json:"signingPrivateKey"`
-	SigningPublicKey   string `yaml:"signingPublicKey" json:"signingPublicKey"`
-	EncrPrivateKey     string `yaml:"encrPrivateKey" json:"encrPrivateKey"`
-	EncrPublicKey      string `yaml:"encrPublicKey" json:"encrPublicKey"`
+	SigningPrivateKey string `yaml:"signingPrivateKey" json:"signingPrivateKey"`
+	SigningPublicKey  string `yaml:"signingPublicKey" json:"signingPublicKey"`
+	EncrPrivateKey    string `yaml:"encrPrivateKey" json:"encrPrivateKey"`
+	EncrPublicKey     string `yaml:"encrPublicKey" json:"encrPublicKey"`
 }
 
 // SimpleKeyMgr provides methods for managing cryptographic keys using configuration.

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -243,7 +243,7 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 		// so *model.StepContext is preserved as the outermost type passed to Registry.Lookup.
 		// Downstream plugins can then type-assert back to *model.StepContext to access Body.
 		registryCtx := ctx
-		if sc, ok := ctx.(*model.StepContext); ok {
+		if sc, ok := ctx.(*model.StepContext); ok && sc != nil {
 			spanCtx, span := tracer.Start(sc.Context, "registry lookup")
 			defer span.End()
 			scCopy := *sc

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -247,7 +247,7 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 			spanCtx, span := tracer.Start(sc.Context, "registry lookup")
 			defer span.End()
 			scCopy := *sc
-			scCopy.WithContext(spanCtx)
+			scCopy.Context = spanCtx
 			registryCtx = &scCopy
 		} else {
 			var span trace.Span

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -239,11 +239,24 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 
 	var subscribers []model.Subscription
 	{
-		spanCtx, span := tracer.Start(ctx, "registry lookup")
-		defer span.End()
+		// Wrap the embedded context.Context field rather than the full interface value,
+		// so *model.StepContext is preserved as the outermost type passed to Registry.Lookup.
+		// Downstream plugins can then type-assert back to *model.StepContext to access Body.
+		registryCtx := ctx
+		if sc, ok := ctx.(*model.StepContext); ok {
+			spanCtx, span := tracer.Start(sc.Context, "registry lookup")
+			defer span.End()
+			scCopy := *sc
+			scCopy.WithContext(spanCtx)
+			registryCtx = &scCopy
+		} else {
+			var span trace.Span
+			registryCtx, span = tracer.Start(ctx, "registry lookup")
+			defer span.End()
+		}
 		var err error
 
-		subscribers, err = skm.Registry.Lookup(spanCtx, &model.Subscription{
+		subscribers, err = skm.Registry.Lookup(registryCtx, &model.Subscription{
 			Subscriber: model.Subscriber{
 				SubscriberID: subscriberID,
 			},


### PR DESCRIPTION
Closes #837

## Summary

- A caller registered on `nfo1.com/retail` could send a request with `context.network_id: nfo2.com/retail` and pass signature validation. Onix checked that the signing subscriber belonged to an allowed network, but never cross-checked the request body's `context.network_id` against the subscriber's actual `network_memberships` from the registry.

- `dediregistry.Lookup` now calls `validateMemberships` on both the cache-hit and HTTP paths, which enforces two guards in sequence:
  1. Static guard — subscriber's `network_memberships` must intersect `allowedNetworkIDs` (pre-existing check, now shared)
  2. Per-request guard — `context.network_id` (when present) must be in the subscriber's `network_memberships` **and** in `allowedNetworkIDs`

- `reqpreprocessor` extracts `network_id`/`networkId` from the request body and stores it as `model.ContextKeyNetworkID` in the Go context before any OTel span wrapping. `extractContextNetworkID` reads this value first, with a fallback to direct body parsing via type assertion.

- `simplekeymanager.LookupNPKeys` was wrapping the full `context.Context` interface with an OTel span before passing it to `Registry.Lookup`, causing `ctx.(*model.StepContext)` to silently fail downstream. Fixed by wrapping only the embedded `sc.Context` field so `*model.StepContext` is preserved as the outermost type passed to the registry.

- Cache key changed from `lookup_<sub>_<key>` to `dedi_lookup_<sub>_<key>` to invalidate pre-deploy entries that have no `network_memberships` field.

## Test plan

- [ ] `TestContextNetworkIDValidation` — 16 of 18 decision table rows. The two omitted rows (12 and 18) are the network_id-absent variants of groups already covered by rows 3 and 9 — when `network_id` is empty the per-request guard exits immediately, so they exercise no new code path.
- [ ] `TestDeDiRegistryClient_Lookup_Cache` — 9 sub-tests including cache-hit path for both guards active simultaneously
- [ ] `TestExtractContextNetworkID` — context value primary path, body fallback path, precedence, absent cases
- [ ] `go test ./...` — full suite green