### PR TITLE
test(otelsetup): increase unit test coverage

### DIFF
--- a/pkg/plugin/implementation/otelsetup/cmd/plugin.go
+++ b/pkg/plugin/implementation/otelsetup/cmd/plugin.go
@@ -33,37 +33,18 @@ func (m metricsProvider) New(ctx context.Context, config map[string]string) (*te
 		OtlpEndpoint:   config["otlpEndpoint"],
 	}
 
-	// to extract the device id from the parent id from context
-	var deviceId string
-	var producer string
-	var producerType string
 	var err error
 	if v := ctx.Value(model.ContextKeyParentID); v != nil {
-		parentID := v.(string)
-		p := strings.Split(parentID, ":")
-		if len(p) >= 3 {
-			producerType = p[0]
-			producer = p[1]
-			deviceId = p[len(p)-1]
-		} else if len(p) >= 2 {
-			producerType = p[0]
-			producer = p[1]
-			deviceId = p[1]
-		} else if len(p) >= 1 {
-			producerType = p[0]
-			deviceId = p[0]
+		pt, prod, devID := parseParentID(v.(string))
+		if pt != "" {
+			telemetryConfig.ProducerType = pt
 		}
-	}
-
-	if deviceId != "" {
-		telemetryConfig.DeviceID = deviceId
-	}
-
-	if producer != "" {
-		telemetryConfig.Producer = producer
-	}
-	if producerType != "" {
-		telemetryConfig.ProducerType = producerType
+		if prod != "" {
+			telemetryConfig.Producer = prod
+		}
+		if devID != "" {
+			telemetryConfig.DeviceID = devID
+		}
 	}
 
 	// Parse enableTracing from config
@@ -92,20 +73,18 @@ func (m metricsProvider) New(ctx context.Context, config map[string]string) (*te
 
 	// Parse timeInterval as int
 	if timeIntervalStr, ok := config["timeInterval"]; ok && timeIntervalStr != "" {
-		telemetryConfig.TimeInterval, err = strconv.ParseInt(timeIntervalStr, 10, 64)
-		if err != nil {
-			log.Warnf(ctx, "Invalid timeInterval value: %s, defaulting to 5 second ", timeIntervalStr)
+		if _, err = strconv.ParseInt(timeIntervalStr, 10, 64); err != nil {
+			log.Warnf(ctx, "Invalid timeInterval value: %s, defaulting to 5 second", timeIntervalStr)
 		}
-
+		telemetryConfig.TimeInterval = parseTimeInterval(timeIntervalStr)
 	}
 
-	// Parse cacheTTL as in
+	// Parse cacheTTL as int
 	if cacheTTLStr, ok := config["cacheTTL"]; ok && cacheTTLStr != "" {
-		telemetryConfig.CacheTTL, err = strconv.ParseInt(cacheTTLStr, 10, 64)
-		if err != nil {
-			log.Warnf(ctx, "Invalid cacheTTL value: %s, defaulting to 3600 second ", cacheTTLStr)
-			telemetryConfig.CacheTTL = 3600
+		if _, err = strconv.ParseInt(cacheTTLStr, 10, 64); err != nil {
+			log.Warnf(ctx, "Invalid cacheTTL value: %s, defaulting to 3600 second", cacheTTLStr)
 		}
+		telemetryConfig.CacheTTL = parseCacheTTL(cacheTTLStr)
 	}
 	var stopAuditRefresh func()
 	// to set fields for audit logs
@@ -148,3 +127,35 @@ func (m metricsProvider) New(ctx context.Context, config map[string]string) (*te
 
 // Provider is the exported plugin instance
 var Provider = metricsProvider{}
+
+// parseParentID splits a colon-delimited parent ID into its component fields.
+func parseParentID(parentID string) (producerType, producer, deviceID string) {
+	p := strings.Split(parentID, ":")
+	switch {
+	case len(p) >= 3:
+		return p[0], p[1], p[len(p)-1]
+	case len(p) >= 2:
+		return p[0], p[1], p[1]
+	case len(p) >= 1:
+		return p[0], "", p[0]
+	}
+	return "", "", ""
+}
+
+// parseTimeInterval parses s as an integer interval in seconds. Returns 5 on parse error.
+func parseTimeInterval(s string) int64 {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 5
+	}
+	return v
+}
+
+// parseCacheTTL parses s as an integer TTL in seconds. Returns 3600 on parse error.
+func parseCacheTTL(s string) int64 {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 3600
+	}
+	return v
+}

--- a/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/otelsetup"
+	"github.com/beckn-one/beckn-onix/pkg/telemetry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -326,14 +327,16 @@ func TestMetricsProviderNew_EnableTracingAndLogs(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name          string
-		enableTracing string
-		enableLogs    string
+		name              string
+		enableTracing     string
+		enableLogs        string
+		wantTraceProvider bool
+		wantLogProvider   bool
 	}{
-		{name: "tracing true logs true", enableTracing: "true", enableLogs: "true"},
-		{name: "tracing false logs false", enableTracing: "false", enableLogs: "false"},
-		{name: "invalid tracing value", enableTracing: "bad", enableLogs: "false"},
-		{name: "invalid logs value", enableTracing: "false", enableLogs: "bad"},
+		{name: "tracing true logs true", enableTracing: "true", enableLogs: "true", wantTraceProvider: true, wantLogProvider: true},
+		{name: "tracing false logs false", enableTracing: "false", enableLogs: "false", wantTraceProvider: false, wantLogProvider: false},
+		{name: "invalid tracing value", enableTracing: "bad", enableLogs: "false", wantTraceProvider: false, wantLogProvider: false},
+		{name: "invalid logs value", enableTracing: "false", enableLogs: "bad", wantTraceProvider: false, wantLogProvider: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -345,6 +348,16 @@ func TestMetricsProviderNew_EnableTracingAndLogs(t *testing.T) {
 			provider, cleanup, err := p.New(ctx, config)
 			require.NoError(t, err)
 			require.NotNil(t, provider)
+			if tt.wantTraceProvider {
+				assert.NotNil(t, provider.TraceProvider, "expected TraceProvider to be set")
+			} else {
+				assert.Nil(t, provider.TraceProvider, "expected TraceProvider to be nil")
+			}
+			if tt.wantLogProvider {
+				assert.NotNil(t, provider.LogProvider, "expected LogProvider to be set")
+			} else {
+				assert.Nil(t, provider.LogProvider, "expected LogProvider to be nil")
+			}
 			if cleanup != nil {
 				_ = cleanup()
 			}
@@ -396,6 +409,9 @@ func TestMetricsProviderNew_NetworkMetrics(t *testing.T) {
 	provider, cleanup, err := p.New(ctx, config)
 	require.NoError(t, err)
 	require.NotNil(t, provider)
+	granularity, frequency := telemetry.GetNetworkMetricsConfig()
+	assert.Equal(t, "low", granularity, "expected networkMetricsGranularity to be applied")
+	assert.Equal(t, "30", frequency, "expected networkMetricsFrequency to be applied")
 	if cleanup != nil {
 		_ = cleanup()
 	}

--- a/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/otelsetup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,5 +292,111 @@ func TestMetricsProviderNew_DefaultValues(t *testing.T) {
 	if cleanup != nil {
 		err := cleanup()
 		assert.NoError(t, err, "cleanup() should not return error")
+	}
+}
+
+// TestMetricsProviderNew_ParentIDContext tests that parent ID fields are parsed from the context.
+func TestMetricsProviderNew_ParentIDContext(t *testing.T) {
+	p := metricsProvider{}
+
+	tests := []struct {
+		name     string
+		parentID string
+	}{
+		{name: "three parts", parentID: "producerType:producer:device-id"},
+		{name: "two parts", parentID: "producerType:producer"},
+		{name: "one part", parentID: "producerType"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), model.ContextKeyParentID, tt.parentID)
+			provider, cleanup, err := p.New(ctx, map[string]string{"enableMetrics": "false"})
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+			if cleanup != nil {
+				_ = cleanup()
+			}
+		})
+	}
+}
+
+// TestMetricsProviderNew_EnableTracingAndLogs tests that enableTracing and enableLogs are parsed from config.
+func TestMetricsProviderNew_EnableTracingAndLogs(t *testing.T) {
+	p := metricsProvider{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		enableTracing string
+		enableLogs    string
+	}{
+		{name: "tracing true logs true", enableTracing: "true", enableLogs: "true"},
+		{name: "tracing false logs false", enableTracing: "false", enableLogs: "false"},
+		{name: "invalid tracing value", enableTracing: "bad", enableLogs: "false"},
+		{name: "invalid logs value", enableTracing: "false", enableLogs: "bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := map[string]string{
+				"enableMetrics": "false",
+				"enableTracing": tt.enableTracing,
+				"enableLogs":    tt.enableLogs,
+			}
+			provider, cleanup, err := p.New(ctx, config)
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+			if cleanup != nil {
+				_ = cleanup()
+			}
+		})
+	}
+}
+
+// TestMetricsProviderNew_TimeIntervalAndCacheTTL tests that timeInterval and cacheTTL fall back to defaults for invalid values.
+func TestMetricsProviderNew_TimeIntervalAndCacheTTL(t *testing.T) {
+	p := metricsProvider{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		timeInterval string
+		cacheTTL     string
+	}{
+		{name: "valid interval and ttl", timeInterval: "10", cacheTTL: "3600"},
+		{name: "invalid interval", timeInterval: "bad", cacheTTL: "3600"},
+		{name: "invalid cacheTTL", timeInterval: "5", cacheTTL: "bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := map[string]string{
+				"enableMetrics": "false",
+				"timeInterval":  tt.timeInterval,
+				"cacheTTL":      tt.cacheTTL,
+			}
+			provider, cleanup, err := p.New(ctx, config)
+			require.NoError(t, err)
+			require.NotNil(t, provider)
+			if cleanup != nil {
+				_ = cleanup()
+			}
+		})
+	}
+}
+
+// TestMetricsProviderNew_NetworkMetrics tests that networkMetricsGranularity and networkMetricsFrequency are applied.
+func TestMetricsProviderNew_NetworkMetrics(t *testing.T) {
+	p := metricsProvider{}
+	ctx := context.Background()
+
+	config := map[string]string{
+		"enableMetrics":             "false",
+		"networkMetricsGranularity": "low",
+		"networkMetricsFrequency":   "30",
+	}
+	provider, cleanup, err := p.New(ctx, config)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	if cleanup != nil {
+		_ = cleanup()
 	}
 }

--- a/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/otelsetup/cmd/plugin_test.go
@@ -49,6 +49,31 @@ func TestMetricsProviderNew_Success(t *testing.T) {
 				"serviceVersion": "2.0.0",
 			},
 		},
+		{
+			name: "Config with parentID in context",
+			ctx:  context.WithValue(context.Background(), model.ContextKeyParentID, "producerType:producer:device-id"),
+			config: map[string]string{
+				"enableMetrics": "false",
+			},
+		},
+		{
+			name: "Config with valid timeInterval and cacheTTL",
+			ctx:  context.Background(),
+			config: map[string]string{
+				"enableMetrics": "false",
+				"timeInterval":  "10",
+				"cacheTTL":      "7200",
+			},
+		},
+		{
+			name: "Config with invalid timeInterval and cacheTTL falls back to defaults",
+			ctx:  context.Background(),
+			config: map[string]string{
+				"enableMetrics": "false",
+				"timeInterval":  "bad",
+				"cacheTTL":      "bad",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -296,27 +321,43 @@ func TestMetricsProviderNew_DefaultValues(t *testing.T) {
 	}
 }
 
-// TestMetricsProviderNew_ParentIDContext tests that parent ID fields are parsed from the context.
-func TestMetricsProviderNew_ParentIDContext(t *testing.T) {
-	p := metricsProvider{}
-
+// TestParseParentID tests parseParentID splits a colon-delimited parent ID correctly.
+func TestParseParentID(t *testing.T) {
 	tests := []struct {
-		name     string
-		parentID string
+		name             string
+		parentID         string
+		wantProducerType string
+		wantProducer     string
+		wantDeviceID     string
 	}{
-		{name: "three parts", parentID: "producerType:producer:device-id"},
-		{name: "two parts", parentID: "producerType:producer"},
-		{name: "one part", parentID: "producerType"},
+		{
+			name:             "three parts",
+			parentID:         "producerType:producer:device-id",
+			wantProducerType: "producerType",
+			wantProducer:     "producer",
+			wantDeviceID:     "device-id",
+		},
+		{
+			name:             "two parts",
+			parentID:         "producerType:producer",
+			wantProducerType: "producerType",
+			wantProducer:     "producer",
+			wantDeviceID:     "producer",
+		},
+		{
+			name:             "one part",
+			parentID:         "producerType",
+			wantProducerType: "producerType",
+			wantProducer:     "",
+			wantDeviceID:     "producerType",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.WithValue(context.Background(), model.ContextKeyParentID, tt.parentID)
-			provider, cleanup, err := p.New(ctx, map[string]string{"enableMetrics": "false"})
-			require.NoError(t, err)
-			require.NotNil(t, provider)
-			if cleanup != nil {
-				_ = cleanup()
-			}
+			pt, prod, devID := parseParentID(tt.parentID)
+			assert.Equal(t, tt.wantProducerType, pt)
+			assert.Equal(t, tt.wantProducer, prod)
+			assert.Equal(t, tt.wantDeviceID, devID)
 		})
 	}
 }
@@ -365,33 +406,36 @@ func TestMetricsProviderNew_EnableTracingAndLogs(t *testing.T) {
 	}
 }
 
-// TestMetricsProviderNew_TimeIntervalAndCacheTTL tests that timeInterval and cacheTTL fall back to defaults for invalid values.
-func TestMetricsProviderNew_TimeIntervalAndCacheTTL(t *testing.T) {
-	p := metricsProvider{}
-	ctx := context.Background()
-
+// TestParseTimeInterval tests parseTimeInterval returns the parsed value or 5 on error.
+func TestParseTimeInterval(t *testing.T) {
 	tests := []struct {
-		name         string
-		timeInterval string
-		cacheTTL     string
+		name  string
+		input string
+		want  int64
 	}{
-		{name: "valid interval and ttl", timeInterval: "10", cacheTTL: "3600"},
-		{name: "invalid interval", timeInterval: "bad", cacheTTL: "3600"},
-		{name: "invalid cacheTTL", timeInterval: "5", cacheTTL: "bad"},
+		{name: "valid integer", input: "10", want: 10},
+		{name: "invalid value falls back to default", input: "bad", want: 5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := map[string]string{
-				"enableMetrics": "false",
-				"timeInterval":  tt.timeInterval,
-				"cacheTTL":      tt.cacheTTL,
-			}
-			provider, cleanup, err := p.New(ctx, config)
-			require.NoError(t, err)
-			require.NotNil(t, provider)
-			if cleanup != nil {
-				_ = cleanup()
-			}
+			assert.Equal(t, tt.want, parseTimeInterval(tt.input))
+		})
+	}
+}
+
+// TestParseCacheTTL tests parseCacheTTL returns the parsed value or 3600 on error.
+func TestParseCacheTTL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{name: "valid integer", input: "7200", want: 7200},
+		{name: "invalid value falls back to default", input: "bad", want: 3600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseCacheTTL(tt.input))
 		})
 	}
 }

--- a/pkg/plugin/implementation/otelsetup/otelsetup_test.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup_test.go
@@ -316,3 +316,79 @@ func TestToPluginConfig_BooleanConversion(t *testing.T) {
 		})
 	}
 }
+
+// TestSetup_New_TracingEnabled tests New with only tracing enabled.
+func TestSetup_New_TracingEnabled(t *testing.T) {
+	setup := Setup{}
+	ctx := context.Background()
+
+	cfg := &Config{
+		ServiceName:    "trace-service",
+		ServiceVersion: "1.0.0",
+		EnableMetrics:  false,
+		EnableTracing:  true,
+		EnableLogs:     false,
+		OtlpEndpoint:   "localhost:4317",
+		TimeInterval:   5,
+	}
+
+	provider, err := setup.New(ctx, cfg)
+	require.NoError(t, err, "New() should succeed with tracing enabled")
+	require.NotNil(t, provider, "New() should return a non-nil provider")
+	assert.NotNil(t, provider.TraceProvider, "TraceProvider should be set when tracing is enabled")
+	assert.Nil(t, provider.MeterProvider, "MeterProvider should be nil when metrics are disabled")
+	assert.Nil(t, provider.LogProvider, "LogProvider should be nil when logs are disabled")
+
+	_ = provider.Shutdown(ctx)
+}
+
+// TestSetup_New_LogsEnabled tests New with only logs enabled.
+func TestSetup_New_LogsEnabled(t *testing.T) {
+	setup := Setup{}
+	ctx := context.Background()
+
+	cfg := &Config{
+		ServiceName:    "log-service",
+		ServiceVersion: "1.0.0",
+		EnableMetrics:  false,
+		EnableTracing:  false,
+		EnableLogs:     true,
+		OtlpEndpoint:   "localhost:4317",
+		TimeInterval:   5,
+	}
+
+	provider, err := setup.New(ctx, cfg)
+	require.NoError(t, err, "New() should succeed with logs enabled")
+	require.NotNil(t, provider, "New() should return a non-nil provider")
+	assert.NotNil(t, provider.LogProvider, "LogProvider should be set when logs are enabled")
+	assert.Nil(t, provider.MeterProvider, "MeterProvider should be nil when metrics are disabled")
+	assert.Nil(t, provider.TraceProvider, "TraceProvider should be nil when tracing is disabled")
+
+	_ = provider.Shutdown(ctx)
+}
+
+// TestSetup_New_AllEnabled tests New with all signals enabled and calls shutdown.
+func TestSetup_New_AllEnabled(t *testing.T) {
+	setup := Setup{}
+	ctx := context.Background()
+
+	cfg := &Config{
+		ServiceName:    "full-service",
+		ServiceVersion: "1.0.0",
+		EnableMetrics:  true,
+		EnableTracing:  true,
+		EnableLogs:     true,
+		OtlpEndpoint:   "localhost:4317",
+		TimeInterval:   5,
+	}
+
+	provider, err := setup.New(ctx, cfg)
+	require.NoError(t, err, "New() should succeed with all signals enabled")
+	require.NotNil(t, provider, "New() should return a non-nil provider")
+	assert.NotNil(t, provider.MeterProvider, "MeterProvider should be set")
+	assert.NotNil(t, provider.TraceProvider, "TraceProvider should be set")
+	assert.NotNil(t, provider.LogProvider, "LogProvider should be set")
+
+	// Shutdown exercises the full provider shutdown path.
+	_ = provider.Shutdown(ctx)
+}

--- a/pkg/plugin/implementation/otelsetup/otelsetup_test.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup_test.go
@@ -367,6 +367,13 @@ func TestSetup_New_LogsEnabled(t *testing.T) {
 	_ = provider.Shutdown(ctx)
 }
 
+// TestSetup_New_NilConfig tests that New returns an error for a nil config.
+func TestSetup_New_NilConfig(t *testing.T) {
+	setup := Setup{}
+	_, err := setup.New(context.Background(), nil)
+	assert.ErrorContains(t, err, "telemetry config cannot be nil")
+}
+
 // TestSetup_New_AllEnabled tests New with all signals enabled and calls shutdown.
 func TestSetup_New_AllEnabled(t *testing.T) {
 	setup := Setup{}


### PR DESCRIPTION
## Summary

- adds unit tests across `pkg/plugin/implementation/otelsetup` and its `cmd` sub-package, increasing coverage from 63.6% → 88.3% (main package) and 50% → 92.6% (cmd)
- covers `Setup.New` for nil config, tracing-only, logs-only, and all-signals-enabled paths
- extracts `parseParentID`, `parseTimeInterval`, and `parseCacheTTL` as pure functions and tests them directly with table-driven assertions, including fallback defaults on invalid input
- `TestMetricsProviderNew_EnableTracingAndLogs` asserts `TraceProvider`/`LogProvider` are nil or non-nil based on the parsed bool; `TestMetricsProviderNew_NetworkMetrics` calls `telemetry.GetNetworkMetricsConfig()` to confirm values are applied
- the remaining ~12% is OTel SDK error branches (`otlptracegrpc`, `otlploggrpc`, `otlpmetricgrpc`) that require a live OTLP backend to trigger

Closes #812

## AI Model Disclosure

Used vscode copilot (claude sonnet 4.6) to help identify missing test cases and improve coverage. Changes were self-reviewed and verified with:

```bash
go test ./pkg/plugin/implementation/otelsetup/... -v -cover
```