### PR TITLE
fix(handler): pool ReverseProxy copy buffers to cut allocation churn

### DIFF
--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/log"
@@ -338,6 +339,30 @@ func route(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, pb de
 	*responseBody = sendAck(ctx, w)
 }
 
+// proxyBufPool backs reverseProxyBufferPool. Without a BufferPool set on
+// httputil.ReverseProxy, copyBuffer allocates a fresh 32KB []byte per
+// proxied response (see https://github.com/beckn/beckn-onix/issues/848) —
+// pooling avoids that allocation on every request.
+var proxyBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 32*1024)
+		return &b
+	},
+}
+
+// reverseProxyBufferPool implements httputil.BufferPool over proxyBufPool.
+// Buffers are stored as *[]byte rather than []byte so Put does not box a
+// fresh interface value (and allocate) on every call.
+type reverseProxyBufferPool struct{}
+
+func (reverseProxyBufferPool) Get() []byte {
+	return *(proxyBufPool.Get().(*[]byte))
+}
+
+func (reverseProxyBufferPool) Put(b []byte) {
+	proxyBufPool.Put(&b)
+}
+
 func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpClient *http.Client, responseSteps []definition.ResponseStep, responseBody *[]byte) {
 	target := ctx.Route.URL
 	r.Header.Set("X-Forwarded-Host", r.Host)
@@ -380,6 +405,7 @@ func proxy(ctx *model.StepContext, r *http.Request, w http.ResponseWriter, httpC
 		Director:       director,
 		Transport:      httpClient.Transport,
 		ModifyResponse: modifyResponse,
+		BufferPool:     reverseProxyBufferPool{},
 	}
 
 	p.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
- Fixes #848 — `httputil.ReverseProxy` in `proxy()` (`core/module/handler/stdHandler.go`) had no `BufferPool` set, so every proxied response allocated a fresh 32KB buffer via `copyBuffer`. Profiling in the v1.7.2 benchmark report attributed 38.7% of total allocated memory (42.83GB/110.66GB) to this single call site.
- Adds a `sync.Pool`-backed `httputil.BufferPool` implementation and wires it into the `ReverseProxy` literal so the 32KB buffer is reused across requests instead of allocated/discarded per request.
- No behavioral change — this only affects internal buffer reuse for the response copy path.

As discussed in #848, this was allocation churn (GC pressure from short-lived, repeated allocation), not a memory leak — nothing was retained or unbounded.

## Verification — before/after benchmark comparison

Baseline: `benchmarks/results/2026-07-02_14-25-21` (pre-fix, main). New run: `benchmarks/results/2026-07-06_11-21-58` (this branch).

**Memory — confirms the fix targeted the right allocation site:**
- `B/op` geomean **-35.21%**; `BAPCaller_Discover` specifically **83.78 KiB → 52.07 KiB (-37.8%)** — closely matches the 38.7% contribution profiled for `copyBuffer` pre-fix.
- Total allocated memory in the profile run: **110.66 GB → 70.59 GB (-36%)**.
- `net/http/httputil.(*ReverseProxy).copyBuffer` no longer appears in the top 15 allocators post-fix (was #1 at 38.7% pre-fix) — direct confirmation.
- `allocs/op` is essentially unchanged (~850.4 → 850.2), which is expected: pooling removes the *bytes* of a large allocation, not the call count, since a pool hit skips `mallocgc` entirely rather than showing up as a smaller allocation.

**Latency / throughput — secondary win:**
- `sec/op` geomean **-5.61%**.
- p99 (discover): **347µs → 296µs (-14.7%)** — tail latency improved the most, consistent with removing a per-request 32KB allocation spike.
- `BAPCaller_RPS`: **22.86k → 28.11k req/s (+23%)**.

**Correction to the original RCA:** the original issue speculated the mutex profile's `runtime.unlock`/`runtime._LostContendedRuntimeLock` contention (97.5% combined pre-fix) was plausibly caused by this same allocation churn. Post-fix, that contention is **unchanged** (81.55%/15.18% vs. 81.71%/15.83% baseline) despite the 36% drop in allocated bytes — so that hypothesis does not hold. The lock contention has a different or additional cause, independent of this fix. Not addressed here; worth a separate follow-up investigation.

New top allocators post-fix (for future reference, out of scope for this PR): `encoding/json` unmarshal/reflection (~9.79% cumulative), OTel instrumentation — metric attributes, span creation, `setBecknAttr` (~10%+ combined), and HTTP header handling — `textproto.readMIMEHeader`/`MIMEHeader.Set`/`Header.Clone` (~12% combined).

## Test plan
- [x] `go build ./core/...`
- [x] `go test ./core/module/handler/...`
- [x] `gofmt -l` / `go vet` clean
- [x] Re-ran `benchmarks/e2e` suite + memory/mutex profiling (results above) confirming `copyBuffer` allocation is eliminated
