### PR TITLE
schemav2validator: map validation failures to SCH_* codes

### DIFF
--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -13,6 +13,14 @@ type Error struct {
 	Details *ErrorDetails `json:"details,omitempty"`
 }
 
+// NewCodedError constructs an Error carrying an explicit ErrorCode value and
+// message, for callers that already know a specific code to report (e.g. a
+// plugin classifying one of its own failure modes onto the Beckn v2.0.0
+// ErrorCode taxonomy).
+func NewCodedError(code, message string) *Error {
+	return &Error{Code: code, Message: message}
+}
+
 // ErrorDetails carries optional structured context for an Error: a JSONPath to
 // the failing field, and/or a chained root-cause Error from a downstream layer.
 type ErrorDetails struct {

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -17,6 +17,13 @@ type Error struct {
 // message, for callers that already know a specific code to report (e.g. a
 // plugin classifying one of its own failure modes onto the Beckn v2.0.0
 // ErrorCode taxonomy).
+//
+// The returned *Error is a plain value, not a step error: nackBecknError
+// (core/module/handler/responsestep.go) only recognizes SchemaValidationErr,
+// SignValidationErr, BadReqErr, NotFoundErr, and AckNoCallbackErr. Callers
+// must wrap the result in one of those types before returning it from a
+// Step — returning it bare falls through to a generic 500 Internal Server
+// Error instead of the intended NACK code.
 func NewCodedError(code, message string) *Error {
 	return &Error{Code: code, Message: message}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -65,6 +65,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	var paths []string
 	var messages []string
 	hasPath := false
+	code := ""
 	for _, err := range e.Errors {
 		p := err.path()
 		if p != "" {
@@ -72,6 +73,16 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 		paths = append(paths, p)
 		messages = append(messages, err.Message)
+		// First non-empty per-cause code wins. The other causes' text is
+		// still fully present in Message/Details.Path — only their
+		// individual Code is not separately represented on the wire, since
+		// a single Error can only carry one code.
+		if code == "" && err.Code != "" {
+			code = err.Code
+		}
+	}
+	if code == "" {
+		code = http.StatusText(http.StatusBadRequest)
 	}
 
 	var details *ErrorDetails
@@ -80,7 +91,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    http.StatusText(http.StatusBadRequest),
+		Code:    code,
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -26,6 +26,19 @@ func NewBadReqErrf(format string, a ...any) *BadReqErr {
 	return &BadReqErr{fmt.Errorf(format, a...)}
 }
 
+func TestNewCodedError(t *testing.T) {
+	err := NewCodedError("SCH_INVALID_ENUM", "value must be one of the allowed options")
+	if err.Code != "SCH_INVALID_ENUM" {
+		t.Errorf("Code = %s, want SCH_INVALID_ENUM", err.Code)
+	}
+	if err.Message != "value must be one of the allowed options" {
+		t.Errorf("Message = %s, want %s", err.Message, "value must be one of the allowed options")
+	}
+	if err.Details != nil {
+		t.Errorf("Details = %+v, want nil", err.Details)
+	}
+}
+
 func TestError_Error(t *testing.T) {
 	err := &Error{
 		Code:    "404",

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -119,6 +119,49 @@ func TestSchemaValidationErr_BecknError_MixedPaths(t *testing.T) {
 	}
 }
 
+func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []Error
+		want string
+	}{
+		{
+			name: "first entry's code wins over a later different code",
+			errs: []Error{
+				{Code: "SCH_REQUIRED_FIELD_MISSING", Message: "m1"},
+				{Code: "SCH_INVALID_ENUM", Message: "m2"},
+			},
+			want: "SCH_REQUIRED_FIELD_MISSING",
+		},
+		{
+			name: "leading entries with no code are skipped",
+			errs: []Error{
+				{Message: "m1"},
+				{Code: "SCH_INVALID_ENUM", Message: "m2"},
+			},
+			want: "SCH_INVALID_ENUM",
+		},
+		{
+			name: "no entry has a code falls back to the legacy default",
+			errs: []Error{
+				{Message: "m1"},
+				{Message: "m2"},
+			},
+			want: "Bad Request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaErr := &SchemaValidationErr{Errors: tt.errs}
+			beErr := schemaErr.BecknError()
+			if beErr.Code != tt.want {
+				t.Errorf("Code = %s, want %s", beErr.Code, tt.want)
+			}
+		})
+	}
+}
+
 func TestSignValidationErr_BecknError(t *testing.T) {
 	signErr := NewSignValidationErr(errors.New("signature failed"))
 	beErr := signErr.BecknError()

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -529,11 +529,11 @@ func (c *schemaCache) validateReferencedObject(
 			u, err := url.Parse(obj.Context)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				log.Warnf(ctx, "Invalid or disallowed scheme in @context: %s", obj.Context)
-				return &model.Error{Code: "SCH_INVALID_JSONLD_CONTEXT", Message: fmt.Sprintf("invalid scheme in @context: %s", obj.Context)}
+				return model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", fmt.Sprintf("invalid scheme in @context: %s", obj.Context))
 			}
 			if !isAllowedDomain(u, allowedDomains) {
 				log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
-				return &model.Error{Code: "SCH_INVALID_JSONLD_CONTEXT", Message: fmt.Sprintf("domain not allowed: %s", obj.Context)}
+				return model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", fmt.Sprintf("domain not allowed: %s", obj.Context))
 			}
 		}
 		schemaPath := transformContextToSchemaURL(obj.Context)
@@ -541,7 +541,7 @@ func (c *schemaCache) validateReferencedObject(
 		var err error
 		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
 		if err != nil {
-			return &model.Error{Code: "SCH_SCHEMA_ADAPTATION_FAILED", Message: err.Error()}
+			return model.NewCodedError("SCH_SCHEMA_ADAPTATION_FAILED", err.Error())
 		}
 	}
 
@@ -549,7 +549,7 @@ func (c *schemaCache) validateReferencedObject(
 	schema, err := findSchemaByType(ctx, doc, obj.Type)
 	if err != nil {
 		log.Errorf(ctx, err, "Schema not found for @type: %s at path: %s", obj.Type, obj.Path)
-		return &model.Error{Code: "SCH_INVALID_ENTITY_TYPE", Message: err.Error()}
+		return model.NewCodedError("SCH_INVALID_ENTITY_TYPE", err.Error())
 	}
 
 	// Strip JSON-LD metadata before validation

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -529,11 +529,11 @@ func (c *schemaCache) validateReferencedObject(
 			u, err := url.Parse(obj.Context)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				log.Warnf(ctx, "Invalid or disallowed scheme in @context: %s", obj.Context)
-				return fmt.Errorf("invalid scheme in @context: %s", obj.Context)
+				return &model.Error{Code: "SCH_INVALID_JSONLD_CONTEXT", Message: fmt.Sprintf("invalid scheme in @context: %s", obj.Context)}
 			}
 			if !isAllowedDomain(u, allowedDomains) {
 				log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
-				return fmt.Errorf("domain not allowed: %s", obj.Context)
+				return &model.Error{Code: "SCH_INVALID_JSONLD_CONTEXT", Message: fmt.Sprintf("domain not allowed: %s", obj.Context)}
 			}
 		}
 		schemaPath := transformContextToSchemaURL(obj.Context)
@@ -541,7 +541,7 @@ func (c *schemaCache) validateReferencedObject(
 		var err error
 		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
 		if err != nil {
-			return fmt.Errorf("at %s: %w", obj.Path, err)
+			return &model.Error{Code: "SCH_SCHEMA_ADAPTATION_FAILED", Message: err.Error()}
 		}
 	}
 
@@ -549,7 +549,7 @@ func (c *schemaCache) validateReferencedObject(
 	schema, err := findSchemaByType(ctx, doc, obj.Type)
 	if err != nil {
 		log.Errorf(ctx, err, "Schema not found for @type: %s at path: %s", obj.Type, obj.Path)
-		return fmt.Errorf("at %s: %w", obj.Path, err)
+		return &model.Error{Code: "SCH_INVALID_ENTITY_TYPE", Message: err.Error()}
 	}
 
 	// Strip JSON-LD metadata before validation

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -661,24 +661,94 @@ components:
 	
 	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
 	assert.Error(t, err)
+
+	schemaErrors := []model.Error{}
+	(&schemav2Validator{}).extractSchemaErrors(err, &schemaErrors)
+	if len(schemaErrors) == 0 || schemaErrors[0].Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("Code = %+v, want SCH_REQUIRED_FIELD_MISSING", schemaErrors)
+	}
 }
 
 func TestValidateReferencedObject_DomainNotAllowed(t *testing.T) {
 	cache := newSchemaCache(10)
 	ctx := context.Background()
-	
+
 	obj := referencedObject{
 		Path:    "message.test",
 		Context: "https://malicious.com/schema.yaml",
 		Type:    "TestType",
 		Data:    map[string]interface{}{},
 	}
-	
+
 	allowedDomains := []string{"trusted.com"}
-	
+
 	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "domain not allowed")
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_INVALID_JSONLD_CONTEXT" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_JSONLD_CONTEXT", err, err)
+	}
+}
+
+func TestValidateReferencedObject_EntityTypeNotFound(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-schema-*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	schemaContent := `openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object`
+
+	tmpFile.Write([]byte(schemaContent))
+	tmpFile.Close()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: tmpFile.Name(),
+		Type:    "NonExistentType",
+		Data: map[string]interface{}{
+			"@context": tmpFile.Name(),
+			"@type":    "NonExistentType",
+		},
+	}
+
+	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
+	assert.Error(t, err)
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_INVALID_ENTITY_TYPE" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_ENTITY_TYPE", err, err)
+	}
+}
+
+func TestValidateReferencedObject_SchemaLoadFailure(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: "/nonexistent/schema.yaml",
+		Type:    "TestType",
+		Data:    map[string]interface{}{},
+	}
+
+	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
+	assert.Error(t, err)
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_SCHEMA_ADAPTATION_FAILED", err, err)
+	}
 }
 
 func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testing.T) {
@@ -718,6 +788,11 @@ func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testi
 			err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid scheme in @context")
+
+			becknErr, ok := err.(*model.Error)
+			if !ok || becknErr.Code != "SCH_INVALID_JSONLD_CONTEXT" {
+				t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_JSONLD_CONTEXT", err, err)
+			}
 		})
 	}
 }

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -2,6 +2,7 @@ package schemav2validator
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -889,6 +890,50 @@ func TestValidateExtendedSchemas_MissingMessage(t *testing.T) {
 	err := v.validateExtendedSchemas(ctx, body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'message' field")
+}
+
+// TestValidateExtendedSchemas_DomainNotAllowed_PropagatesCode drives a real
+// domain-object validation failure through the full production path
+// (validateExtendedSchemas -> validateReferencedObject -> extractSchemaErrors'
+// *model.Error passthrough branch -> prefixSchemaErrorPaths), confirming the
+// classified code and path both survive end-to-end — not just at the unit
+// level of validateReferencedObject or extractSchemaErrors individually.
+func TestValidateExtendedSchemas_DomainNotAllowed_PropagatesCode(t *testing.T) {
+	v := &schemav2Validator{
+		config: &Config{
+			EnableExtendedSchema: true,
+			ExtendedSchemaConfig: ExtendedSchemaConfig{
+				AllowedDomains: []string{"trusted.com"},
+			},
+		},
+		schemaCache: newSchemaCache(10),
+	}
+
+	ctx := context.Background()
+	body := map[string]interface{}{
+		"message": map[string]interface{}{
+			"order": map[string]interface{}{
+				"@context": "https://malicious.com/schema.yaml",
+				"@type":    "SomeType",
+			},
+		},
+	}
+
+	err := v.validateExtendedSchemas(ctx, body)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSONLD_CONTEXT" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSONLD_CONTEXT", schemaErr.Errors)
+	}
+	if schemaErr.Errors[0].Details == nil || schemaErr.Errors[0].Details.Path == "" {
+		t.Errorf("Details = %+v, want a non-empty Path from prefixSchemaErrorPaths", schemaErr.Errors[0].Details)
+	}
 }
 
 func TestPrefixSchemaErrorPaths(t *testing.T) {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -161,7 +161,9 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	var payloadData payload
 	err := json.Unmarshal(data, &payloadData)
 	if err != nil {
-		return model.NewBadReqErr(fmt.Errorf("failed to parse JSON payload: %v", err))
+		return &model.SchemaValidationErr{Errors: []model.Error{
+			{Code: "SCH_INVALID_JSON", Message: fmt.Sprintf("failed to parse JSON payload: %v", err)},
+		}}
 	}
 
 	if payloadData.Context.Action == "" {
@@ -528,9 +530,37 @@ func (v *schemav2Validator) formatValidationError(err error) error {
 	return &model.SchemaValidationErr{Errors: schemaErrors}
 }
 
+// schemaFieldToCode maps an openapi3.SchemaError's SchemaField (the JSON-schema
+// keyword that failed, e.g. "required", "enum", "format") to the corresponding
+// Beckn v2.0.0 SCH_* code. Composite keywords (oneOf/anyOf/allOf) and any
+// constraint without a dedicated code fall back to SCH_SCHEMA_VALIDATION_FAILED,
+// since kin-openapi doesn't attribute those to one single underlying cause.
+func schemaFieldToCode(schemaField string) string {
+	switch schemaField {
+	case "required":
+		return "SCH_REQUIRED_FIELD_MISSING"
+	case "properties":
+		// kin-openapi uses SchemaField "properties" specifically for the
+		// additionalProperties-disallowed case ("property %q is unsupported").
+		return "SCH_FIELD_NOT_ALLOWED"
+	case "enum":
+		return "SCH_INVALID_ENUM"
+	case "format":
+		return "SCH_INVALID_FORMAT"
+	case "type":
+		return "SCH_TYPE_NOT_SUPPORTED"
+	default:
+		return "SCH_SCHEMA_VALIDATION_FAILED"
+	}
+}
+
 // extractSchemaErrors recursively extracts detailed error information from SchemaError.
 func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model.Error) {
-	if schemaErr, ok := err.(*openapi3.SchemaError); ok {
+	if becknErr, ok := err.(*model.Error); ok {
+		// Already a fully-classified error (e.g. from validateReferencedObject's
+		// domain/JSON-LD checks) — pass it through as-is.
+		*schemaErrors = append(*schemaErrors, *becknErr)
+	} else if schemaErr, ok := err.(*openapi3.SchemaError); ok {
 		// Extract path from current error and message from Origin if available
 		pathParts := schemaErr.JSONPointer()
 		path := strings.Join(pathParts, "/")
@@ -560,7 +590,7 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			}
 		}
 
-		errItem := model.Error{Message: message}
+		errItem := model.Error{Code: schemaFieldToCode(schemaErr.SchemaField), Message: message}
 		if path != "" {
 			errItem.Details = &model.ErrorDetails{Path: path}
 		}
@@ -571,8 +601,9 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			v.extractSchemaErrors(e, schemaErrors)
 		}
 	} else {
-		// Generic error
+		// Generic error — no schema keyword to classify against.
 		*schemaErrors = append(*schemaErrors, model.Error{
+			Code:    "SCH_SCHEMA_VALIDATION_FAILED",
 			Message: err.Error(),
 		})
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -162,7 +162,7 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	err := json.Unmarshal(data, &payloadData)
 	if err != nil {
 		return &model.SchemaValidationErr{Errors: []model.Error{
-			{Code: "SCH_INVALID_JSON", Message: fmt.Sprintf("failed to parse JSON payload: %v", err)},
+			*model.NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to parse JSON payload: %v", err)),
 		}}
 	}
 
@@ -191,7 +191,9 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 
 	var jsonData any
 	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return model.NewBadReqErr(fmt.Errorf("invalid JSON: %v", err))
+		return &model.SchemaValidationErr{Errors: []model.Error{
+			*model.NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("invalid JSON: %v", err)),
+		}}
 	}
 
 	opts := []openapi3.SchemaValidationOption{
@@ -530,28 +532,30 @@ func (v *schemav2Validator) formatValidationError(err error) error {
 	return &model.SchemaValidationErr{Errors: schemaErrors}
 }
 
-// schemaFieldToCode maps an openapi3.SchemaError's SchemaField (the JSON-schema
-// keyword that failed, e.g. "required", "enum", "format") to the corresponding
-// Beckn v2.0.0 SCH_* code. Composite keywords (oneOf/anyOf/allOf) and any
-// constraint without a dedicated code fall back to SCH_SCHEMA_VALIDATION_FAILED,
-// since kin-openapi doesn't attribute those to one single underlying cause.
+// schemaFieldCodes maps an openapi3.SchemaError's SchemaField (the JSON-schema
+// keyword that failed) to the corresponding Beckn v2.0.0 SCH_* code.
+var schemaFieldCodes = map[string]string{
+	"required": "SCH_REQUIRED_FIELD_MISSING",
+	// kin-openapi uses SchemaField "properties" specifically for the
+	// additionalProperties-disallowed case ("property %q is unsupported").
+	"properties": "SCH_FIELD_NOT_ALLOWED",
+	"enum":       "SCH_INVALID_ENUM",
+	// "const" is JSON Schema's own sugar for an enum with a single allowed
+	// value — there is no dedicated SCH_* code for it, so it shares enum's.
+	"const":  "SCH_INVALID_ENUM",
+	"format": "SCH_INVALID_FORMAT",
+	"type":   "SCH_TYPE_NOT_SUPPORTED",
+}
+
+// schemaFieldToCode looks up schemaFieldCodes. Composite keywords
+// (oneOf/anyOf/allOf) and any constraint without a dedicated code fall back
+// to SCH_SCHEMA_VALIDATION_FAILED, since kin-openapi doesn't attribute those
+// to one single underlying cause.
 func schemaFieldToCode(schemaField string) string {
-	switch schemaField {
-	case "required":
-		return "SCH_REQUIRED_FIELD_MISSING"
-	case "properties":
-		// kin-openapi uses SchemaField "properties" specifically for the
-		// additionalProperties-disallowed case ("property %q is unsupported").
-		return "SCH_FIELD_NOT_ALLOWED"
-	case "enum":
-		return "SCH_INVALID_ENUM"
-	case "format":
-		return "SCH_INVALID_FORMAT"
-	case "type":
-		return "SCH_TYPE_NOT_SUPPORTED"
-	default:
-		return "SCH_SCHEMA_VALIDATION_FAILED"
+	if code, ok := schemaFieldCodes[schemaField]; ok {
+		return code
 	}
+	return "SCH_SCHEMA_VALIDATION_FAILED"
 }
 
 // extractSchemaErrors recursively extracts detailed error information from SchemaError.

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -594,11 +594,11 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			}
 		}
 
-		errItem := model.Error{Code: schemaFieldToCode(schemaErr.SchemaField), Message: message}
+		errItem := model.NewCodedError(schemaFieldToCode(schemaErr.SchemaField), message)
 		if path != "" {
 			errItem.Details = &model.ErrorDetails{Path: path}
 		}
-		*schemaErrors = append(*schemaErrors, errItem)
+		*schemaErrors = append(*schemaErrors, *errItem)
 	} else if multiErr, ok := err.(openapi3.MultiError); ok {
 		// Nested MultiError
 		for _, e := range multiErr {
@@ -606,10 +606,7 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 		}
 	} else {
 		// Generic error — no schema keyword to classify against.
-		*schemaErrors = append(*schemaErrors, model.Error{
-			Code:    "SCH_SCHEMA_VALIDATION_FAILED",
-			Message: err.Error(),
-		})
+		*schemaErrors = append(*schemaErrors, *model.NewCodedError("SCH_SCHEMA_VALIDATION_FAILED", err.Error()))
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -8,10 +8,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // testSpecBodyless mirrors the Beckn 2.0 /catalog/subscription path which
@@ -294,7 +296,7 @@ func TestValidate_SchemaErrorDetails(t *testing.T) {
 
 	hasDetails := false
 	for _, got := range schemaErr.Errors {
-		t.Logf("Details = %+v", got.Details)
+		t.Logf("Code = %s, Details = %+v", got.Code, got.Details)
 		if got.Details != nil && got.Details.Path == "" {
 			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
 		}
@@ -304,6 +306,156 @@ func TestValidate_SchemaErrorDetails(t *testing.T) {
 	}
 	if !hasDetails {
 		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
+	}
+
+	// "message.order" is required and missing — SchemaField "required" must
+	// map to SCH_REQUIRED_FIELD_MISSING.
+	if schemaErr.Errors[0].Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", schemaErr.Errors[0].Code)
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("aggregate Code = %s, want SCH_REQUIRED_FIELD_MISSING (first non-empty per-cause code)", beErr.Code)
+	}
+}
+
+func TestSchemaFieldToCode(t *testing.T) {
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{"required", "SCH_REQUIRED_FIELD_MISSING"},
+		{"properties", "SCH_FIELD_NOT_ALLOWED"},
+		{"enum", "SCH_INVALID_ENUM"},
+		{"format", "SCH_INVALID_FORMAT"},
+		{"type", "SCH_TYPE_NOT_SUPPORTED"},
+		{"allOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"oneOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"anyOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"pattern", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"unknown-keyword", "SCH_SCHEMA_VALIDATION_FAILED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			if got := schemaFieldToCode(tt.field); got != tt.want {
+				t.Errorf("schemaFieldToCode(%q) = %s, want %s", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSON" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSON", schemaErr.Errors)
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Code != "SCH_INVALID_JSON" {
+		t.Errorf("aggregate Code = %s, want SCH_INVALID_JSON", beErr.Code)
+	}
+}
+
+// TestExtractSchemaErrors_CompositeOriginFallsBackToGeneric exercises the
+// Origin != nil branch (oneOf/anyOf/allOf composite failures), previously
+// uncovered by any test. Since kin-openapi attributes the failure to the
+// composite keyword itself (not the nested cause), classification correctly
+// falls back to the generic SCH_SCHEMA_VALIDATION_FAILED rather than
+// guessing at whichever nested branch failed.
+func TestExtractSchemaErrors_CompositeOriginFallsBackToGeneric(t *testing.T) {
+	sub := openapi3.NewObjectSchema().WithProperty("name", openapi3.NewStringSchema())
+	sub.Required = []string{"name"}
+
+	parent := openapi3.NewObjectSchema()
+	parent.AllOf = openapi3.SchemaRefs{openapi3.NewSchemaRef("", sub)}
+
+	err := parent.VisitJSON(map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.SchemaField != "allOf" || schemaErr.Origin == nil {
+		t.Fatalf("expected SchemaField=allOf with a non-nil Origin, got SchemaField=%s, Origin=%v", schemaErr.SchemaField, schemaErr.Origin)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	got := schemaErrors[0]
+	t.Logf("extracted = %+v", got)
+	if got.Code != "SCH_SCHEMA_VALIDATION_FAILED" {
+		t.Errorf("Code = %s, want SCH_SCHEMA_VALIDATION_FAILED", got.Code)
+	}
+	if got.Message == "" {
+		t.Error("Message = \"\", want a non-empty message describing the nested cause")
+	}
+}
+
+// TestExtractSchemaErrors_CompositeOriginParsesNestedFieldPath exercises the
+// "Error at \"/path\": reason" string-parsing branch specifically — triggered
+// when the nested cause inside an allOf/oneOf failure occurred on a property
+// deep enough to have a tagged reversePath. Previously uncovered by any test.
+func TestExtractSchemaErrors_CompositeOriginParsesNestedFieldPath(t *testing.T) {
+	innerSub := openapi3.NewObjectSchema().WithProperty("name", openapi3.NewStringSchema())
+	innerSub.Required = []string{"name"}
+	sub := openapi3.NewObjectSchema().WithProperty("nested", innerSub)
+
+	parent := openapi3.NewObjectSchema()
+	parent.AllOf = openapi3.SchemaRefs{openapi3.NewSchemaRef("", sub)}
+
+	err := parent.VisitJSON(map[string]interface{}{"nested": map[string]interface{}{}})
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.Origin == nil || !strings.Contains(schemaErr.Origin.Error(), `Error at "`) {
+		t.Fatalf(`expected Origin.Error() to contain 'Error at "', got: %v`, schemaErr.Origin)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	got := schemaErrors[0]
+	t.Logf("extracted = %+v", got)
+	if got.Details == nil || got.Details.Path != "nested/name" {
+		t.Errorf("Details = %+v, want Path=nested/name", got.Details)
+	}
+	// kin-openapi's SchemaError.Error() appends a verbose schema/value dump
+	// after the reason — check the extracted reason is the prefix, not an
+	// exact match against that library-formatted tail.
+	if !strings.HasPrefix(got.Message, `property "name" is missing`) {
+		t.Errorf("Message = %q, want it to start with %q", got.Message, `property "name" is missing`)
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -328,6 +328,7 @@ func TestSchemaFieldToCode(t *testing.T) {
 		{"required", "SCH_REQUIRED_FIELD_MISSING"},
 		{"properties", "SCH_FIELD_NOT_ALLOWED"},
 		{"enum", "SCH_INVALID_ENUM"},
+		{"const", "SCH_INVALID_ENUM"},
 		{"format", "SCH_INVALID_FORMAT"},
 		{"type", "SCH_TYPE_NOT_SUPPORTED"},
 		{"allOf", "SCH_SCHEMA_VALIDATION_FAILED"},
@@ -370,6 +371,34 @@ func TestValidate_InvalidJSON(t *testing.T) {
 	beErr := schemaErr.BecknError()
 	if beErr.Code != "SCH_INVALID_JSON" {
 		t.Errorf("aggregate Code = %s, want SCH_INVALID_JSON", beErr.Code)
+	}
+}
+
+// TestValidate_NumericOverflowFailsSecondUnmarshal exercises Validate()'s
+// second json.Unmarshal call (into `any`, for schema validation) failing
+// independently of the first (into the narrow `payload` struct, used only to
+// extract context.action). A numeric literal outside float64 range decodes
+// fine into `payload` — which ignores unrelated fields — but fails when
+// decoded into `any`, which must convert every value.
+func TestValidate_NumericOverflowFailsSecondUnmarshal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"select"},"message":{"order":{}},"extra":1e400}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSON" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSON", schemaErr.Errors)
 	}
 }
 
@@ -456,6 +485,56 @@ func TestExtractSchemaErrors_CompositeOriginParsesNestedFieldPath(t *testing.T) 
 	// exact match against that library-formatted tail.
 	if !strings.HasPrefix(got.Message, `property "name" is missing`) {
 		t.Errorf("Message = %q, want it to start with %q", got.Message, `property "name" is missing`)
+	}
+}
+
+// TestExtractSchemaErrors_ConstViolation confirms a JSON-schema "const"
+// violation — SchemaField "const", no dedicated SCH_* code in the taxonomy —
+// classifies as SCH_INVALID_ENUM, since const is enum-of-one.
+func TestExtractSchemaErrors_ConstViolation(t *testing.T) {
+	sub := openapi3.NewStringSchema()
+	sub.Const = "search"
+
+	err := sub.VisitJSON("select")
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.SchemaField != "const" {
+		t.Fatalf("expected SchemaField=const, got %s", schemaErr.SchemaField)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	if got := schemaErrors[0].Code; got != "SCH_INVALID_ENUM" {
+		t.Errorf("Code = %s, want SCH_INVALID_ENUM", got)
+	}
+}
+
+// TestExtractSchemaErrors_BecknErrorPassthrough closes the coverage gap on
+// extractSchemaErrors' *model.Error passthrough branch (used to carry
+// validateReferencedObject's already-classified domain/JSON-LD/@type errors
+// into the aggregate SchemaValidationErr) — previously exercised by no test.
+func TestExtractSchemaErrors_BecknErrorPassthrough(t *testing.T) {
+	original := model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", "domain not allowed: malicious.com")
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(original, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	if schemaErrors[0] != *original {
+		t.Errorf("extractSchemaErrors did not pass through *model.Error as-is: got %+v, want %+v", schemaErrors[0], *original)
 	}
 }
 


### PR DESCRIPTION
Closes #863. Part of the #861 EPIC. Builds on #862/#876 (already merged into this branch).

## Migration required

This PR changes the wire-visible `code` field of schemav2validator's schema-validation NACK responses:

- **`error.code` is no longer a fixed generic string.** Previously every schemav2validator validation failure emitted `"Bad Request"` unconditionally. It now emits a specific `SCH_*` value depending on the cause (see below). Any consumer matching on the literal `"Bad Request"` for these responses needs to switch to matching on the specific `SCH_*` codes instead.
- **Malformed-JSON requests change both error type and message format.** Previously these returned `*model.BadReqErr` with message `"BAD Request: <detail>"`. They now return `*model.SchemaValidationErr` with code `SCH_INVALID_JSON` and an unprefixed message. Any caller type-asserting on `*model.BadReqErr` or string-matching the `"BAD Request: "` prefix for this specific failure path needs to update.

HTTP status codes are unaffected — only the JSON body's `code`/`message` change.

## Scope
Only `pkg/plugin/implementation/schemav2validator/` — the v1 `schemavalidator` plugin (old-gen Beckn networks) is explicitly out of scope, per #863's updated description.

## What changed

- **`schemav2validator.go`**: new `schemaFieldToCode()` maps `openapi3.SchemaError.SchemaField` (the JSON-schema keyword that failed) to the corresponding `SCH_*` code via a lookup table:
  - `required` → `SCH_REQUIRED_FIELD_MISSING`
  - `properties` (additionalProperties rejection) → `SCH_FIELD_NOT_ALLOWED`
  - `enum` → `SCH_INVALID_ENUM`
  - `const` → `SCH_INVALID_ENUM` (const is JSON Schema's own sugar for an enum with one allowed value; there's no dedicated taxonomy code for it)
  - `format` → `SCH_INVALID_FORMAT`
  - `type` → `SCH_TYPE_NOT_SUPPORTED`
  - everything else (including composite `oneOf`/`allOf`/`anyOf`, which kin-openapi doesn't attribute to one single underlying cause) → `SCH_SCHEMA_VALIDATION_FAILED`
  - Both `json.Unmarshal` failure sites in `Validate()` (extracting `context.action`, and decoding for schema validation) now return `SCH_INVALID_JSON` instead of a generic `BadReqErr` — previously only the first site was converted; the second is independently reachable (e.g. a numeric literal outside float64 range fails `any`-decoding while passing the narrower struct decode) and is now handled consistently.
- **`extended_schema.go`**: `validateReferencedObject`'s domain-object checks now return classified `*model.Error` values instead of plain errors: invalid/disallowed `@context` → `SCH_INVALID_JSONLD_CONTEXT`, schema load failure → `SCH_SCHEMA_ADAPTATION_FAILED`, unresolvable `@type` → `SCH_INVALID_ENTITY_TYPE`. `extractSchemaErrors` gained a passthrough branch for these pre-classified errors.
- **`pkg/model/error.go`**: `SchemaValidationErr.BecknError()`'s aggregate `Code` is now the first non-empty per-cause code (falling back to the legacy string only if none is set) — the aggregation approach agreed on for #863. `Message`/`Details.Path` aggregation is unchanged; only `Code` selection changed. Also adds `model.NewCodedError(code, message string) *Error`, a small shared constructor for the now-6 call sites building a classified `*model.Error` directly, replacing ad hoc struct literals.

## Also closes a coverage gap from #862's review
`extractSchemaErrors`'s `Origin != nil` branch (composite `oneOf`/`allOf` schema failures) had 0% test coverage, flagged during #862's review rounds. Two tests close it: one confirms the generic-fallback classification for composite failures, one exercises the nested `"Error at \"..."` path/message string-parsing that was previously never exercised.

## Testing
- `go build` / `go vet` clean.
- Full repo test suite passes (one transient, unrelated flake in `opapolicychecker` — a temp-path-length-sensitive test — confirmed reproducible on the base branch too, unrelated to this diff).
- New/updated tests: `schemaFieldToCode` table test (including `const`), `SCH_INVALID_JSON` end-to-end for both unmarshal sites, `SCH_REQUIRED_FIELD_MISSING` end-to-end + aggregate-code assertion, all three `extended_schema.go` domain-error codes, aggregation "first non-empty code wins" (3 cases), the two `Origin`-branch coverage tests above, a direct unit test for `extractSchemaErrors`' `*model.Error` passthrough branch (previously 0% covered), and an end-to-end `validateExtendedSchemas` test confirming a domain-not-allowed failure's code and path survive the full production path.

Marked as draft — same review-cycle pattern as #876 before this comes out of draft.
