### PR TITLE
Core: reshape model.Error for Beckn v2.0.0 ErrorCode taxonomy alignment

### DIFF
--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -134,12 +134,12 @@ func TestSendNack(t *testing.T) {
 			name: "SchemaValidationErr",
 			err: &model.SchemaValidationErr{
 				Errors: []model.Error{
-					{Paths: "/path1", Message: "Error 1"},
-					{Paths: "/path2", Message: "Error 2"},
+					{Details: &model.ErrorDetails{Path: "/path1"}, Message: "Error 1"},
+					{Details: &model.ErrorDetails{Path: "/path2"}, Message: "Error 2"},
 				},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","paths":"/path1;/path2","message":"Error 1; Error 2"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
 		},
 		{
 			name:     "SignValidationErr",
@@ -363,11 +363,11 @@ func TestNack_1(t *testing.T) {
 			name: "Schema Validation Error",
 			err: &model.Error{
 				Code:    "BAD_REQUEST",
-				Paths:   "/test/path",
 				Message: "Invalid schema",
+				Details: &model.ErrorDetails{Path: "/test/path"},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"BAD_REQUEST","paths":"/test/path","message":"Invalid schema"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"BAD_REQUEST","message":"Invalid schema","details":{"path":"/test/path"}}}}`,
 		},
 		{
 			name: "Internal Server Error",

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -56,18 +56,23 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 	}
 
-	// Collect all error paths and messages
+	// Collect all error paths and messages, positionally aligned so a
+	// consumer splitting both joined strings can still correlate the Nth
+	// path with the Nth message even when some entries have no path.
 	var paths []string
 	var messages []string
+	hasPath := false
 	for _, err := range e.Errors {
-		if p := err.path(); p != "" {
-			paths = append(paths, p)
+		p := err.path()
+		if p != "" {
+			hasPath = true
 		}
+		paths = append(paths, p)
 		messages = append(messages, err.Message)
 	}
 
 	var details *ErrorDetails
-	if len(paths) > 0 {
+	if hasPath {
 		details = &ErrorDetails{Path: strings.Join(paths, ";")}
 	}
 

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -56,9 +56,12 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 	}
 
-	// Collect all error paths and messages, positionally aligned so a
-	// consumer splitting both joined strings can still correlate the Nth
-	// path with the Nth message even when some entries have no path.
+	// Collect all error paths, one entry per cause (an entry with no path
+	// contributes an empty string), so Details.Path preserves per-cause
+	// structure when split on ";" — path segments don't contain literal
+	// semicolons in practice. Message is a separate, human-readable
+	// concatenation only; it may itself contain either delimiter, so it
+	// is not safe to split back into per-cause text.
 	var paths []string
 	var messages []string
 	hasPath := false

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -8,14 +8,29 @@ import (
 
 // Error represents a standard error response.
 type Error struct {
-	Code    string `json:"code"`
-	Paths   string `json:"paths,omitempty"`
-	Message string `json:"message"`
+	Code    string        `json:"code"`
+	Message string        `json:"message"`
+	Details *ErrorDetails `json:"details,omitempty"`
+}
+
+// ErrorDetails carries optional structured context for an Error: a JSONPath to
+// the failing field, and/or a chained root-cause Error from a downstream layer.
+type ErrorDetails struct {
+	Path  string `json:"path,omitempty"`
+	Cause *Error `json:"cause,omitempty"`
+}
+
+// path returns the details path, or "" if Details is unset.
+func (e *Error) path() string {
+	if e.Details == nil {
+		return ""
+	}
+	return e.Details.Path
 }
 
 // This implements the error interface for the Error struct.
 func (e *Error) Error() string {
-	return fmt.Sprintf("Error: Code=%s, Path=%s, Message=%s", e.Code, e.Paths, e.Message)
+	return fmt.Sprintf("Error: Code=%s, Path=%s, Message=%s", e.Code, e.path(), e.Message)
 }
 
 // SchemaValidationErr occurs when schema validation errors are encountered.
@@ -27,7 +42,7 @@ type SchemaValidationErr struct {
 func (e *SchemaValidationErr) Error() string {
 	var errorMessages []string
 	for _, err := range e.Errors {
-		errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", err.Paths, err.Message))
+		errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", err.path(), err.Message))
 	}
 	return strings.Join(errorMessages, "; ")
 }
@@ -45,15 +60,20 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	var paths []string
 	var messages []string
 	for _, err := range e.Errors {
-		if err.Paths != "" {
-			paths = append(paths, err.Paths)
+		if p := err.path(); p != "" {
+			paths = append(paths, p)
 		}
 		messages = append(messages, err.Message)
 	}
 
+	var details *ErrorDetails
+	if len(paths) > 0 {
+		details = &ErrorDetails{Path: strings.Join(paths, ";")}
+	}
+
 	return &Error{
 		Code:    http.StatusText(http.StatusBadRequest),
-		Paths:   strings.Join(paths, ";"),
+		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
 }

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -29,8 +29,8 @@ func NewBadReqErrf(format string, a ...any) *BadReqErr {
 func TestError_Error(t *testing.T) {
 	err := &Error{
 		Code:    "404",
-		Paths:   "/api/v1/user",
 		Message: "User not found",
+		Details: &ErrorDetails{Path: "/api/v1/user"},
 	}
 
 	expected := "Error: Code=404, Path=/api/v1/user, Message=User not found"
@@ -46,8 +46,8 @@ func TestError_Error(t *testing.T) {
 func TestSchemaValidationErr_Error(t *testing.T) {
 	schemaErr := &SchemaValidationErr{
 		Errors: []Error{
-			{Paths: "/user", Message: "Field required"},
-			{Paths: "/email", Message: "Invalid format"},
+			{Details: &ErrorDetails{Path: "/user"}, Message: "Field required"},
+			{Details: &ErrorDetails{Path: "/email"}, Message: "Invalid format"},
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestSchemaValidationErr_Error(t *testing.T) {
 func TestSchemaValidationErr_BecknError(t *testing.T) {
 	schemaErr := &SchemaValidationErr{
 		Errors: []Error{
-			{Paths: "/user", Message: "Field required"},
+			{Details: &ErrorDetails{Path: "/user"}, Message: "Field required"},
 		},
 	}
 
@@ -72,6 +72,9 @@ func TestSchemaValidationErr_BecknError(t *testing.T) {
 	if beErr.Code != expected {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Code, expected)
+	}
+	if beErr.Details == nil || beErr.Details.Path != "/user" {
+		t.Errorf("beErr.Details = %+v, want Path=/user", beErr.Details)
 	}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -78,6 +78,47 @@ func TestSchemaValidationErr_BecknError(t *testing.T) {
 	}
 }
 
+func TestSchemaValidationErr_BecknError_NoPaths(t *testing.T) {
+	schemaErr := &SchemaValidationErr{
+		Errors: []Error{
+			{Message: "generic error one"},
+			{Message: "generic error two"},
+		},
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Details != nil {
+		t.Errorf("beErr.Details = %+v, want nil when no entry has a path", beErr.Details)
+	}
+	expectedMsg := "generic error one; generic error two"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestSchemaValidationErr_BecknError_MixedPaths(t *testing.T) {
+	schemaErr := &SchemaValidationErr{
+		Errors: []Error{
+			{Details: &ErrorDetails{Path: "/a"}, Message: "m1"},
+			{Message: "m2"},
+			{Details: &ErrorDetails{Path: "/c"}, Message: "m3"},
+		},
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Details == nil {
+		t.Fatal("beErr.Details = nil, want non-nil since at least one entry has a path")
+	}
+	expectedPath := "/a;;/c"
+	if beErr.Details.Path != expectedPath {
+		t.Errorf("beErr.Details.Path = %s, want %s (positionally aligned with Message)", beErr.Details.Path, expectedPath)
+	}
+	expectedMsg := "m1; m2; m3"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
 func TestSignValidationErr_BecknError(t *testing.T) {
 	signErr := NewSignValidationErr(errors.New("signature failed"))
 	beErr := signErr.BecknError()

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -193,26 +193,30 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 			var schemaErrors []model.Error
 			v.extractSchemaErrors(err, &schemaErrors)
 
-			// Prefix all paths with object path
-			for i := range schemaErrors {
-				prefixed := obj.Path
-				if schemaErrors[i].Details != nil && schemaErrors[i].Details.Path != "" {
-					prefixed = obj.Path + "." + schemaErrors[i].Details.Path
-				}
-				// Update Path in place when Details already exists so any
-				// other field (e.g. Cause) set upstream is preserved.
-				if schemaErrors[i].Details != nil {
-					schemaErrors[i].Details.Path = prefixed
-				} else {
-					schemaErrors[i].Details = &model.ErrorDetails{Path: prefixed}
-				}
-			}
+			prefixSchemaErrorPaths(schemaErrors, obj.Path)
 
 			return &model.SchemaValidationErr{Errors: schemaErrors}
 		}
 	}
 
 	return nil
+}
+
+// prefixSchemaErrorPaths prefixes objPath onto each error's Details.Path,
+// updating it in place when Details already exists so any other field (e.g.
+// a chained Cause) set upstream is preserved rather than discarded.
+func prefixSchemaErrorPaths(schemaErrors []model.Error, objPath string) {
+	for i := range schemaErrors {
+		prefixed := objPath
+		if schemaErrors[i].Details != nil && schemaErrors[i].Details.Path != "" {
+			prefixed = objPath + "." + schemaErrors[i].Details.Path
+		}
+		if schemaErrors[i].Details != nil {
+			schemaErrors[i].Details.Path = prefixed
+		} else {
+			schemaErrors[i].Details = &model.ErrorDetails{Path: prefixed}
+		}
+	}
 }
 
 // newSchemaCache creates a new schema cache.

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -195,16 +195,17 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 
 			// Prefix all paths with object path
 			for i := range schemaErrors {
-				existing := ""
+				prefixed := obj.Path
+				if schemaErrors[i].Details != nil && schemaErrors[i].Details.Path != "" {
+					prefixed = obj.Path + "." + schemaErrors[i].Details.Path
+				}
+				// Update Path in place when Details already exists so any
+				// other field (e.g. Cause) set upstream is preserved.
 				if schemaErrors[i].Details != nil {
-					existing = schemaErrors[i].Details.Path
-				}
-				if existing != "" {
-					existing = obj.Path + "." + existing
+					schemaErrors[i].Details.Path = prefixed
 				} else {
-					existing = obj.Path
+					schemaErrors[i].Details = &model.ErrorDetails{Path: prefixed}
 				}
-				schemaErrors[i].Details = &model.ErrorDetails{Path: existing}
 			}
 
 			return &model.SchemaValidationErr{Errors: schemaErrors}

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -195,11 +195,16 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 
 			// Prefix all paths with object path
 			for i := range schemaErrors {
-				if schemaErrors[i].Paths != "" {
-					schemaErrors[i].Paths = obj.Path + "." + schemaErrors[i].Paths
-				} else {
-					schemaErrors[i].Paths = obj.Path
+				existing := ""
+				if schemaErrors[i].Details != nil {
+					existing = schemaErrors[i].Details.Path
 				}
+				if existing != "" {
+					existing = obj.Path + "." + existing
+				} else {
+					existing = obj.Path
+				}
+				schemaErrors[i].Details = &model.ErrorDetails{Path: existing}
 			}
 
 			return &model.SchemaValidationErr{Errors: schemaErrors}

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -7,10 +7,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 )
@@ -812,6 +814,65 @@ func TestValidateExtendedSchemas_MissingMessage(t *testing.T) {
 	err := v.validateExtendedSchemas(ctx, body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'message' field")
+}
+
+func TestPrefixSchemaErrorPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		schemaErrors []model.Error
+		objPath      string
+		want         []model.Error
+	}{
+		{
+			name:         "no existing details gets object path",
+			schemaErrors: []model.Error{{Message: "m1"}},
+			objPath:      "message.order",
+			want: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "message.order"}},
+			},
+		},
+		{
+			name: "existing path is prefixed with object path",
+			schemaErrors: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "items[0].id"}},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "message.order.items[0].id"}},
+			},
+		},
+		{
+			name: "existing cause is preserved after prefixing",
+			schemaErrors: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "items[0].id",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "message.order.items[0].id",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefixSchemaErrorPaths(tt.schemaErrors, tt.objPath)
+			if !reflect.DeepEqual(tt.schemaErrors, tt.want) {
+				t.Errorf("prefixSchemaErrorPaths() = %+v, want %+v", tt.schemaErrors, tt.want)
+			}
+		})
+	}
 }
 
 func TestIsSchemaVersionSegment(t *testing.T) {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -863,6 +863,27 @@ func TestPrefixSchemaErrorPaths(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "existing details with no path yet gets object path, cause still preserved",
+			schemaErrors: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "message.order",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -560,10 +560,11 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			}
 		}
 
-		*schemaErrors = append(*schemaErrors, model.Error{
-			Details: &model.ErrorDetails{Path: path},
-			Message: message,
-		})
+		errItem := model.Error{Message: message}
+		if path != "" {
+			errItem.Details = &model.ErrorDetails{Path: path}
+		}
+		*schemaErrors = append(*schemaErrors, errItem)
 	} else if multiErr, ok := err.(openapi3.MultiError); ok {
 		// Nested MultiError
 		for _, e := range multiErr {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -561,7 +561,7 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 		}
 
 		*schemaErrors = append(*schemaErrors, model.Error{
-			Paths:   path,
+			Details: &model.ErrorDetails{Path: path},
 			Message: message,
 		})
 	} else if multiErr, ok := err.(openapi3.MultiError); ok {
@@ -572,7 +572,6 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 	} else {
 		// Generic error
 		*schemaErrors = append(*schemaErrors, model.Error{
-			Paths:   "",
 			Message: err.Error(),
 		})
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -2,6 +2,7 @@ package schemav2validator
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // testSpecBodyless mirrors the Beckn 2.0 /catalog/subscription path which
@@ -262,6 +265,38 @@ func TestValidate_NestedValidation(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestValidate_SchemaErrorDetails confirms extractSchemaErrors only attaches
+// Details when the underlying validation cause has a non-empty path — never
+// a non-nil Details with an empty Path (the fix for issue #862's finding #5).
+func TestValidate_SchemaErrorDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"select"},"message":{}}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) == 0 {
+		t.Fatal("expected at least one schema error")
+	}
+
+	for _, got := range schemaErr.Errors {
+		t.Logf("Details = %+v", got.Details)
+		if got.Details != nil && got.Details.Path == "" {
+			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
+		}
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -292,11 +292,18 @@ func TestValidate_SchemaErrorDetails(t *testing.T) {
 		t.Fatal("expected at least one schema error")
 	}
 
+	hasDetails := false
 	for _, got := range schemaErr.Errors {
 		t.Logf("Details = %+v", got.Details)
 		if got.Details != nil && got.Details.Path == "" {
 			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
 		}
+		if got.Details != nil && got.Details.Path != "" {
+			hasDetails = true
+		}
+	}
+	if !hasDetails {
+		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
 	}
 }
 

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator.go
@@ -104,10 +104,11 @@ func (v *schemaValidator) Validate(ctx context.Context, reqURL *url.URL, data []
 				message := cause.Error()                          // Validation error message
 
 				// Append the error to the schemaErrors array
-				schemaErrors = append(schemaErrors, model.Error{
-					Details: &model.ErrorDetails{Path: path},
-					Message: message,
-				})
+				errItem := model.Error{Message: message}
+				if path != "" {
+					errItem.Details = &model.ErrorDetails{Path: path}
+				}
+				schemaErrors = append(schemaErrors, errItem)
 			}
 			// Return the array of schema validation errors
 			return &model.SchemaValidationErr{Errors: schemaErrors}

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator.go
@@ -105,7 +105,7 @@ func (v *schemaValidator) Validate(ctx context.Context, reqURL *url.URL, data []
 
 				// Append the error to the schemaErrors array
 				schemaErrors = append(schemaErrors, model.Error{
-					Paths:   path,
+					Details: &model.ErrorDetails{Path: path},
 					Message: message,
 				})
 			}

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
@@ -2,12 +2,14 @@ package schemavalidator
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -145,6 +147,39 @@ func TestValidator_Validate_Failure(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestValidator_Validate_SchemaErrorDetails confirms Validate() attaches
+// Details with the JSON-schema cause's path through the real code path
+// (extractSchemaErrors is inlined here, not a separately-testable helper).
+// Note: an empty-path (root-level) cause isn't reachable through this
+// validator's public entrypoint — Domain/Version presence is checked before
+// schema.Validate() ever runs, so "context" is always already present by the
+// time a schema-level cause can occur.
+func TestValidator_Validate_SchemaErrorDetails(t *testing.T) {
+	schemaDir := setupTestSchema(t)
+	defer os.RemoveAll(schemaDir)
+
+	config := &Config{SchemaDir: schemaDir}
+	v, _, err := New(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = v.Validate(context.Background(), &url.URL{Path: "endpoint"}, []byte(`{"context": {"domain": "example", "version": "1.0"}}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) == 0 {
+		t.Fatal("expected at least one schema error")
+	}
+
+	got := schemaErr.Errors[0]
+	if got.Details == nil || got.Details.Path == "" {
+		t.Errorf("Details = %+v, want a non-nil Details with a non-empty Path", got.Details)
 	}
 }
 

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
@@ -153,10 +153,12 @@ func TestValidator_Validate_Failure(t *testing.T) {
 // TestValidator_Validate_SchemaErrorDetails confirms Validate() attaches
 // Details with the JSON-schema cause's path through the real code path
 // (extractSchemaErrors is inlined here, not a separately-testable helper).
-// Note: an empty-path (root-level) cause isn't reachable through this
-// validator's public entrypoint — Domain/Version presence is checked before
-// schema.Validate() ever runs, so "context" is always already present by the
-// time a schema-level cause can occur.
+// Note: setupTestSchema's schema only requires "context" at the root, so a
+// root-level (empty-path) cause never occurs for THIS test's schema — that is
+// not a general property of Validate() itself. Validate() never independently
+// checks for a top-level "message" field before calling schema.Validate(), so
+// a real schema requiring ["context", "message"] at root (as this plugin's
+// own README documents) could still produce a root-level cause with no path.
 func TestValidator_Validate_SchemaErrorDetails(t *testing.T) {
 	schemaDir := setupTestSchema(t)
 	defer os.RemoveAll(schemaDir)
@@ -177,9 +179,17 @@ func TestValidator_Validate_SchemaErrorDetails(t *testing.T) {
 		t.Fatal("expected at least one schema error")
 	}
 
-	got := schemaErr.Errors[0]
-	if got.Details == nil || got.Details.Path == "" {
-		t.Errorf("Details = %+v, want a non-nil Details with a non-empty Path", got.Details)
+	hasDetails := false
+	for _, got := range schemaErr.Errors {
+		if got.Details != nil && got.Details.Path == "" {
+			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
+		}
+		if got.Details != nil && got.Details.Path != "" {
+			hasDetails = true
+		}
+	}
+	if !hasDetails {
+		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
 	}
 }
 


### PR DESCRIPTION
Closes #862. Part of the #861 EPIC.

**Migration required:** this changes the JSON shape of Beckn NACK error responses. Consumers reading `error.paths` must switch to `error.details.path` — the field is removed, not deprecated, so old and new shapes are never emitted side-by-side.

## What changed

- `model.Error`: removed the top-level `Paths` string field; added `Details *ErrorDetails{Path string, Cause *Error}` matching the spec's `Error.details` object.
- `Details.Cause` is present in the struct for forward compatibility but is not populated by any call site yet — no plugin currently produces a chained root-cause error, so there was nothing to wire up. Left for a future ticket if/when a real use case shows up.
- `SchemaValidationErr.BecknError()`/`.Error()`: unchanged aggregation behavior (still joins all field messages into one `message` string); the joined per-field paths now populate `Details.Path` instead of the removed `Paths` field. Path collection is now positionally aligned with messages (an entry with no path contributes an empty segment rather than being skipped), so a consumer splitting both joined strings can still correlate the Nth path with the Nth message.
- Updated the call sites that built `model.Error{Paths: ...}` (`schemavalidator.go`, `schemav2validator.go`, `extended_schema.go`) to use `Details: &model.ErrorDetails{Path: ...}`, only attaching `Details` when the path is actually non-empty (preserving the old field's clean `omitempty` disappearance for individual, non-aggregated error items).
- `extended_schema.go`'s path-prefixing loop now updates `Details.Path` in place when `Details` already exists, instead of always reconstructing it — this preserves any other field (e.g. a future `Cause`) already set on that error, rather than silently discarding it.
- Updated `pkg/model/error_test.go` and `core/module/handler/responsestep_test.go` (including exact NACK JSON body assertions) for the new shape, plus added coverage for the no-path and mixed-path aggregation cases.

## Explicitly out of scope for this PR (tracked separately under #861)
- No `code` value changes — every error type still emits the same HTTP-status-string codes as before (`"Bad Request"`, `"Unauthorized"`, etc.). Mapping to canonical `SCH_*`/`AUT_*`/`POL_*`/etc. codes is plugin-wise work (#863–#870).
- No version gating — confirmed unnecessary; `nackBecknError` never gated error codes by protocol version except the unrelated `AckNoCallbackErr`→202 case, and the pre-2.0 spec already had a `details`-shaped concept at the top level, so this shape change applies uniformly regardless of protocol version.
- No `CTX_*` code mapping — the only real context-level check (`bpp_uri`) lives in the `router` plugin, not here; that mapping is tracked in #869.

## Why this targets the epic branch, not main
This is a breaking wire-format change (`error.paths` → `error.details.path`). Merging it straight to `main` would ship half the #861 breaking change (the shape) while every `code` value is still legacy — a worse migration experience for consumers than one clean release. All of #861's sub-tickets accumulate on `epic/861-error-code-alignment` and go to `main` together once complete, targeting the next release.

## Testing
- `go build` / `go vet` clean on all touched packages.
- Full repo test suite passes (`go test $(go list ./... | grep -v /cmd$)`).
