### PR TITLE
feat: log adapter version at startup and expose it at runtime (#808)

### DIFF
--- a/.github/workflows/deploy-to-gke-BS.yml
+++ b/.github/workflows/deploy-to-gke-BS.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+      with:
+        # Full history + tags, so `git describe --tags` in version-vars.sh
+        # can actually resolve a release tag instead of always falling back
+        # to the bare commit SHA (the default shallow checkout fetches no
+        # tag refs at all).
+        fetch-depth: 0
 
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v2
@@ -33,12 +39,9 @@ jobs:
     - name: Build Docker Image
       run: |
         IMAGE_NAME=${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_REPO }}/beckn-onix:${{ github.sha }}
-        GIT_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
-        GIT_COMMIT="$(git rev-parse --short HEAD)"
-        GIT_TREE_STATE="clean"
-        BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        source install/scripts/version-vars.sh
         docker build -f Dockerfile.adapter \
-          --build-arg ONIX_VERSION="$GIT_VERSION" \
+          --build-arg ONIX_VERSION="$ONIX_VERSION" \
           --build-arg GIT_COMMIT="$GIT_COMMIT" \
           --build-arg GIT_TREE_STATE="$GIT_TREE_STATE" \
           --build-arg BUILD_DATE="$BUILD_DATE" \

--- a/.github/workflows/deploy-to-gke-BS.yml
+++ b/.github/workflows/deploy-to-gke-BS.yml
@@ -33,7 +33,16 @@ jobs:
     - name: Build Docker Image
       run: |
         IMAGE_NAME=${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_REPO }}/beckn-onix:${{ github.sha }}
-        docker build -f Dockerfile.adapter -t $IMAGE_NAME .
+        GIT_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
+        GIT_COMMIT="$(git rev-parse --short HEAD)"
+        GIT_TREE_STATE="clean"
+        BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        docker build -f Dockerfile.adapter \
+          --build-arg ONIX_VERSION="$GIT_VERSION" \
+          --build-arg GIT_COMMIT="$GIT_COMMIT" \
+          --build-arg GIT_TREE_STATE="$GIT_TREE_STATE" \
+          --build-arg BUILD_DATE="$BUILD_DATE" \
+          -t $IMAGE_NAME .
         docker push $IMAGE_NAME
 
     - name: Get GKE Credentials

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -8,7 +8,12 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-RUN go build -o server cmd/adapter/main.go
+ARG ONIX_VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
+
+RUN go build -ldflags "-X github.com/beckn-one/beckn-onix/pkg/version.Version=${ONIX_VERSION} -X github.com/beckn-one/beckn-onix/pkg/version.GitCommit=${GIT_COMMIT} -X github.com/beckn-one/beckn-onix/pkg/version.GitTreeState=${GIT_TREE_STATE} -X github.com/beckn-one/beckn-onix/pkg/version.BuildDate=${BUILD_DATE}" -o server cmd/adapter/main.go
 
 # Create a minimal runtime image
 FROM cgr.dev/chainguard/wolfi-base:latest

--- a/Dockerfile.adapter-with-plugins
+++ b/Dockerfile.adapter-with-plugins
@@ -12,8 +12,13 @@ COPY go.sum .
 
 RUN go mod download
 
+ARG ONIX_VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
+
 # Build main server
-RUN go build -o server cmd/adapter/main.go
+RUN go build -ldflags "-X github.com/beckn-one/beckn-onix/pkg/version.Version=${ONIX_VERSION} -X github.com/beckn-one/beckn-onix/pkg/version.GitCommit=${GIT_COMMIT} -X github.com/beckn-one/beckn-onix/pkg/version.GitTreeState=${GIT_TREE_STATE} -X github.com/beckn-one/beckn-onix/pkg/version.BuildDate=${BUILD_DATE}" -o server cmd/adapter/main.go
 
 # Make the build script executable and run it to build plugins
 RUN chmod +x install/build-plugins.sh && \

--- a/Dockerfile.adapter-with-plugins
+++ b/Dockerfile.adapter-with-plugins
@@ -7,6 +7,7 @@ COPY cmd/adapter/ ./cmd/adapter/
 COPY core/ ./core/
 COPY pkg/ ./pkg/
 COPY install/build-plugins.sh ./install/build-plugins.sh
+COPY install/scripts/version-vars.sh ./install/scripts/version-vars.sh
 COPY go.mod .
 COPY go.sum .
 
@@ -20,8 +21,13 @@ ARG BUILD_DATE=unknown
 # Build main server
 RUN go build -ldflags "-X github.com/beckn-one/beckn-onix/pkg/version.Version=${ONIX_VERSION} -X github.com/beckn-one/beckn-onix/pkg/version.GitCommit=${GIT_COMMIT} -X github.com/beckn-one/beckn-onix/pkg/version.GitTreeState=${GIT_TREE_STATE} -X github.com/beckn-one/beckn-onix/pkg/version.BuildDate=${BUILD_DATE}" -o server cmd/adapter/main.go
 
-# Make the build script executable and run it to build plugins
+# Make the build script executable and run it to build plugins. The version
+# ARGs are passed through as environment variables so the otelsetup plugin
+# (a separate .so, a separate link unit from the server binary above) gets
+# the same build identity instead of falling back to pkg/version's
+# "dev"/"unknown" defaults.
 RUN chmod +x install/build-plugins.sh && \
+    ONIX_VERSION="${ONIX_VERSION}" GIT_COMMIT="${GIT_COMMIT}" GIT_TREE_STATE="${GIT_TREE_STATE}" BUILD_DATE="${BUILD_DATE}" \
     ./install/build-plugins.sh
 
 # Create minimal runtime image

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
+	"github.com/beckn-one/beckn-onix/pkg/version"
 	_ "go.uber.org/automaxprocs"
 )
 
@@ -57,6 +58,8 @@ func main() {
 	flag.Parse()
 
 	// Use custom log for initial setup messages.
+	log.Infof(context.Background(), "Starting Beckn-ONIX version=%s commit=%s tree=%s built=%s",
+		version.Version, version.GitCommit, version.GitTreeState, version.BuildDate)
 	log.Infof(context.Background(), "Starting application with config: %s", configPath)
 
 	// Run the application within a context.

--- a/core/module/handler/healthcheck.go
+++ b/core/module/handler/healthcheck.go
@@ -4,12 +4,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/beckn-one/beckn-onix/pkg/version"
 )
+
+// buildInfo carries build-time identity fields for the running binary.
+type buildInfo struct {
+	Version      string `json:"version"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+}
 
 // HealthCheckResponse defines the structure for our health check JSON response.
 type healthCheckResponse struct {
-	Status  string `json:"status"`
-	Service string `json:"service"`
+	Status  string    `json:"status"`
+	Service string    `json:"service"`
+	Build   buildInfo `json:"build"`
 }
 
 // healthHandler handles requests to the /health endpoint.
@@ -25,6 +36,12 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	response := healthCheckResponse{
 		Status:  "ok",
 		Service: "beckn-adapter",
+		Build: buildInfo{
+			Version:      version.Version,
+			GitCommit:    version.GitCommit,
+			GitTreeState: version.GitTreeState,
+			BuildDate:    version.BuildDate,
+		},
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/core/module/handler/healthcheck_test.go
+++ b/core/module/handler/healthcheck_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/version"
 )
 
 // TestHealthHandler tests the successful GET request to the /health endpoint.
@@ -44,6 +46,22 @@ func TestHealthHandler(t *testing.T) {
 	if response.Service != expService {
 		t.Errorf("HealthHandler returned wrong service in JSON: got %v want %v",
 			response.Service, expService)
+	}
+	if response.Build.Version != version.Version {
+		t.Errorf("HealthHandler returned wrong build.version in JSON: got %v want %v",
+			response.Build.Version, version.Version)
+	}
+	if response.Build.GitCommit != version.GitCommit {
+		t.Errorf("HealthHandler returned wrong build.gitCommit in JSON: got %v want %v",
+			response.Build.GitCommit, version.GitCommit)
+	}
+	if response.Build.GitTreeState != version.GitTreeState {
+		t.Errorf("HealthHandler returned wrong build.gitTreeState in JSON: got %v want %v",
+			response.Build.GitTreeState, version.GitTreeState)
+	}
+	if response.Build.BuildDate != version.BuildDate {
+		t.Errorf("HealthHandler returned wrong build.buildDate in JSON: got %v want %v",
+			response.Build.BuildDate, version.BuildDate)
 	}
 }
 

--- a/install/build-plugins.sh
+++ b/install/build-plugins.sh
@@ -3,6 +3,17 @@
 # Create plugins directory
 mkdir -p plugins
 
+# otelsetup imports pkg/version and is the only plugin that needs build-time
+# identity embedded via -ldflags -X -- it's compiled as its own .so, a
+# separate link unit from the main adapter binary, so without this it would
+# silently keep pkg/version's "dev"/"unknown" defaults regardless of what
+# version the adapter binary itself was built with. ONIX_VERSION/GIT_COMMIT/
+# GIT_TREE_STATE/BUILD_DATE may already be set in the environment (e.g. by
+# install/setup.sh, or as Docker build-args) -- version-vars.sh keeps
+# whatever is already set and only computes from git for what's missing.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/scripts/version-vars.sh"
+
 # Build each plugin as a shared library. Entries are "<source dir>" or
 # "<source dir>:<output name>" — the .so basename is the plugin id used in
 # config, so it can differ from the package directory (vcvalidator builds as
@@ -37,7 +48,11 @@ for entry in "${plugins[@]}"; do
     plugin="${entry%%:*}"
     out="${entry#*:}"
     echo "Building $plugin plugin..."
-    go build -buildmode=plugin -o "plugins/${out}.so" "./pkg/plugin/implementation/${plugin}/cmd/plugin.go"
+    ldflags=()
+    if [ "$plugin" = "otelsetup" ]; then
+        ldflags=(-ldflags "${ONIX_LDFLAGS}")
+    fi
+    go build -buildmode=plugin "${ldflags[@]}" -o "plugins/${out}.so" "./pkg/plugin/implementation/${plugin}/cmd/plugin.go"
     if [ $? -eq 0 ]; then
         echo "✓ Successfully built $plugin plugin"
     else

--- a/install/build-plugins.sh
+++ b/install/build-plugins.sh
@@ -7,10 +7,10 @@ mkdir -p plugins
 # identity embedded via -ldflags -X -- it's compiled as its own .so, a
 # separate link unit from the main adapter binary, so without this it would
 # silently keep pkg/version's "dev"/"unknown" defaults regardless of what
-# version the adapter binary itself was built with. ONIX_VERSION/GIT_COMMIT/
-# GIT_TREE_STATE/BUILD_DATE may already be set in the environment (e.g. by
-# install/setup.sh, or as Docker build-args) -- version-vars.sh keeps
-# whatever is already set and only computes from git for what's missing.
+# version the adapter binary itself was built with. version-vars.sh computes
+# these fresh from git when run locally; inside a Docker build stage (no
+# .git in the build context) it instead keeps whatever ONIX_VERSION/
+# GIT_COMMIT/GIT_TREE_STATE/BUILD_DATE were passed in as Docker build-args.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPT_DIR}/scripts/version-vars.sh"
 

--- a/install/scripts/version-vars.sh
+++ b/install/scripts/version-vars.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Single source of truth for the adapter's build-time identity vars (see
+# pkg/version). Source this file to populate ONIX_VERSION, GIT_COMMIT,
+# GIT_TREE_STATE, BUILD_DATE, and ONIX_LDFLAGS.
+#
+# Any of the four vars may already be set in the environment before this
+# file is sourced (e.g. passed in as Docker build-args, since a Docker
+# build stage has no .git to compute them from) -- in that case the
+# existing value is kept as-is and the corresponding git command is
+# skipped entirely.
+
+: "${ONIX_VERSION:=$(git describe --tags --always 2>/dev/null || echo dev)}"
+: "${GIT_COMMIT:=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+
+if [ -z "${GIT_TREE_STATE:-}" ]; then
+    if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+fi
+
+if [ -z "${BUILD_DATE:-}" ]; then
+    # Derived from the commit's own timestamp, not wall-clock, so building
+    # the same commit twice produces an identical value -- and therefore a
+    # cacheable Docker layer -- instead of a fresh timestamp on every build.
+    COMMIT_EPOCH="$(git show -s --format=%ct HEAD 2>/dev/null || echo 0)"
+    BUILD_DATE="$(date -u -d "@${COMMIT_EPOCH}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "${COMMIT_EPOCH}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+fi
+
+ONIX_VERSION_PKG="github.com/beckn-one/beckn-onix/pkg/version"
+ONIX_LDFLAGS="-X ${ONIX_VERSION_PKG}.Version=${ONIX_VERSION} -X ${ONIX_VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${ONIX_VERSION_PKG}.GitTreeState=${GIT_TREE_STATE} -X ${ONIX_VERSION_PKG}.BuildDate=${BUILD_DATE}"

--- a/install/scripts/version-vars.sh
+++ b/install/scripts/version-vars.sh
@@ -4,29 +4,37 @@
 # pkg/version). Source this file to populate ONIX_VERSION, GIT_COMMIT,
 # GIT_TREE_STATE, BUILD_DATE, and ONIX_LDFLAGS.
 #
-# Any of the four vars may already be set in the environment before this
-# file is sourced (e.g. passed in as Docker build-args, since a Docker
-# build stage has no .git to compute them from) -- in that case the
-# existing value is kept as-is and the corresponding git command is
-# skipped entirely.
+# When a usable .git is present (local dev, CI checkout), these are always
+# recomputed fresh from git -- re-sourcing this file mid-session always
+# reflects the current HEAD, even if a previous source in the same shell
+# left ONIX_VERSION etc. exported with an older value.
+#
+# When no .git is present (inside a Docker build stage, whose build context
+# never includes .git), whatever is already set in the environment is kept
+# as-is instead of being overwritten with git-lookup failures -- this is how
+# the Dockerfiles' ARG-passed values survive being threaded through to
+# install/build-plugins.sh.
 
-: "${ONIX_VERSION:=$(git describe --tags --always 2>/dev/null || echo dev)}"
-: "${GIT_COMMIT:=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    ONIX_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
+    GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 
-if [ -z "${GIT_TREE_STATE:-}" ]; then
     if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
         GIT_TREE_STATE="clean"
     else
         GIT_TREE_STATE="dirty"
     fi
-fi
 
-if [ -z "${BUILD_DATE:-}" ]; then
     # Derived from the commit's own timestamp, not wall-clock, so building
     # the same commit twice produces an identical value -- and therefore a
     # cacheable Docker layer -- instead of a fresh timestamp on every build.
     COMMIT_EPOCH="$(git show -s --format=%ct HEAD 2>/dev/null || echo 0)"
     BUILD_DATE="$(date -u -d "@${COMMIT_EPOCH}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "${COMMIT_EPOCH}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+else
+    : "${ONIX_VERSION:=dev}"
+    : "${GIT_COMMIT:=unknown}"
+    : "${GIT_TREE_STATE:=unknown}"
+    : "${BUILD_DATE:=unknown}"
 fi
 
 ONIX_VERSION_PKG="github.com/beckn-one/beckn-onix/pkg/version"

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -111,6 +111,15 @@ else
     echo -e "${YELLOW}plugins directory already exists${NC}"
 fi
 
+# Compute build-time identity vars once, then export them so the plugin
+# build (Step 3) and the adapter build (Step 4) embed the exact same
+# version/commit/tree-state/build-date -- including the otelsetup plugin,
+# which otherwise silently ships with pkg/version's "dev"/"unknown"
+# defaults since it's compiled as a separate .so.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/scripts/version-vars.sh"
+export ONIX_VERSION GIT_COMMIT GIT_TREE_STATE BUILD_DATE
+
 # Step 3: Build adapter plugins
 echo -e "${YELLOW}Step 3: Building adapter plugins...${NC}"
 
@@ -132,18 +141,7 @@ fi
 echo -e "${YELLOW}Step 4: Building Beckn-ONIX adapter server...${NC}"
 
 if [ -f "go.mod" ]; then
-    ONIX_VERSION_PKG="github.com/beckn-one/beckn-onix/pkg/version"
-    GIT_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
-    GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
-        GIT_TREE_STATE="clean"
-    else
-        GIT_TREE_STATE="dirty"
-    fi
-    BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    LDFLAGS="-X ${ONIX_VERSION_PKG}.Version=${GIT_VERSION} -X ${ONIX_VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${ONIX_VERSION_PKG}.GitTreeState=${GIT_TREE_STATE} -X ${ONIX_VERSION_PKG}.BuildDate=${BUILD_DATE}"
-
-    go build -ldflags "${LDFLAGS}" -o beckn-adapter cmd/adapter/main.go
+    go build -ldflags "${ONIX_LDFLAGS}" -o beckn-adapter cmd/adapter/main.go
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✓ Adapter server built successfully${NC}"
     else

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Resolve this script's own directory before any `cd` below changes the
+# working directory -- BASH_SOURCE[0] is relative to the CWD at invocation
+# time (this script is documented to be run as `cd install && ./setup.sh`),
+# so computing this later, after the `cd ..` further down, silently
+# resolves to the repo root instead of install/.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -132,8 +139,10 @@ fi
 echo -e "${YELLOW}Step 4: Building Beckn-ONIX adapter server...${NC}"
 
 if [ -f "go.mod" ]; then
-    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    source "${SCRIPT_DIR}/scripts/version-vars.sh"
+    if ! source "${SCRIPT_DIR}/scripts/version-vars.sh"; then
+        echo -e "${RED}Error: failed to source ${SCRIPT_DIR}/scripts/version-vars.sh${NC}"
+        exit 1
+    fi
 
     go build -ldflags "${ONIX_LDFLAGS}" -o beckn-adapter cmd/adapter/main.go
     if [ $? -eq 0 ]; then

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -132,7 +132,18 @@ fi
 echo -e "${YELLOW}Step 4: Building Beckn-ONIX adapter server...${NC}"
 
 if [ -f "go.mod" ]; then
-    go build -o beckn-adapter cmd/adapter/main.go
+    ONIX_VERSION_PKG="github.com/beckn-one/beckn-onix/pkg/version"
+    GIT_VERSION="$(git describe --tags --always 2>/dev/null || echo dev)"
+    GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+    BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    LDFLAGS="-X ${ONIX_VERSION_PKG}.Version=${GIT_VERSION} -X ${ONIX_VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${ONIX_VERSION_PKG}.GitTreeState=${GIT_TREE_STATE} -X ${ONIX_VERSION_PKG}.BuildDate=${BUILD_DATE}"
+
+    go build -ldflags "${LDFLAGS}" -o beckn-adapter cmd/adapter/main.go
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✓ Adapter server built successfully${NC}"
     else

--- a/install/setup.sh
+++ b/install/setup.sh
@@ -111,15 +111,6 @@ else
     echo -e "${YELLOW}plugins directory already exists${NC}"
 fi
 
-# Compute build-time identity vars once, then export them so the plugin
-# build (Step 3) and the adapter build (Step 4) embed the exact same
-# version/commit/tree-state/build-date -- including the otelsetup plugin,
-# which otherwise silently ships with pkg/version's "dev"/"unknown"
-# defaults since it's compiled as a separate .so.
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${SCRIPT_DIR}/scripts/version-vars.sh"
-export ONIX_VERSION GIT_COMMIT GIT_TREE_STATE BUILD_DATE
-
 # Step 3: Build adapter plugins
 echo -e "${YELLOW}Step 3: Building adapter plugins...${NC}"
 
@@ -141,6 +132,9 @@ fi
 echo -e "${YELLOW}Step 4: Building Beckn-ONIX adapter server...${NC}"
 
 if [ -f "go.mod" ]; then
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    source "${SCRIPT_DIR}/scripts/version-vars.sh"
+
     go build -ldflags "${ONIX_LDFLAGS}" -o beckn-adapter cmd/adapter/main.go
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✓ Adapter server built successfully${NC}"

--- a/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
+++ b/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
@@ -156,12 +156,23 @@ Every OTLP signal carries these resource attributes. The `producer` and `produce
 | Attribute | Config field | Notes |
 |---|---|---|
 | `service.name` | `serviceName` | Required |
-| `service.version` | `serviceVersion` | |
+| `service.version` | `serviceVersion` | Defaults to the binary's build-time version (see below) when not set |
 | `environment` | `environment` | |
 | `domain` | `domain` | |
 | `device_id` | `deviceID` | |
 | `producer` | `producer` | Subscriber ID — enables network-level attribution |
 | `producerType` | `producerType` | `bap` or `bpp` |
+| `onix.build.commit` | — | Git commit short SHA the binary was built from; not operator-configurable |
+| `onix.build.tree_state` | — | `clean` or `dirty` — whether the build tree had uncommitted changes at build time |
+| `onix.build.date` | — | UTC build timestamp (RFC3339) |
+
+### Build identity: how and when it's emitted
+
+`service.version`, `onix.build.commit`, `onix.build.tree_state`, and `onix.build.date` come from `pkg/version`, populated via `-ldflags -X` at build time (see `install/setup.sh`, `Dockerfile.adapter`, `Dockerfile.adapter-with-plugins`). They are fixed at compile time — no config field can override the three `onix.build.*` attributes, since they describe the binary actually running, not operator intent.
+
+These attributes are set once, when the `otelsetup` plugin constructs the OTel `Resource` at startup — before any module is registered — and are then attached to *every* metric, trace, and log signal the adapter exports via OTLP for the remainder of the process's lifetime. This is not a one-time startup announcement: each export batch (every metrics collection interval, every trace/log flush) carries the same resource block, so any single trace, log line, or metric sample can be traced back to the exact build that produced it without a separate lookup.
+
+This gives the network observer a self-reported build identity per node — enough to detect stale, mismatched, or locally-patched deployments across the network. It is not a substitute for cryptographic attestation: an operator who controls their own build can set any values here. See [beckn/beckn-onix#872](https://github.com/beckn/beckn-onix/issues/872) for the follow-up on verifiable build provenance.
 
 ### Shutdown
 

--- a/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
+++ b/pkg/plugin/implementation/otelsetup/OBSERVABILITY.md
@@ -163,7 +163,7 @@ Every OTLP signal carries these resource attributes. The `producer` and `produce
 | `producer` | `producer` | Subscriber ID — enables network-level attribution |
 | `producerType` | `producerType` | `bap` or `bpp` |
 | `onix.build.commit` | — | Git commit short SHA the binary was built from; not operator-configurable |
-| `onix.build.tree_state` | — | `clean` or `dirty` — whether the build tree had uncommitted changes at build time |
+| `onix.build.tree_state` | — | `clean` or `dirty` if built with `-ldflags` injection, `unknown` otherwise |
 | `onix.build.date` | — | UTC build timestamp (RFC3339) |
 
 ### Build identity: how and when it's emitted

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -115,20 +115,7 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 		}, nil
 	}
 
-	baseAttrs := []attribute.KeyValue{
-		attribute.String("service.name", cfg.ServiceName),
-		attribute.String("service.version", cfg.ServiceVersion),
-		attribute.String("environment", cfg.Environment),
-		attribute.String("domain", cfg.Domain),
-		attribute.String("device_id", cfg.DeviceID),
-		attribute.String("producerType", cfg.ProducerType),
-		attribute.String("producer", cfg.Producer),
-		// Intrinsic to the binary, not operator-configurable — lets an
-		// observer spot stale/mismatched/locally-patched deployments.
-		attribute.String("onix.build.commit", version.GitCommit),
-		attribute.String("onix.build.tree_state", version.GitTreeState),
-		attribute.String("onix.build.date", version.BuildDate),
-	}
+	baseAttrs := buildBaseAttrs(cfg)
 
 	var meterProvider *metric.MeterProvider
 	if cfg.EnableMetrics {
@@ -213,6 +200,28 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 			return nil
 		},
 	}, nil
+}
+
+// buildBaseAttrs constructs the resource attributes shared by every signal
+// type (metrics, traces, logs). Extracted as its own function so tests can
+// assert on the attribute set directly, without needing a getter into the
+// OTel SDK's Resource (sdk/metric.MeterProvider and sdk/trace.TracerProvider
+// don't expose one).
+func buildBaseAttrs(cfg *Config) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("service.name", cfg.ServiceName),
+		attribute.String("service.version", cfg.ServiceVersion),
+		attribute.String("environment", cfg.Environment),
+		attribute.String("domain", cfg.Domain),
+		attribute.String("device_id", cfg.DeviceID),
+		attribute.String("producerType", cfg.ProducerType),
+		attribute.String("producer", cfg.Producer),
+		// Intrinsic to the binary, not operator-configurable — lets an
+		// observer spot stale/mismatched/locally-patched deployments.
+		attribute.String("onix.build.commit", version.GitCommit),
+		attribute.String("onix.build.tree_state", version.GitTreeState),
+		attribute.String("onix.build.date", version.BuildDate),
+	}
 }
 
 func buildAtts(base []attribute.KeyValue, eid string) []attribute.KeyValue {

--- a/pkg/plugin/implementation/otelsetup/otelsetup.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
 	"github.com/beckn-one/beckn-onix/pkg/telemetry"
+	"github.com/beckn-one/beckn-onix/pkg/version"
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -50,7 +51,7 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		ServiceName:    "beckn-onix",
-		ServiceVersion: "dev",
+		ServiceVersion: version.Version,
 		Environment:    "development",
 		Domain:         "",
 		DeviceID:       "beckn-onix-device",
@@ -122,6 +123,11 @@ func (Setup) New(ctx context.Context, cfg *Config) (*telemetry.Provider, error) 
 		attribute.String("device_id", cfg.DeviceID),
 		attribute.String("producerType", cfg.ProducerType),
 		attribute.String("producer", cfg.Producer),
+		// Intrinsic to the binary, not operator-configurable — lets an
+		// observer spot stale/mismatched/locally-patched deployments.
+		attribute.String("onix.build.commit", version.GitCommit),
+		attribute.String("onix.build.tree_state", version.GitTreeState),
+		attribute.String("onix.build.date", version.BuildDate),
 	}
 
 	var meterProvider *metric.MeterProvider

--- a/pkg/plugin/implementation/otelsetup/otelsetup_test.go
+++ b/pkg/plugin/implementation/otelsetup/otelsetup_test.go
@@ -4,9 +4,52 @@ import (
 	"context"
 	"testing"
 
+	"github.com/beckn-one/beckn-onix/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 )
+
+// TestDefaultConfig_ServiceVersionFollowsPkgVersion asserts DefaultConfig's
+// ServiceVersion tracks pkg/version.Version rather than a fixed literal --
+// regression test for otelsetup.go defaulting to "dev" unconditionally.
+func TestDefaultConfig_ServiceVersionFollowsPkgVersion(t *testing.T) {
+	original := version.Version
+	defer func() { version.Version = original }()
+
+	version.Version = "v9.9.9-test"
+	assert.Equal(t, "v9.9.9-test", DefaultConfig().ServiceVersion,
+		"DefaultConfig().ServiceVersion should follow pkg/version.Version")
+}
+
+// TestBuildBaseAttrs_IncludesBuildIdentity asserts the onix.build.* resource
+// attributes are present and reflect pkg/version's current values -- these
+// are attached to every metric/trace/log Resource via buildAtts(), which has
+// no public getter to assert against directly on the OTel SDK providers.
+func TestBuildBaseAttrs_IncludesBuildIdentity(t *testing.T) {
+	origCommit, origTreeState, origDate := version.GitCommit, version.GitTreeState, version.BuildDate
+	defer func() {
+		version.GitCommit, version.GitTreeState, version.BuildDate = origCommit, origTreeState, origDate
+	}()
+
+	version.GitCommit = "abc1234"
+	version.GitTreeState = "dirty"
+	version.BuildDate = "2026-01-01T00:00:00Z"
+
+	cfg := &Config{
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Environment:    "test",
+	}
+
+	attrs := buildBaseAttrs(cfg)
+
+	assert.Contains(t, attrs, attribute.String("onix.build.commit", "abc1234"))
+	assert.Contains(t, attrs, attribute.String("onix.build.tree_state", "dirty"))
+	assert.Contains(t, attrs, attribute.String("onix.build.date", "2026-01-01T00:00:00Z"))
+	assert.Contains(t, attrs, attribute.String("service.name", "test-service"))
+	assert.Contains(t, attrs, attribute.String("service.version", "1.0.0"))
+}
 
 func TestSetup_New_Success(t *testing.T) {
 	setup := Setup{}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,22 @@
+// Package version holds build-time identity information for the adapter
+// binary. Values are injected via -ldflags -X at build time (see
+// install/setup.sh, Dockerfile.adapter, Dockerfile.adapter-with-plugins).
+// When built without those flags (go run, go test, plain go build), they
+// keep their zero-value defaults below.
+package version
+
+var (
+	// Version is the nearest git tag at build time (e.g. v1.6.0), as
+	// reported by `git describe --tags --always`.
+	Version = "dev"
+
+	// GitCommit is the short SHA of the commit the binary was built from.
+	GitCommit = "unknown"
+
+	// GitTreeState is "clean" if the working tree had no uncommitted
+	// changes at build time, "dirty" otherwise.
+	GitTreeState = "unknown"
+
+	// BuildDate is the UTC build timestamp in RFC3339 format.
+	BuildDate = "unknown"
+)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,7 +14,8 @@ var (
 	GitCommit = "unknown"
 
 	// GitTreeState is "clean" if the working tree had no uncommitted
-	// changes at build time, "dirty" otherwise.
+	// changes at build time, "dirty" otherwise, or "unknown" for builds
+	// without -ldflags injection (go run, go test, plain go build).
 	GitTreeState = "unknown"
 
 	// BuildDate is the UTC build timestamp in RFC3339 format.


### PR DESCRIPTION
## Summary
- Adds a `pkg/version` package (`Version`, `GitCommit`, `GitTreeState`, `BuildDate`) populated via `-ldflags -X` at build time in `install/setup.sh`, both Dockerfiles, and the CI workflow (falls back to `dev`/`unknown` for unflagged builds).
- Logs build identity at startup, adds a `build` object to `/health`, and adds `onix.build.*` OTel resource attributes (plus defaulting `otelsetup`'s `service.version` to the build-time version) — documented in `OBSERVABILITY.md`.
- Scope is deliberately limited to self-reported build identity for spotting stale/mismatched/locally-patched deployments. Cryptographic build attestation (so a malicious operator can't fake these fields) is scoped separately as a follow-up: #872.

## Test plan
- [x] `go build` / `go test` pass for all touched packages (`pkg/version`, `core/module/handler`, `pkg/plugin/implementation/otelsetup`, `cmd/adapter`)
- [x] Manually built the adapter binary with test `-ldflags` values and confirmed the startup log line reflects them correctly
- [x] Reviewer sign-off on `/health` response shape and OTel attribute naming before merge

Closes #808