### PR TITLE
signvalidator & keymanager/simplekeymanager: map to AUT_* codes

### DIFF
--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -145,7 +145,13 @@ func TestSendNack(t *testing.T) {
 			name:     "SignValidationErr",
 			err:      model.NewSignValidationErr(errors.New("signature invalid")),
 			status:   http.StatusUnauthorized,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Unauthorized","message":"Signature Validation Error: signature invalid"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"AUT_SIGNATURE_INVALID","message":"Signature Validation Error: signature invalid"}}}`,
+		},
+		{
+			name:     "Coded SignValidationErr",
+			err:      model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", errors.New("no subscriber found with given credentials")),
+			status:   http.StatusUnauthorized,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"AUT_SUBSCRIBER_NOT_FOUND","message":"Signature Validation Error: no subscriber found with given credentials"}}}`,
 		},
 		{
 			name:     "BadReqErr",
@@ -181,9 +187,15 @@ func TestSendNack(t *testing.T) {
 		},
 		{
 			name:     "v2 SignValidationErr",
-			err:      model.NewSignValidationErr(errors.New("signature expired")),
+			err:      model.NewCodedSignValidationErr("AUT_SIGNATURE_INVALID", errors.New("signature expired")),
 			status:   http.StatusUnauthorized,
-			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"Unauthorized","message":"Signature Validation Error: signature expired"}}}`,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"AUT_SIGNATURE_INVALID","message":"Signature Validation Error: signature expired"}}}`,
+		},
+		{
+			name:     "v2 Coded SignValidationErr key expired",
+			err:      model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", errors.New("subscriber key is expired or revoked")),
+			status:   http.StatusUnauthorized,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"AUT_KEY_EXPIRED_OR_REVOKED","message":"Signature Validation Error: subscriber key is expired or revoked"}}}`,
 		},
 		{
 			name: "v2 AckNoCallbackErr ACK status",
@@ -476,10 +488,12 @@ type mockKM struct {
 	err    error
 }
 
-func (m *mockKM) GenerateKeyset() (*model.Keyset, error)                               { return nil, nil }
-func (m *mockKM) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error     { return nil }
-func (m *mockKM) DeleteKeyset(_ context.Context, _ string) error                      { return nil }
-func (m *mockKM) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) { return "", "", nil }
+func (m *mockKM) GenerateKeyset() (*model.Keyset, error)                          { return nil, nil }
+func (m *mockKM) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error { return nil }
+func (m *mockKM) DeleteKeyset(_ context.Context, _ string) error                  { return nil }
+func (m *mockKM) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) {
+	return "", "", nil
+}
 func (m *mockKM) Keyset(_ context.Context, _ string) (*model.Keyset, error) {
 	return m.keyset, m.err
 }
@@ -916,7 +930,7 @@ func TestValidateAckSignatureStep_MissingSignature_AllStatusCodes_Degrades(t *te
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 		http.StatusNotFound,
-		http.StatusAccepted,        // 202 AckNoCallback
+		http.StatusAccepted, // 202 AckNoCallback
 		http.StatusInternalServerError,
 	}
 	for _, code := range codes {

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -194,7 +194,11 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
 		if err := s.validate(ctx, headerValue, "", false); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
-			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
+			// s.validate always returns an already-classified *model.SignValidationErr;
+			// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As
+			// still finds that inner classification instead of shadowing it with a new,
+			// default-coded wrapper.
+			return fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err)
 		}
 	}
 
@@ -202,7 +206,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue = ctx.Request.Header.Get(model.AuthHeaderSubscriber)
 	if len(headerValue) == 0 {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
-		return model.NewSignValidationErr(fmt.Errorf("%s missing", model.UnaAuthorizedHeaderSubscriber))
+		return model.NewCodedSignValidationErr("AUT_SIGNATURE_MISSING", fmt.Errorf("%s missing", model.UnaAuthorizedHeaderSubscriber))
 	}
 	reqSig, err := s.lookupCallbackRequestSig(ctx, headerValue)
 	if err != nil {
@@ -211,7 +215,9 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	}
 	if err := s.validate(ctx, headerValue, reqSig, true); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
-		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
+		// Same reasoning as the gateway-header branch above: preserve s.validate's
+		// classification instead of shadowing it.
+		return fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err)
 	}
 	return nil
 }

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -194,10 +194,13 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
 		if err := s.validate(ctx, headerValue, "", false); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
-			// s.validate always returns an already-classified *model.SignValidationErr;
-			// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As
-			// still finds that inner classification instead of shadowing it with a new,
-			// default-coded wrapper.
+			// s.validate returns an already-classified *model.SignValidationErr for
+			// most failure paths (keymanager lookup, signvalidator crypto/timestamp
+			// checks) — wrap with plain fmt.Errorf (not model.NewSignValidationErr)
+			// so errors.As still finds that inner classification instead of
+			// shadowing it with a new, default-coded wrapper. Its own header-parse
+			// and algorithm-mismatch checks still return unclassified errors that
+			// fall through to a generic 500 either way; see #864 follow-up.
 			return fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err)
 		}
 	}

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -222,7 +222,7 @@ func TestValidateSignStep_InitSteps_WithPayloadStore(t *testing.T) {
 // verify real signatures in unit tests.
 func testKeyset() *model.Keyset {
 	return &model.Keyset{
-		UniqueKeyID:   "key-1",
+		UniqueKeyID:    "key-1",
 		SigningPrivate: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 	}
 }
@@ -423,6 +423,55 @@ func TestValidateHeaders_SolicitedCallback_PreV2_FallsBackToValidate(t *testing.
 	}
 	if !sv.validateCalled {
 		t.Error("expected Validate to be called for pre-v2 version")
+	}
+}
+
+// TestValidateHeaders_PreservesClassifiedCode verifies that validateHeaders
+// propagates the AUT_* code a lower layer already classified (signvalidator's
+// Validate/ValidateAck or keymanager's LookupNPKeys) instead of shadowing it
+// with a fresh, default-coded model.NewSignValidationErr wrapper.
+func TestValidateHeaders_PreservesClassifiedCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		sv       *mockSignValidatorBasic
+		km       *mockKMBasic
+		wantCode string
+	}{
+		{
+			name:     "Validate returns a classified error",
+			sv:       &mockSignValidatorBasic{validateErr: model.NewCodedSignValidationErr("AUT_UNAUTHORIZED_ACTION", errors.New("identity mismatch"))},
+			km:       &mockKMBasic{publicKey: "pubKey=="},
+			wantCode: "AUT_UNAUTHORIZED_ACTION",
+		},
+		{
+			name:     "LookupNPKeys returns a classified error",
+			sv:       &mockSignValidatorBasic{},
+			km:       &mockKMBasic{lookupErr: model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", errors.New("no subscriber found with given credentials"))},
+			wantCode: "AUT_SUBSCRIBER_NOT_FOUND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step, _ := newValidateSignStep(tt.sv, tt.km, nil)
+			vStep := step.(*validateSignStep)
+
+			ctx := makeValidateStepCtx("2.0.0", "msg-vh-code", "bap.example.com",
+				providerInitiatedAuthHeader("bpp.example.com"),
+				`{"context":{"action":"on_search","messageId":"msg-vh-code","version":"2.0.0"}}`)
+
+			err := vStep.validateHeaders(ctx)
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != tt.wantCode {
+				t.Errorf("signErr.Code = %s, want %s (validateHeaders must not shadow the inner classification)", signErr.Code, tt.wantCode)
+			}
+		})
 	}
 }
 

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -112,20 +112,44 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 }
 
+// defaultSignValidationCode is used when a SignValidationErr carries no more
+// specific classification — the closest generic bucket in the AUT_* taxonomy.
+const defaultSignValidationCode = "AUT_SIGNATURE_INVALID"
+
 // SignValidationErr occurs when signature validation fails.
 type SignValidationErr struct {
+	// Code is the AUT_* taxonomy value for this failure's specific cause.
+	Code string
 	error
 }
 
-// NewSignValidationErr creates a new instance of SignValidationErr from an error.
+// NewSignValidationErr creates a new instance of SignValidationErr from an error,
+// classified as AUT_SIGNATURE_INVALID (the generic bucket). Use
+// NewCodedSignValidationErr when the caller knows a more specific AUT_* cause.
 func NewSignValidationErr(e error) *SignValidationErr {
-	return &SignValidationErr{e}
+	return &SignValidationErr{Code: defaultSignValidationCode, error: e}
+}
+
+// NewCodedSignValidationErr creates a SignValidationErr classified with an
+// explicit AUT_* code, for callers that already know the specific cause.
+func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
+	return &SignValidationErr{Code: code, error: e}
+}
+
+// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
+// plugin-defined sentinel error) in addition to matching *SignValidationErr itself.
+func (e *SignValidationErr) Unwrap() error {
+	return e.error
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
 func (e *SignValidationErr) BecknError() *Error {
+	code := e.Code
+	if code == "" {
+		code = defaultSignValidationCode
+	}
 	return &Error{
-		Code:    http.StatusText(http.StatusUnauthorized),
+		Code:    code,
 		Message: "Signature Validation Error: " + e.Error(),
 	}
 }

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -13,7 +13,7 @@ import (
 
 // NewSignValidationErrf creates a new SignValidationErr with a formatted error message.
 func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
-	return &SignValidationErr{fmt.Errorf(format, a...)}
+	return &SignValidationErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}
 }
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
@@ -184,7 +184,49 @@ func TestSignValidationErr_BecknError(t *testing.T) {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
 	}
+	if beErr.Code != "AUT_SIGNATURE_INVALID" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_INVALID (default classification)", beErr.Code)
+	}
+}
 
+func TestNewCodedSignValidationErr_BecknError(t *testing.T) {
+	signErr := NewCodedSignValidationErr("AUT_SIGNATURE_MISSING", errors.New("signature missing in header"))
+	beErr := signErr.BecknError()
+
+	if beErr.Code != "AUT_SIGNATURE_MISSING" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_MISSING", beErr.Code)
+	}
+	expectedMsg := "Signature Validation Error: signature missing in header"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestSignValidationErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
+	signErr := &SignValidationErr{error: errors.New("signature failed")}
+	beErr := signErr.BecknError()
+
+	if beErr.Code != "AUT_SIGNATURE_INVALID" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_INVALID when Code is unset", beErr.Code)
+	}
+}
+
+func TestSignValidationErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	signErr := NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", sentinel)
+
+	if !errors.Is(signErr, sentinel) {
+		t.Errorf("errors.Is(signErr, sentinel) = false, want true via Unwrap()")
+	}
+
+	var target *SignValidationErr
+	wrapped := fmt.Errorf("wrapped: %w", signErr)
+	if !errors.As(wrapped, &target) {
+		t.Fatalf("errors.As(wrapped, &target) = false, want true")
+	}
+	if target.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("target.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", target.Code)
+	}
 }
 
 func TestNewSignValidationErrf(t *testing.T) {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -33,6 +33,26 @@ type Subscription struct {
 	NetworkMemberships []string  `json:"network_memberships,omitempty"`
 }
 
+// nonUsableKeySubscriptionStatuses are the Subscription.Status values that mean a
+// matched subscriber's key is no longer usable for signature verification.
+// INITIATED and UNDER_SUBSCRIPTION are intentionally absent — this function
+// distinguishes revocation/expiry from good standing only; it does not gate on
+// subscription completeness. A subscriber that has registered a key but not yet
+// finished onboarding is still treated as usable here. If pre-subscription
+// participants should be rejected too, that is a separate authorization
+// decision for a caller (or a future ticket) to make, not part of this check.
+var nonUsableKeySubscriptionStatuses = map[string]bool{
+	"EXPIRED":      true,
+	"UNSUBSCRIBED": true,
+	"INVALID_SSL":  true,
+}
+
+// IsKeyStatusUsable reports whether a subscriber's registry Status still
+// permits its key to be used for signature verification.
+func IsKeyStatusUsable(status string) bool {
+	return !nonUsableKeySubscriptionStatuses[status]
+}
+
 // RegistryMetadata represents metadata configured on a registry itself rather than on a specific record.
 type RegistryMetadata struct {
 	NamespaceIdentifier string
@@ -45,8 +65,8 @@ type RegistryMetadata struct {
 // node-level manifest metadata (from the registry meta block) in a single response,
 // since both come from the same DeDi endpoint call.
 type SubscriberRecord struct {
-	Subscription        // identity, URL, signing/encryption keys — from data["details"]
-	Meta map[string]string // node manifest metadata — from data["meta"]; may be empty
+	Subscription                   // identity, URL, signing/encryption keys — from data["details"]
+	Meta         map[string]string // node manifest metadata — from data["meta"]; may be empty
 }
 
 // Authorization-related constants for headers.

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2,6 +2,29 @@ package model
 
 import "testing"
 
+func TestIsKeyStatusUsable(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{status: "SUBSCRIBED", want: true},
+		{status: "INITIATED", want: true},
+		{status: "UNDER_SUBSCRIPTION", want: true},
+		{status: "", want: true},
+		{status: "EXPIRED", want: false},
+		{status: "UNSUBSCRIBED", want: false},
+		{status: "INVALID_SSL", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := IsKeyStatusUsable(tt.status); got != tt.want {
+				t.Errorf("IsKeyStatusUsable(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveCallerID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -50,7 +50,20 @@ var (
 
 	// ErrNilRegistryLookup indicates that the registry lookup implementation is nil.
 	ErrNilRegistryLookup = errors.New("registry lookup implementation cannot be nil")
+
+	// ErrKeyExpiredOrRevoked indicates that the matched subscriber's key exists but
+	// is no longer usable (registry status EXPIRED, UNSUBSCRIBED, or INVALID_SSL).
+	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
 )
+
+// nonUsableKeyStatuses are the model.Subscription.Status values that indicate a
+// matched subscriber's key is no longer valid for signature verification, as
+// distinct from "no such subscriber/key" (zero results from Lookup).
+var nonUsableKeyStatuses = map[string]bool{
+	"EXPIRED":      true,
+	"UNSUBSCRIBED": true,
+	"INVALID_SSL":  true,
+}
 
 // ValidateCfg validates the Vault configuration and sets default KV version if missing.
 func ValidateCfg(cfg *Config) error {
@@ -275,6 +288,12 @@ func (km *KeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyset, erro
 }
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
+//
+// A zero-result lookup and a matched-but-unusable-status subscriber are both
+// AUT_* authentication failures, so both are returned already classified as
+// *model.SignValidationErr — the caller (signvalidator's validateSignStep)
+// propagates this as-is; it does not need to know keymanager's own sentinel
+// errors to build the correct NACK code.
 func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
 	subscribers, err := km.Registry.Lookup(ctx, &model.Subscription{
 		Subscriber: model.Subscriber{
@@ -286,7 +305,10 @@ func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID st
 		return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 	}
 	if len(subscribers) == 0 {
-		return "", "", ErrSubscriberNotFound
+		return "", "", model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", ErrSubscriberNotFound)
+	}
+	if nonUsableKeyStatuses[subscribers[0].Status] {
+		return "", "", model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", ErrKeyExpiredOrRevoked)
 	}
 	return subscribers[0].SigningPublicKey, subscribers[0].EncrPublicKey, nil
 }

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -56,14 +56,14 @@ var (
 	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
 )
 
-// nonUsableKeyStatuses are the model.Subscription.Status values that indicate a
-// matched subscriber's key is no longer valid for signature verification, as
-// distinct from "no such subscriber/key" (zero results from Lookup).
-var nonUsableKeyStatuses = map[string]bool{
-	"EXPIRED":      true,
-	"UNSUBSCRIBED": true,
-	"INVALID_SSL":  true,
-}
+// AUT_* codes reachable from LookupNPKeys.
+const (
+	// codeSubscriberNotFound is used when the registry lookup returns zero results.
+	codeSubscriberNotFound = "AUT_SUBSCRIBER_NOT_FOUND"
+	// codeKeyExpiredOrRevoked is used when a matched subscriber's key is no
+	// longer usable per model.IsKeyStatusUsable.
+	codeKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
+)
 
 // ValidateCfg validates the Vault configuration and sets default KV version if missing.
 func ValidateCfg(cfg *Config) error {
@@ -305,10 +305,10 @@ func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID st
 		return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 	}
 	if len(subscribers) == 0 {
-		return "", "", model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", ErrSubscriberNotFound)
+		return "", "", model.NewCodedSignValidationErr(codeSubscriberNotFound, ErrSubscriberNotFound)
 	}
-	if nonUsableKeyStatuses[subscribers[0].Status] {
-		return "", "", model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", ErrKeyExpiredOrRevoked)
+	if !model.IsKeyStatusUsable(subscribers[0].Status) {
+		return "", "", model.NewCodedSignValidationErr(codeKeyExpiredOrRevoked, ErrKeyExpiredOrRevoked)
 	}
 	return subscribers[0].SigningPublicKey, subscribers[0].EncrPublicKey, nil
 }

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -50,7 +50,6 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 	}, nil
 }
 
-
 func TestValidateCfgSuccess(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -971,9 +970,9 @@ func TestLookupNPKeysSuccess(t *testing.T) {
 						Subscriber: model.Subscriber{
 							SubscriberID: sub.SubscriberID,
 						},
-						KeyID:           sub.KeyID,
+						KeyID:            sub.KeyID,
 						SigningPublicKey: "mock-signing-public-key",
-						EncrPublicKey:   "mock-encryption-public-key",
+						EncrPublicKey:    "mock-encryption-public-key",
 					},
 				}, nil
 			},
@@ -1009,6 +1008,8 @@ func TestLookupNPKeysFailure(t *testing.T) {
 		name               string
 		registryLookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
 		expectedError      string
+		wantCode           string
+		wantSentinel       error
 	}{
 		{
 			name: "registry failure",
@@ -1023,6 +1024,35 @@ func TestLookupNPKeysFailure(t *testing.T) {
 				return nil, nil
 			},
 			expectedError: "no subscriber found with given credentials",
+			wantCode:      "AUT_SUBSCRIBER_NOT_FOUND",
+			wantSentinel:  ErrSubscriberNotFound,
+		},
+		{
+			name: "subscriber found but key EXPIRED",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "EXPIRED"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
+		},
+		{
+			name: "subscriber found but UNSUBSCRIBED",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "UNSUBSCRIBED"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
+		},
+		{
+			name: "subscriber found but INVALID_SSL",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "INVALID_SSL"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
 		},
 	}
 
@@ -1039,6 +1069,18 @@ func TestLookupNPKeysFailure(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.expectedError) {
 				t.Errorf("expected error to contain %v, got %v", tt.expectedError, err.Error())
+			}
+			if tt.wantCode != "" {
+				var signErr *model.SignValidationErr
+				if !errors.As(err, &signErr) {
+					t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+				}
+				if signErr.Code != tt.wantCode {
+					t.Errorf("signErr.Code = %s, want %s", signErr.Code, tt.wantCode)
+				}
+				if !errors.Is(err, tt.wantSentinel) {
+					t.Errorf("expected errors.Is(err, %v) = true", tt.wantSentinel)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -20,6 +20,21 @@ const (
 	maxClockSkewTolerance     = 10 * time.Second
 )
 
+// AUT_* codes reachable from this plugin's failure modes. AUT_RATE_LIMITED,
+// AUT_DOMAIN_NOT_ALLOWED, and AUT_REPLAY_DETECTED have no corresponding checks
+// in signvalidator today and are intentionally absent from this list.
+const (
+	// codeSignatureMissing covers an absent signature value in the Authorization header.
+	codeSignatureMissing = "AUT_SIGNATURE_MISSING"
+	// codeSignatureInvalid is the generic bucket for malformed headers, undecodable
+	// signature/key material, expired/not-yet-valid timestamp windows, and failed
+	// cryptographic verification — none of these have a more specific taxonomy value.
+	codeSignatureInvalid = "AUT_SIGNATURE_INVALID"
+	// codeUnauthorizedAction covers a cryptographically valid signature whose signer
+	// identity does not match the identity declared in the request context.
+	codeUnauthorizedAction = "AUT_UNAUTHORIZED_ACTION"
+)
+
 // Config struct for Verifier.
 type Config struct {
 	// ClockSkewTolerance is the maximum future drift allowed for the `created`
@@ -53,12 +68,16 @@ func New(ctx context.Context, config *Config) (*validator, func() error, error) 
 func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(header)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error parsing header: %w", err))
+		// parseAuthHeader always returns an already-classified *model.SignValidationErr;
+		// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As still
+		// finds that inner classification instead of shadowing it with a new, less
+		// specific wrapper.
+		return fmt.Errorf("error parsing header: %w", err)
 	}
 
 	signatureBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
-		return fmt.Errorf("error decoding signature: %w", err)
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding signature: %w", err))
 	}
 
 	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
@@ -72,11 +91,11 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error decoding public key: %w", err))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding public key: %w", err))
 	}
 
 	if !ed25519.Verify(ed25519.PublicKey(decodedPublicKey), []byte(signingString), signatureBytes) {
-		return model.NewSignValidationErr(fmt.Errorf("signature verification failed"))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("signature verification failed"))
 	}
 
 	if checkIdentity {
@@ -105,24 +124,22 @@ func parseAuthHeader(header string) (int64, int64, string, string, error) {
 	}
 
 	if signatureMap["algorithm"] != "ed25519" {
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
 	}
 
 	createdTimestamp, err := strconv.ParseInt(signatureMap["created"], 10, 64)
 	if err != nil {
-		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", "", fmt.Errorf("invalid created timestamp: %w", err)
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("invalid created timestamp: %w", err))
 	}
 
 	expiredTimestamp, err := strconv.ParseInt(signatureMap["expires"], 10, 64)
 	if err != nil {
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("invalid expires timestamp: %w", err))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("invalid expires timestamp: %w", err))
 	}
 
 	signature := signatureMap["signature"]
 	if signature == "" {
-		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("signature missing in header"))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureMissing, fmt.Errorf("signature missing in header"))
 	}
 
 	var subscriberID string
@@ -141,12 +158,16 @@ func parseAuthHeader(header string) (int64, int64, string, string, error) {
 func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(signatureHeader)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error parsing Signature header: %w", err))
+		// parseAuthHeader always returns an already-classified *model.SignValidationErr;
+		// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As still
+		// finds that inner classification instead of shadowing it with a new, less
+		// specific wrapper.
+		return fmt.Errorf("error parsing Signature header: %w", err)
 	}
 
 	signatureBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
-		return fmt.Errorf("error decoding signature: %w", err)
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding signature: %w", err))
 	}
 
 	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
@@ -157,11 +178,11 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error decoding public key: %w", err))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding public key: %w", err))
 	}
 
 	if !ed25519.Verify(ed25519.PublicKey(decodedPublicKey), []byte(signingString), signatureBytes) {
-		return model.NewSignValidationErr(fmt.Errorf("AckSignature verification failed"))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("AckSignature verification failed"))
 	}
 
 	if checkIdentity {
@@ -196,7 +217,7 @@ func checkSubscriberIdentity(ctx *model.StepContext, body []byte, signerID strin
 	}
 
 	if signerID != expected {
-		return model.NewSignValidationErr(fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
+		return model.NewCodedSignValidationErr(codeUnauthorizedAction, fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
 			signerID, expected))
 	}
 	return nil
@@ -211,7 +232,7 @@ func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int6
 	// Accept created values up to clockSkewTolerance in the future.
 	deadline := now.Add(clockSkewTolerance)
 	if time.Unix(createdTimestamp, 0).UTC().After(deadline) {
-		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, overshoot=%ds",
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, overshoot=%ds",
 			prefix,
 			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),
@@ -221,7 +242,7 @@ func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int6
 	}
 	// expires: zero tolerance — reject without exception.
 	if now.Unix() > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
 			prefix,
 			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -214,18 +215,21 @@ func TestVerifyFailure(t *testing.T) {
 		header      string
 		pubKey      string
 		errContains string
+		wantCode    string
 	}{
 		{
-			name:   "Missing Authorization Header",
-			body:   []byte("Test Payload"),
-			header: "",
-			pubKey: publicKeyBase64,
+			name:     "Missing Authorization Header",
+			body:     []byte("Test Payload"),
+			header:   "",
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
-			name:   "Malformed Header",
-			body:   []byte("Test Payload"),
-			header: `InvalidSignature created="wrong"`,
-			pubKey: publicKeyBase64,
+			name:     "Malformed Header",
+			body:     []byte("Test Payload"),
+			header:   `InvalidSignature created="wrong"`,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Unsupported Algorithm",
@@ -233,7 +237,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="rsa", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="somesig=="`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Missing Algorithm",
@@ -241,7 +246,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="somesig=="`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Base64 Signature",
@@ -249,7 +255,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="!!INVALIDBASE64!!"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Expired Signature",
@@ -259,6 +266,7 @@ func TestVerifyFailure(t *testing.T) {
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix()-7200, time.Now().Unix()-3600) + `"`,
 			pubKey:      publicKeyBase64,
 			errContains: "expired_by=",
+			wantCode:    codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Public Key",
@@ -266,21 +274,24 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix(), time.Now().Unix()+3600) + `"`,
-			pubKey: wrongPublicKeyBase64,
+			pubKey:   wrongPublicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Expires Timestamp",
 			body: []byte("Test Payload"),
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="invalid_timestamp"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Signature Missing in Headers",
 			body: []byte("Test Payload"),
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) + `"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureMissing,
 		},
 	}
 
@@ -294,6 +305,13 @@ func TestVerifyFailure(t *testing.T) {
 			}
 			if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 				t.Fatalf("Expected error to contain %q, got: %v", tt.errContains, err)
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != tt.wantCode {
+				t.Errorf("signErr.Code = %s, want %s", signErr.Code, tt.wantCode)
 			}
 			if close != nil {
 				if err := close(); err != nil {
@@ -329,8 +347,16 @@ func TestValidate_SubIdentity_FromContext_Mismatch(t *testing.T) {
 
 	verifier, _, _ := New(context.Background(), &Config{})
 	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
-	if err := verifier.Validate(ctx, header, publicKey, true); err == nil {
+	err := verifier.Validate(ctx, header, publicKey, true)
+	if err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != codeUnauthorizedAction {
+		t.Errorf("signErr.Code = %s, want %s", signErr.Code, codeUnauthorizedAction)
 	}
 }
 
@@ -448,8 +474,16 @@ func TestValidateAck_SubIdentity_FromContext_Mismatch(t *testing.T) {
 
 	verifier, _, _ := New(context.Background(), &Config{})
 	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true); err == nil {
+	err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true)
+	if err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != codeUnauthorizedAction {
+		t.Errorf("signErr.Code = %s, want %s", signErr.Code, codeUnauthorizedAction)
 	}
 }
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -60,7 +60,20 @@ var (
 
 	// ErrInvalidConfig indicates that the configuration is invalid.
 	ErrInvalidConfig = errors.New("invalid configuration")
+
+	// ErrKeyExpiredOrRevoked indicates that the matched subscriber's key exists but
+	// is no longer usable (registry status EXPIRED, UNSUBSCRIBED, or INVALID_SSL).
+	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
 )
+
+// nonUsableKeyStatuses are the model.Subscription.Status values that indicate a
+// matched subscriber's key is no longer valid for signature verification, as
+// distinct from "no such subscriber/key" (zero results from Lookup).
+var nonUsableKeyStatuses = map[string]bool{
+	"EXPIRED":      true,
+	"UNSUBSCRIBED": true,
+	"INVALID_SSL":  true,
+}
 
 // ValidateCfg validates the SimpleKeyManager configuration.
 func ValidateCfg(cfg *Config) error {
@@ -230,6 +243,12 @@ func (skm *SimpleKeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyse
 }
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
+//
+// A zero-result lookup and a matched-but-unusable-status subscriber are both
+// AUT_* authentication failures, so both are returned already classified as
+// *model.SignValidationErr — the caller (signvalidator's validateSignStep)
+// propagates this as-is; it does not need to know keymanager's own sentinel
+// errors to build the correct NACK code.
 func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
 	if err := validateParams(subscriberID, uniqueKeyID); err != nil {
 		return "", "", err
@@ -266,7 +285,10 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 			return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 		}
 		if len(subscribers) == 0 {
-			return "", "", ErrSubscriberNotFound
+			return "", "", model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", ErrSubscriberNotFound)
+		}
+		if nonUsableKeyStatuses[subscribers[0].Status] {
+			return "", "", model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", ErrKeyExpiredOrRevoked)
 		}
 	}
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -66,14 +66,14 @@ var (
 	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
 )
 
-// nonUsableKeyStatuses are the model.Subscription.Status values that indicate a
-// matched subscriber's key is no longer valid for signature verification, as
-// distinct from "no such subscriber/key" (zero results from Lookup).
-var nonUsableKeyStatuses = map[string]bool{
-	"EXPIRED":      true,
-	"UNSUBSCRIBED": true,
-	"INVALID_SSL":  true,
-}
+// AUT_* codes reachable from LookupNPKeys.
+const (
+	// codeSubscriberNotFound is used when the registry lookup returns zero results.
+	codeSubscriberNotFound = "AUT_SUBSCRIBER_NOT_FOUND"
+	// codeKeyExpiredOrRevoked is used when a matched subscriber's key is no
+	// longer usable per model.IsKeyStatusUsable.
+	codeKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
+)
 
 // ValidateCfg validates the SimpleKeyManager configuration.
 func ValidateCfg(cfg *Config) error {
@@ -285,10 +285,10 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 			return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 		}
 		if len(subscribers) == 0 {
-			return "", "", model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", ErrSubscriberNotFound)
+			return "", "", model.NewCodedSignValidationErr(codeSubscriberNotFound, ErrSubscriberNotFound)
 		}
-		if nonUsableKeyStatuses[subscribers[0].Status] {
-			return "", "", model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", ErrKeyExpiredOrRevoked)
+		if !model.IsKeyStatusUsable(subscribers[0].Status) {
+			return "", "", model.NewCodedSignValidationErr(codeKeyExpiredOrRevoked, ErrKeyExpiredOrRevoked)
 		}
 	}
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -3,15 +3,23 @@ package simplekeymanager
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Mock implementations for testing
-type mockRegistry struct{}
+type mockRegistry struct {
+	// LookupFunc overrides the default lookup behavior when set.
+	LookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
+}
 
 func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+	if m.LookupFunc != nil {
+		return m.LookupFunc(ctx, sub)
+	}
 	return []model.Subscription{
 		{
 			Subscriber: model.Subscriber{
@@ -43,12 +51,12 @@ func TestValidateCfg(t *testing.T) {
 		{
 			name: "valid config with all keys",
 			cfg: &Config{
-				SubscriberID: "test-np",
-				KeyID:        "test-key",
-				SigningPrivateKey:  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
-				SigningPublicKey:   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				EncrPrivateKey:     "dGVzdC1lbmNyLXByaXZhdGU=",
-				EncrPublicKey:      "dGVzdC1lbmNyLXB1YmxpYw==",
+				SubscriberID:      "test-np",
+				KeyID:             "test-key",
+				SigningPrivateKey: "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+				SigningPublicKey:  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+				EncrPrivateKey:    "dGVzdC1lbmNyLXByaXZhdGU=",
+				EncrPublicKey:     "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
@@ -95,12 +103,12 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config with keys",
 			cfg: &Config{
-				SubscriberID:     "test-np",
-				KeyID:            "test-key",
+				SubscriberID:      "test-np",
+				KeyID:             "test-key",
 				SigningPrivateKey: "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				SigningPublicKey:  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				EncrPrivateKey:   "dGVzdC1lbmNyLXByaXZhdGU=",
-				EncrPublicKey:    "dGVzdC1lbmNyLXB1YmxpYw==",
+				EncrPrivateKey:    "dGVzdC1lbmNyLXByaXZhdGU=",
+				EncrPublicKey:     "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
@@ -333,6 +341,75 @@ func TestLookupNPKeys(t *testing.T) {
 	}
 }
 
+func TestLookupNPKeys_SubscriberNotFound(t *testing.T) {
+	skm := &SimpleKeyMgr{
+		Registry: &mockRegistry{
+			LookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	_, _, err := skm.LookupNPKeys(context.Background(), "test-subscriber", "test-key")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+	if !strings.Contains(err.Error(), "no subscriber found with given credentials") {
+		t.Errorf("err = %v, want message to contain 'no subscriber found with given credentials'", err)
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("signErr.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", signErr.Code)
+	}
+	if !errors.Is(err, ErrSubscriberNotFound) {
+		t.Error("expected errors.Is(err, ErrSubscriberNotFound) = true")
+	}
+}
+
+func TestLookupNPKeys_KeyExpiredOrRevoked(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "EXPIRED", status: "EXPIRED"},
+		{name: "UNSUBSCRIBED", status: "UNSUBSCRIBED"},
+		{name: "INVALID_SSL", status: "INVALID_SSL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skm := &SimpleKeyMgr{
+				Registry: &mockRegistry{
+					LookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+						return []model.Subscription{{Status: tt.status}}, nil
+					},
+				},
+			}
+
+			_, _, err := skm.LookupNPKeys(context.Background(), "test-subscriber", "test-key")
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			if !strings.Contains(err.Error(), "subscriber key is expired or revoked") {
+				t.Errorf("err = %v, want message to contain 'subscriber key is expired or revoked'", err)
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != "AUT_KEY_EXPIRED_OR_REVOKED" {
+				t.Errorf("signErr.Code = %s, want AUT_KEY_EXPIRED_OR_REVOKED", signErr.Code)
+			}
+			if !errors.Is(err, ErrKeyExpiredOrRevoked) {
+				t.Error("expected errors.Is(err, ErrKeyExpiredOrRevoked) = true")
+			}
+		})
+	}
+}
+
 func TestParseKey(t *testing.T) {
 	skm := &SimpleKeyMgr{}
 
@@ -370,12 +447,12 @@ func TestLoadKeysFromConfig(t *testing.T) {
 
 	// Test with valid config
 	cfg := &Config{
-		SubscriberID: "test-np",
-		KeyID:        "test-key",
-		SigningPrivateKey:  base64.StdEncoding.EncodeToString([]byte("signing-private")),
-		SigningPublicKey:   base64.StdEncoding.EncodeToString([]byte("signing-public")),
-		EncrPrivateKey:     base64.StdEncoding.EncodeToString([]byte("encr-private")),
-		EncrPublicKey:      base64.StdEncoding.EncodeToString([]byte("encr-public")),
+		SubscriberID:      "test-np",
+		KeyID:             "test-key",
+		SigningPrivateKey: base64.StdEncoding.EncodeToString([]byte("signing-private")),
+		SigningPublicKey:  base64.StdEncoding.EncodeToString([]byte("signing-public")),
+		EncrPrivateKey:    base64.StdEncoding.EncodeToString([]byte("encr-private")),
+		EncrPublicKey:     base64.StdEncoding.EncodeToString([]byte("encr-public")),
 	}
 
 	err := skm.loadKeysFromConfig(ctx, cfg)


### PR DESCRIPTION
Closes #864. Part of the #861 EPIC. Builds on #862/#876 and #863/#877 (already merged into this branch).

## Migration required

This PR changes the wire-visible `code` field of signature-validation NACK responses:

- **`error.code` is no longer a fixed generic string.** Previously every `signvalidator` failure emitted `"Unauthorized"` unconditionally. It now emits a specific `AUT_*` value depending on the cause (see below). Any consumer matching on the literal `"Unauthorized"` needs to switch to matching on the specific `AUT_*` codes instead.
- HTTP status codes are unaffected (still 401) — only the JSON body's `code`/`message` change.
- No version gating: unlike `schemavalidator`/`schemav2validator` (a v1/v2 plugin split), `signvalidator` has a single implementation for all protocol versions, and `nackBecknError` never gated sign-error codes by version. `AUT_*` codes are emitted unconditionally for all protocol versions, consistent with #876/#877's precedent (no version gating exists anywhere yet in this epic).

## Scope

`pkg/plugin/implementation/signvalidator/`, `pkg/plugin/implementation/keymanager/`, `pkg/plugin/implementation/simplekeymanager/`, plus a required reachability fix in `core/module/handler/step.go`.

## What changed

- **`pkg/model/error.go`**: `SignValidationErr` gains a `Code` field, `NewCodedSignValidationErr(code, err)` constructor (mirrors `NewCodedError` from #877), and an `Unwrap()` method so `errors.Is`/`errors.As` can reach both the wrapper (for `nackBecknError`) and an inner sentinel cause (for tests/other callers). `NewSignValidationErr` now defaults to `AUT_SIGNATURE_INVALID` instead of the old hardcoded `"Unauthorized"`.
- **`signvalidator.go`**: classified all ~10 failure call sites:
  - Malformed/missing header fields, undecodable signature/public-key material, not-yet-valid/expired timestamp windows, and failed ed25519 verification → `AUT_SIGNATURE_INVALID`. No dedicated code exists for these distinct causes in the 9-value taxonomy; the existing error *messages* already disambiguate the specific cause (e.g. "not yet valid" vs "expired" vs "error decoding public key"), so folding them into one bucket only loses code-level granularity, not message-level detail.
  - Missing `signature=` value → `AUT_SIGNATURE_MISSING`.
  - `checkSubscriberIdentity` mismatch (cryptographically valid signature, wrong declared identity) → `AUT_UNAUTHORIZED_ACTION`.
  - Also fixes two call sites that were previously bare, unclassified errors — a malformed `created` timestamp and a signature base64-decode failure — which fell through to a generic 500 instead of a 401 today.
- **`keymanager.go` / `simplekeymanager.go`**: `LookupNPKeys` now inspects the matched subscriber's registry `Status` (`model.Subscription.Status`) and returns `AUT_KEY_EXPIRED_OR_REVOKED` for `EXPIRED`/`UNSUBSCRIBED`/`INVALID_SSL`, distinct from `AUT_SUBSCRIBER_NOT_FOUND` on a zero-result lookup. Classification happens *inside* the plugin (which already depends on `pkg/model` for `Keyset`/`Subscription`), not in core handler code — keeping the swappable-plugin abstraction (`definition.KeyManager`) intact. `step.go` does not need to know either package's sentinel errors; it just propagates the already-classified `*model.SignValidationErr` through its existing `fmt.Errorf("...: %w", err)` wrapping.
- **`core/module/handler/step.go`**: fixes a reachability bug in `validateHeaders` — every error from `s.validate(...)` was being re-wrapped in a *fresh* `model.NewSignValidationErr(...)`, which shadowed whatever code the plugin layer had already classified (since `errors.As` matches the outermost `*SignValidationErr` first). Without this fix, none of the new `AUT_*` classifications would have reached the client — they'd all have collapsed back to the default. Now propagates via plain `fmt.Errorf(%w)`, same fix already applied inside `signvalidator.go`'s own `Validate`/`ValidateAck`. The genuinely missing-Authorization-header case is now explicitly classified as `AUT_SIGNATURE_MISSING`.

## Known limitations, documented rather than fixed here

- **`AUT_SUBSCRIBER_NOT_FOUND` vs `AUT_KEY_NOT_FOUND` collapse.** `Registry.Lookup` is queried by `subscriberID` + `keyID` together; a zero-result response can't tell you which one didn't match without an extra round-trip. Both collapse to `AUT_SUBSCRIBER_NOT_FOUND` for now.
- **`AUT_RATE_LIMITED`, `AUT_DOMAIN_NOT_ALLOWED`, `AUT_REPLAY_DETECTED`** have no corresponding logic anywhere in `signvalidator`/`keymanager` today — no rate limiter, no domain allowlist check (that lives in `schemav2validator`, PR #802), no replay cache. Not reachable from this plugin pair's current implementation; implementing the underlying feature is out of scope for an error-code mapping ticket.

## Self-review fixes

- Corrected a `step.go` comment that overclaimed `s.validate` always returns an already-classified error — its own header-parse/algorithm-mismatch checks still return unclassified errors that fall through to a generic 500 either way (unchanged behavior, comment-only fix).
- Hoisted the `EXPIRED`/`UNSUBSCRIBED`/`INVALID_SSL` status check, previously duplicated identically in `keymanager.go` and `simplekeymanager.go`, into a single `model.IsKeyStatusUsable(status string) bool` — both plugins already depend on `pkg/model`, so this removes the risk of the two copies drifting.
- Added local `codeSubscriberNotFound`/`codeKeyExpiredOrRevoked` constants in both `keymanager.go` and `simplekeymanager.go`, matching the named-constant style `signvalidator.go` already used for its own `AUT_*` literals (previously these two files passed raw string literals to `NewCodedSignValidationErr`).
- Documented explicitly (in `model.IsKeyStatusUsable`'s doc comment) that `INITIATED`/`UNDER_SUBSCRIPTION` subscribers are intentionally still treated as usable — this check distinguishes revocation/expiry from good standing, not subscription completeness. Confirmed with the epic owner that this is deliberate scope, not a gap: gating on subscription completeness (if ever desired) is a separate authorization decision.

## Testing

- New/updated tests per reachable `AUT_*` value in `signvalidator_test.go`, `keymanager_test.go`, `simplekeymanager_test.go`, `step_test.go` (including a dedicated `TestValidateHeaders_PreservesClassifiedCode` regression test for the re-wrap fix), and `pkg/model/error_test.go` (`Code`, `NewCodedSignValidationErr`, `Unwrap`).
- `core/module/handler/responsestep_test.go`: extended `TestSendNack`'s table with coded-`SignValidationErr` cases confirming `AUT_*` codes reach the wire end-to-end, for both pre-v2 and v2 envelopes.
- `go build` / `go vet` clean on all touched packages. Full repo test suite passes (`go test $(go list ./... | grep -v /cmd$ | grep -v /benchmarks/e2e$)`).
- Coverage: `signvalidator` 92.9%, `keymanager` 98.3%. `simplekeymanager` (81.2%→82.1%) and `core/module/handler` (78.1%→78.5%) both have pre-existing sub-90% baselines unrelated to this change — not regressed, but not brought up to the repo's 90% target either, since the gaps are in unrelated code paths (PEM parsing, tracer-context wrapping, etc.).

Marked as draft — same review-cycle pattern as #876/#877 before this comes out of draft.
