### PR TITLE
fix(schemav2validator): remove core-schema skip in extended schema validation

### DIFF
--- a/pkg/plugin/implementation/schemav2validator/README.md
+++ b/pkg/plugin/implementation/schemav2validator/README.md
@@ -99,8 +99,7 @@ A startup warning is logged if no schemas are found, which usually means the dir
 
 **Extended Schema Validation** (if `extendedSchema_enabled: "true"` AND core validation passed):
 5. **Scan for @context**: Recursively traverse `message` field for objects with `@context` and `@type`
-6. **Filter Core Schemas**: Skip objects with `/schema/core/` in `@context` URL
-7. **Validate Each Domain Object**:
+6. **Validate Each Domain Object**:
    - Check domain whitelist (if `allowedDomains` configured)
    - Transform `@context` URL: `context.jsonld` → `attributes.yaml`
    - Load schema from URL/file (check cache first, download if miss)
@@ -108,7 +107,7 @@ A startup warning is logged if no schemas are found, which usually means the dir
    - Strip `@context` and `@type` metadata from object
    - Validate remaining data against domain schema
    - Prefix error paths with object location (e.g., `message.order.field`)
-8. **Return Errors**: Returns first validation error (fail-fast)
+7. **Return Errors**: Returns first validation error (fail-fast)
 
 ## Action-Based Matching
 
@@ -219,7 +218,6 @@ schemaValidator:
 
 **At Runtime** (after core validation passes):
 - Scans `message` field for objects with `@context` and `@type`
-- Skips core Beckn schemas (containing `/schema/core/`)
 - Downloads domain schemas from `@context` URLs (cached for 24 hours)
 - Validates domain-specific data against schemas
 - Returns errors with full JSON paths (e.g., `message.order.chargingRate`)

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -98,11 +98,6 @@ type cachedDomainSchema struct {
 	accessCount  int64
 }
 
-// isCoreSchema checks if @context URL is a core Beckn schema.
-func isCoreSchema(contextURL string) bool {
-	return strings.Contains(contextURL, "/schema/core/")
-}
-
 func rawSchemaKey(rel string) string {
 	parts := strings.SplitN(filepath.ToSlash(rel), "/", 3)
 	if len(parts) == 3 {
@@ -160,7 +155,7 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 		return fmt.Errorf("missing 'message' field in request body")
 	}
 
-	// Find domain-specific objects with @context (skip core schemas)
+	// Find all objects with @context
 	objects := findReferencedObjects(message, "message")
 
 	if len(objects) == 0 {
@@ -412,15 +407,12 @@ func findReferencedObjects(data interface{}, path string) []referencedObject {
 		// Check for @context and @type
 		if contextVal, hasContext := v["@context"].(string); hasContext {
 			if typeVal, hasType := v["@type"].(string); hasType {
-				// Skip core schemas during traversal
-				if !isCoreSchema(contextVal) {
-					results = append(results, referencedObject{
-						Path:    path,
-						Context: contextVal,
-						Type:    typeVal,
-						Data:    v,
-					})
-				}
+				results = append(results, referencedObject{
+					Path:    path,
+					Context: contextVal,
+					Type:    typeVal,
+					Data:    v,
+				})
 			}
 		}
 

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -15,42 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsCoreSchema(t *testing.T) {
-	tests := []struct {
-		name       string
-		contextURL string
-		want       bool
-	}{
-		{
-			name:       "core schema URL",
-			contextURL: "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/core/v2/context.jsonld",
-			want:       true,
-		},
-		{
-			name:       "domain schema URL",
-			contextURL: "https://raw.githubusercontent.com/beckn/protocol-specifications-new/refs/heads/draft/schema/EvChargingOffer/v1/context.jsonld",
-			want:       false,
-		},
-		{
-			name:       "empty URL",
-			contextURL: "",
-			want:       false,
-		},
-		{
-			name:       "URL without schema/core",
-			contextURL: "https://example.com/some/path/context.jsonld",
-			want:       false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isCoreSchema(tt.contextURL)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestFindReferencedObjects(t *testing.T) {
 	tests := []struct {
 		name string
@@ -69,14 +33,14 @@ func TestFindReferencedObjects(t *testing.T) {
 			want: 1,
 		},
 		{
-			name: "core schema object - should be skipped",
+			name: "object with @context and @type is always found",
 			data: map[string]interface{}{
 				"@context": "https://example.com/schema/core/v2/context.jsonld",
 				"@type":    "beckn:Order",
 				"field":    "value",
 			},
 			path: "message",
-			want: 0,
+			want: 1,
 		},
 		{
 			name: "nested domain objects",
@@ -92,7 +56,7 @@ func TestFindReferencedObjects(t *testing.T) {
 				},
 			},
 			path: "message",
-			want: 1, // Only domain object, core skipped
+			want: 2, // both the outer and nested object are found
 		},
 		{
 			name: "array with domain objects",


### PR DESCRIPTION
## Summary
- Removes `isCoreSchema` and its call site in `findReferencedObjects` — every object with `@context` + `@type` now always goes through Extended Schema validation instead of being conditionally skipped.
- `isCoreSchema` was a raw `strings.Contains(contextURL, "/schema/core/")` check on sender-controlled input, with no host or path verification — a sender could bypass Extended Schema validation for any object entirely just by including that substring in a bogus `@context`.
- The check no longer corresponds to anything in the current, actually-loaded core spec: `protocol-specifications-v2` (`core-v2.0.0-lts`, pinned via `beckndefaults`) only ever uses `@context`/`@type` on the JSON-LD `Attributes` extension point, which by the spec's own description is always domain-specific ("The @context property MUST reference a valid JSON-LD context URI ... identify the domain type being expressed"). The check was modeled on an older `protocol-specifications-new` draft repo layout (`schema/core/...`) that no longer exists — confirmed the fixture URL used in the old test now 404s.
- Updated `extended_schema_test.go` (removed `TestIsCoreSchema`, fixed two `TestFindReferencedObjects` cases that assumed skipping) and `README.md` (removed the documented "Filter Core Schemas" step) to match.

Full analysis posted on the issue: #843

Fixes #843

## Test plan
- [x] `go vet ./pkg/plugin/implementation/schemav2validator/...`
- [x] `go test ./pkg/plugin/implementation/schemav2validator/...` — all pass
- [x] Reviewer sanity-check: confirm no production network relies on the old core-context-skip behavior