### PR TITLE
opapolicychecker: map policy denials to POL_* codes

### DIFF
--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -112,62 +112,91 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 }
 
+// codedErr is the common shape shared by wrapper error types that carry one
+// opaque cause plus an optional explicit taxonomy code, falling back to a
+// type-specific default when Code is empty. Embed it in a named type (e.g.
+// SignValidationErr, BadReqErr) to get Code storage and Unwrap() without
+// duplicating them — the embedding type still defines its own constructors
+// and BecknError(), since message-prefix formatting and the default code
+// genuinely differ per type.
+type codedErr struct {
+	// Code is the taxonomy value for this failure's specific cause, or ""
+	// if unclassified — the embedding type's BecknError() should apply its
+	// own default via resolveCode in that case.
+	Code string
+	error
+}
+
+// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
+// plugin-defined sentinel error) in addition to matching the embedding type.
+func (e *codedErr) Unwrap() error {
+	return e.error
+}
+
+// resolveCode returns code if non-empty, else defaultCode. Shared by each
+// wrapper type's BecknError() to apply its own default fallback.
+func resolveCode(code, defaultCode string) string {
+	if code != "" {
+		return code
+	}
+	return defaultCode
+}
+
 // defaultSignValidationCode is used when a SignValidationErr carries no more
 // specific classification — the closest generic bucket in the AUT_* taxonomy.
 const defaultSignValidationCode = "AUT_SIGNATURE_INVALID"
 
 // SignValidationErr occurs when signature validation fails.
 type SignValidationErr struct {
-	// Code is the AUT_* taxonomy value for this failure's specific cause.
-	Code string
-	error
+	codedErr
 }
 
 // NewSignValidationErr creates a new instance of SignValidationErr from an error,
 // classified as AUT_SIGNATURE_INVALID (the generic bucket). Use
 // NewCodedSignValidationErr when the caller knows a more specific AUT_* cause.
 func NewSignValidationErr(e error) *SignValidationErr {
-	return &SignValidationErr{Code: defaultSignValidationCode, error: e}
+	return &SignValidationErr{codedErr{Code: defaultSignValidationCode, error: e}}
 }
 
 // NewCodedSignValidationErr creates a SignValidationErr classified with an
 // explicit AUT_* code, for callers that already know the specific cause.
 func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
-	return &SignValidationErr{Code: code, error: e}
-}
-
-// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
-// plugin-defined sentinel error) in addition to matching *SignValidationErr itself.
-func (e *SignValidationErr) Unwrap() error {
-	return e.error
+	return &SignValidationErr{codedErr{Code: code, error: e}}
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
 func (e *SignValidationErr) BecknError() *Error {
-	code := e.Code
-	if code == "" {
-		code = defaultSignValidationCode
-	}
 	return &Error{
-		Code:    code,
+		Code:    resolveCode(e.Code, defaultSignValidationCode),
 		Message: "Signature Validation Error: " + e.Error(),
 	}
 }
 
 // BadReqErr occurs when a bad request is encountered.
 type BadReqErr struct {
-	error
+	codedErr
 }
 
-// NewBadReqErr creates a new instance of BadReqErr from an error.
+// NewBadReqErr creates a new instance of BadReqErr from an error. Code is left
+// unset, so BecknError() falls back to the legacy "Bad Request" string — the
+// many existing callers of this constructor across the codebase keep that
+// behavior unchanged. Use NewCodedBadReqErr when the caller knows a more
+// specific taxonomy code.
 func NewBadReqErr(err error) *BadReqErr {
-	return &BadReqErr{err}
+	return &BadReqErr{codedErr{error: err}}
+}
+
+// NewCodedBadReqErr creates a BadReqErr classified with an explicit taxonomy
+// code, for callers that already know the specific cause (e.g. a policy
+// checker classifying a denial onto the Beckn v2.0.0 POL_* codes).
+func NewCodedBadReqErr(code string, err error) *BadReqErr {
+	return &BadReqErr{codedErr{Code: code, error: err}}
 }
 
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
 	return &Error{
-		Code:    http.StatusText(http.StatusBadRequest),
+		Code:    resolveCode(e.Code, http.StatusText(http.StatusBadRequest)),
 		Message: "BAD Request: " + e.Error(),
 	}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -80,7 +80,6 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	var paths []string
 	var messages []string
 	hasPath := false
-	code := ""
 	for _, err := range e.Errors {
 		p := err.path()
 		if p != "" {
@@ -88,16 +87,6 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 		paths = append(paths, p)
 		messages = append(messages, err.Message)
-		// First non-empty per-cause code wins. The other causes' text is
-		// still fully present in Message/Details.Path — only their
-		// individual Code is not separately represented on the wire, since
-		// a single Error can only carry one code.
-		if code == "" && err.Code != "" {
-			code = err.Code
-		}
-	}
-	if code == "" {
-		code = http.StatusText(http.StatusBadRequest)
 	}
 
 	var details *ErrorDetails
@@ -106,10 +95,24 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    code,
+		Code:    FirstNonEmptyCode(e.Errors, http.StatusText(http.StatusBadRequest)),
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
+}
+
+// FirstNonEmptyCode returns the first non-empty Code among errs, in order, or
+// defaultCode if none is set. Used when multiple causes must be reduced to
+// one representative Code for the wire — the other causes' text is still
+// carried in full elsewhere (e.g. a joined Message), only their Code is
+// dropped, since a single Error can only carry one code.
+func FirstNonEmptyCode(errs []Error, defaultCode string) string {
+	for _, e := range errs {
+		if e.Code != "" {
+			return e.Code
+		}
+	}
+	return defaultCode
 }
 
 // codedErr is the common shape shared by wrapper error types that carry one
@@ -133,11 +136,11 @@ func (e *codedErr) Unwrap() error {
 	return e.error
 }
 
-// resolveCode returns code if non-empty, else defaultCode. Shared by each
-// wrapper type's BecknError() to apply its own default fallback.
-func resolveCode(code, defaultCode string) string {
-	if code != "" {
-		return code
+// resolveCode returns Code if non-empty, else defaultCode. Called by each
+// embedding type's BecknError() to apply its own default fallback.
+func (e *codedErr) resolveCode(defaultCode string) string {
+	if e.Code != "" {
+		return e.Code
 	}
 	return defaultCode
 }
@@ -151,11 +154,13 @@ type SignValidationErr struct {
 	codedErr
 }
 
-// NewSignValidationErr creates a new instance of SignValidationErr from an error,
-// classified as AUT_SIGNATURE_INVALID (the generic bucket). Use
-// NewCodedSignValidationErr when the caller knows a more specific AUT_* cause.
+// NewSignValidationErr creates a new instance of SignValidationErr from an
+// error. Code is left unset, so BecknError() falls back to the generic
+// AUT_SIGNATURE_INVALID bucket — mirrors NewBadReqErr's lazy-default
+// convention. Use NewCodedSignValidationErr when the caller knows a more
+// specific AUT_* cause.
 func NewSignValidationErr(e error) *SignValidationErr {
-	return &SignValidationErr{codedErr{Code: defaultSignValidationCode, error: e}}
+	return &SignValidationErr{codedErr{error: e}}
 }
 
 // NewCodedSignValidationErr creates a SignValidationErr classified with an
@@ -167,7 +172,7 @@ func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
 // BecknError converts the SignValidationErr to an instance of Error.
 func (e *SignValidationErr) BecknError() *Error {
 	return &Error{
-		Code:    resolveCode(e.Code, defaultSignValidationCode),
+		Code:    e.resolveCode(defaultSignValidationCode),
 		Message: "Signature Validation Error: " + e.Error(),
 	}
 }
@@ -196,7 +201,7 @@ func NewCodedBadReqErr(code string, err error) *BadReqErr {
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
 	return &Error{
-		Code:    resolveCode(e.Code, http.StatusText(http.StatusBadRequest)),
+		Code:    e.resolveCode(http.StatusText(http.StatusBadRequest)),
 		Message: "BAD Request: " + e.Error(),
 	}
 }

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -13,7 +13,7 @@ import (
 
 // NewSignValidationErrf creates a new SignValidationErr with a formatted error message.
 func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
-	return &SignValidationErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}
+	return &SignValidationErr{codedErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}}
 }
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
@@ -23,7 +23,7 @@ func NewNotFoundErrf(format string, a ...any) *NotFoundErr {
 
 // NewBadReqErrf creates a new BadReqErr with a formatted error message.
 func NewBadReqErrf(format string, a ...any) *BadReqErr {
-	return &BadReqErr{fmt.Errorf(format, a...)}
+	return &BadReqErr{codedErr{error: fmt.Errorf(format, a...)}}
 }
 
 func TestNewCodedError(t *testing.T) {
@@ -203,7 +203,7 @@ func TestNewCodedSignValidationErr_BecknError(t *testing.T) {
 }
 
 func TestSignValidationErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
-	signErr := &SignValidationErr{error: errors.New("signature failed")}
+	signErr := &SignValidationErr{codedErr{error: errors.New("signature failed")}}
 	beErr := signErr.BecknError()
 
 	if beErr.Code != "AUT_SIGNATURE_INVALID" {
@@ -226,6 +226,25 @@ func TestSignValidationErr_Unwrap(t *testing.T) {
 	}
 	if target.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
 		t.Errorf("target.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", target.Code)
+	}
+}
+
+func TestResolveCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		defaultCode string
+		want        string
+	}{
+		{"explicit code wins", "AUT_KEY_EXPIRED_OR_REVOKED", "AUT_SIGNATURE_INVALID", "AUT_KEY_EXPIRED_OR_REVOKED"},
+		{"empty code falls back to default", "", "Bad Request", "Bad Request"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveCode(tt.code, tt.defaultCode); got != tt.want {
+				t.Errorf("resolveCode(%q, %q) = %s, want %s", tt.code, tt.defaultCode, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -256,6 +275,40 @@ func TestBadReqErr_BecknError(t *testing.T) {
 	if beErr.Message != expectedMsg {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
+	}
+	if beErr.Code != "Bad Request" {
+		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default unchanged for NewBadReqErr callers", beErr.Code)
+	}
+}
+
+func TestNewCodedBadReqErr_BecknError(t *testing.T) {
+	badReqErr := NewCodedBadReqErr("POL_GEO_RESTRICTED", errors.New("delivery not offered in this region"))
+	beErr := badReqErr.BecknError()
+
+	if beErr.Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("beErr.Code = %s, want POL_GEO_RESTRICTED", beErr.Code)
+	}
+	expectedMsg := "BAD Request: delivery not offered in this region"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestBadReqErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
+	badReqErr := &BadReqErr{codedErr{error: errors.New("invalid input")}}
+	beErr := badReqErr.BecknError()
+
+	if beErr.Code != "Bad Request" {
+		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default when Code is unset", beErr.Code)
+	}
+}
+
+func TestBadReqErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	badReqErr := NewCodedBadReqErr("POL_GENERIC_ERROR", sentinel)
+
+	if !errors.Is(badReqErr, sentinel) {
+		t.Errorf("errors.Is(badReqErr, sentinel) = false, want true via Unwrap()")
 	}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -175,6 +175,41 @@ func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
 	}
 }
 
+func TestFirstNonEmptyCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		errs        []Error
+		defaultCode string
+		want        string
+	}{
+		{
+			name:        "first non-empty code wins",
+			errs:        []Error{{Message: "m1"}, {Code: "POL_KYC_REQUIRED", Message: "m2"}, {Code: "POL_GEO_RESTRICTED", Message: "m3"}},
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_KYC_REQUIRED",
+		},
+		{
+			name:        "no entry has a code falls back to default",
+			errs:        []Error{{Message: "m1"}, {Message: "m2"}},
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_GENERIC_ERROR",
+		},
+		{
+			name:        "empty slice falls back to default",
+			errs:        nil,
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_GENERIC_ERROR",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FirstNonEmptyCode(tt.errs, tt.defaultCode); got != tt.want {
+				t.Errorf("FirstNonEmptyCode() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSignValidationErr_BecknError(t *testing.T) {
 	signErr := NewSignValidationErr(errors.New("signature failed"))
 	beErr := signErr.BecknError()
@@ -241,7 +276,8 @@ func TestResolveCode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveCode(tt.code, tt.defaultCode); got != tt.want {
+			e := &codedErr{Code: tt.code}
+			if got := e.resolveCode(tt.defaultCode); got != tt.want {
 				t.Errorf("resolveCode(%q, %q) = %s, want %s", tt.code, tt.defaultCode, got, tt.want)
 			}
 		})

--- a/pkg/plugin/implementation/opapolicychecker/README.md
+++ b/pkg/plugin/implementation/opapolicychecker/README.md
@@ -194,11 +194,15 @@ networkPolicies:
 |---|---|
 | `{"valid": true, "violations": []}` | Allowed — recommended structured format |
 | `{"valid": false, "violations": ["msg1", "msg2"]}` | Rejected — violation messages returned to caller |
+| `{"valid": false, "violations": [{"code": "POL_...", "message": "..."}]}` | Rejected — each violation may optionally carry a Beckn v2.0.0 `POL_*` error code alongside its message, instead of a plain string. Coded and plain-string entries can be mixed in the same list; codes not provided fall back to `POL_GENERIC_ERROR` |
 | `set()` / `[]string` | Each string is a violation message |
+| `set()` of `{"code": "POL_...", "message": "..."}` objects | Same coded-violation shape as the structured format above — also supported directly under the simpler `set()`/direct-query style |
 | `bool` `true` | Allowed |
 | `bool` `false` | Rejected |
 | `string` (non-empty) | Rejected — the string is the violation message |
 | Empty / undefined | **Rejected** — fail-closed; indicates a misconfigured query path |
+
+A violation's `code`, when provided, should be one of the `POL_*` values in the Beckn v2.0.0 `ErrorCode` taxonomy (e.g. `POL_GEO_RESTRICTED`, `POL_KYC_REQUIRED`, `POL_ELIGIBILITY_NOT_MET`) — see `pkg/plugin/implementation/opapolicychecker/evaluator.go`'s `parseViolationItem` for the exact parsing rules.
 
 ---
 

--- a/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // generateDummyRules creates a .rego policy file with N rules.
@@ -116,7 +118,7 @@ func BenchmarkEvaluate_MostlyInactive(b *testing.B) {
 			if err != nil {
 				b.Fatalf("correctness check failed: %v", err)
 			}
-			if len(violations) != 1 || violations[0] != "real_violation" {
+			if len(violations) != 1 || violations[0].Message != "real_violation" {
 				b.Fatalf("expected [real_violation], got %v", violations)
 			}
 
@@ -238,7 +240,7 @@ func TestBenchmarkReport(t *testing.T) {
 
 		ctx := context.Background()
 		durations := make([]time.Duration, iterations)
-		var lastViolations []string
+		var lastViolations []model.Error
 
 		for i := 0; i < iterations; i++ {
 			start := time.Now()
@@ -274,7 +276,7 @@ func TestBenchmarkReport(t *testing.T) {
 
 		ctx := context.Background()
 		durations := make([]time.Duration, iterations)
-		var lastViolations []string
+		var lastViolations []model.Error
 
 		for i := 0; i < iterations; i++ {
 			start := time.Now()

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -696,7 +696,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 
 	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violationMessages(violations), "; "))
 	log.Warnf(ctx, "OPAPolicyChecker: networkID=%q%s %s", reqCtx.NetworkID, requestLogCtx, msg)
-	return model.NewCodedBadReqErr(violationCode(violations), fmt.Errorf("%s", msg))
+	return model.NewCodedBadReqErr(model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR"), fmt.Errorf("%s", msg))
 }
 
 // violationMessages extracts each violation's human-readable message, in order.
@@ -706,16 +706,6 @@ func violationMessages(violations []model.Error) []string {
 		messages[i] = v.Message
 	}
 	return messages
-}
-
-// violationCode picks the first non-empty per-violation code, falling back to
-// POL_GENERIC_ERROR when no violation carries a specific classification (e.g.
-// every violation came from a policy that only emits plain violation strings,
-// per today's OPA result contract). The other violations' text is still fully
-// present in the joined message — only their individual Code, if any, doesn't
-// separately reach the wire, since a single Error can only carry one code.
-func violationCode(violations []model.Error) string {
-	return model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR")
 }
 
 func (e *PolicyEnforcer) Close() {

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -696,7 +696,8 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 
 	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violationMessages(violations), "; "))
 	log.Warnf(ctx, "OPAPolicyChecker: networkID=%q%s %s", reqCtx.NetworkID, requestLogCtx, msg)
-	return model.NewCodedBadReqErr(model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR"), fmt.Errorf("%s", msg))
+	code := model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR")
+	return model.NewCodedBadReqErr(code, fmt.Errorf("%s", msg))
 }
 
 // violationMessages extracts each violation's human-readable message, in order.

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -642,12 +642,14 @@ func (e *PolicyEnforcer) selectedPolicy(networkID string) *loadedPolicy {
 }
 
 // CheckPolicy evaluates the message body against loaded OPA policies.
-// Returns a BadReqErr (causing NACK) if violations are found, classified with
-// the first non-empty per-violation POL_* code (falling back to
-// POL_GENERIC_ERROR when the policy only emits plain violation strings — see
-// evaluator.go's extractStructuredViolations for the structured/coded shape a
-// Rego policy can opt into).
-// Returns an error on evaluation failure (fail closed).
+// Returns a BadReqErr (causing NACK) for every failure mode — an
+// uninitialized evaluator, an evaluation failure, or actual violations —
+// each classified with a POL_* code. Violations use the first non-empty
+// per-violation code (falling back to POL_GENERIC_ERROR when the policy only
+// emits plain violation strings — see evaluator.go's parseViolationItem for
+// the structured/coded shape a Rego policy can opt into); the other two
+// failure modes always use POL_GENERIC_ERROR, since they're evaluation-layer
+// failures rather than a specific policy decision.
 func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	if !e.config.Enabled {
 		log.Debug(ctx, "OPAPolicyChecker: plugin disabled, skipping")
@@ -670,7 +672,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	// Disabled policies intentionally do not initialize an evaluator in loadPolicy.
 	ev := policy.evaluator
 	if ev == nil {
-		return model.NewBadReqErr(fmt.Errorf("policy evaluator is not initialized"))
+		return model.NewCodedBadReqErr("POL_GENERIC_ERROR", fmt.Errorf("policy evaluator is not initialized"))
 	}
 
 	if e.config.DebugLogging {
@@ -713,12 +715,7 @@ func violationMessages(violations []model.Error) []string {
 // present in the joined message — only their individual Code, if any, doesn't
 // separately reach the wire, since a single Error can only carry one code.
 func violationCode(violations []model.Error) string {
-	for _, v := range violations {
-		if v.Code != "" {
-			return v.Code
-		}
-	}
-	return "POL_GENERIC_ERROR"
+	return model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR")
 }
 
 func (e *PolicyEnforcer) Close() {

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -642,7 +642,11 @@ func (e *PolicyEnforcer) selectedPolicy(networkID string) *loadedPolicy {
 }
 
 // CheckPolicy evaluates the message body against loaded OPA policies.
-// Returns a BadReqErr (causing NACK) if violations are found.
+// Returns a BadReqErr (causing NACK) if violations are found, classified with
+// the first non-empty per-violation POL_* code (falling back to
+// POL_GENERIC_ERROR when the policy only emits plain violation strings — see
+// evaluator.go's extractStructuredViolations for the structured/coded shape a
+// Rego policy can opt into).
 // Returns an error on evaluation failure (fail closed).
 func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	if !e.config.Enabled {
@@ -678,7 +682,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	violations, err := ev.Evaluate(ctx, ctx.Body)
 	if err != nil {
 		log.Errorf(ctx, err, "OPAPolicyChecker: policy evaluation failed for networkID=%q%s: %v", reqCtx.NetworkID, requestLogCtx, err)
-		return model.NewBadReqErr(fmt.Errorf("policy evaluation error: %w", err))
+		return model.NewCodedBadReqErr("POL_GENERIC_ERROR", fmt.Errorf("policy evaluation error: %w", err))
 	}
 
 	if len(violations) == 0 {
@@ -688,9 +692,33 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 		return nil
 	}
 
-	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violations, "; "))
+	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violationMessages(violations), "; "))
 	log.Warnf(ctx, "OPAPolicyChecker: networkID=%q%s %s", reqCtx.NetworkID, requestLogCtx, msg)
-	return model.NewBadReqErr(fmt.Errorf("%s", msg))
+	return model.NewCodedBadReqErr(violationCode(violations), fmt.Errorf("%s", msg))
+}
+
+// violationMessages extracts each violation's human-readable message, in order.
+func violationMessages(violations []model.Error) []string {
+	messages := make([]string, len(violations))
+	for i, v := range violations {
+		messages[i] = v.Message
+	}
+	return messages
+}
+
+// violationCode picks the first non-empty per-violation code, falling back to
+// POL_GENERIC_ERROR when no violation carries a specific classification (e.g.
+// every violation came from a policy that only emits plain violation strings,
+// per today's OPA result contract). The other violations' text is still fully
+// present in the joined message — only their individual Code, if any, doesn't
+// separately reach the wire, since a single Error can only carry one code.
+func violationCode(violations []model.Error) string {
+	for _, v := range violations {
+		if v.Code != "" {
+			return v.Code
+		}
+	}
+	return "POL_GENERIC_ERROR"
 }
 
 func (e *PolicyEnforcer) Close() {

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -257,6 +257,81 @@ violations contains msg if {
 	}
 }
 
+// TestEvaluator_BareSetResult_WithCodedViolations is a regression test for a
+// fail-open bug found in self-review: extractViolations' []interface{} case
+// (the bare-set query style used above in TestEvaluator_WithViolation, and
+// documented in README.md as a supported format) only accepted plain string
+// items, silently dropping a coded violation object entirely — meaning a
+// policy that denied via a coded violation under this query style would be
+// treated as compliant (violations == nil), and CheckPolicy would incorrectly
+// allow the request. This confirms the fix: coded violations now survive the
+// same code path as the structured {"valid",...} format.
+func TestEvaluator_BareSetResult_WithCodedViolations(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violations", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"context": {"action": "confirm"}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v — a coded violation under the bare-set query style must not be silently dropped", len(violations), violations)
+	}
+	if violations[0].Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("violations[0].Code = %q, want POL_GEO_RESTRICTED", violations[0].Code)
+	}
+	if violations[0].Message != "delivery not offered in this region" {
+		t.Errorf("violations[0].Message = %q, want %q", violations[0].Message, "delivery not offered in this region")
+	}
+}
+
+// TestEnforcer_BareSetResult_NonCompliant_PropagatesCode is the CheckPolicy
+// end-to-end counterpart: confirms a coded violation under the bare-set query
+// style correctly denies the request (not silently allows it) and the code
+// reaches the final NACK.
+func TestEnforcer_BareSetResult_NonCompliant_PropagatesCode(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a coded violation under the bare-set query style must not be silently allowed")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GEO_RESTRICTED" {
+		t.Errorf("BecknError().Code = %s, want POL_GEO_RESTRICTED", code)
+	}
+}
+
 func TestEvaluator_RuntimeConfig(t *testing.T) {
 	policy := `
 package policy
@@ -771,6 +846,37 @@ violations contains "blocked" if { input.context.action == "confirm" }
 	}
 	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
 		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR for an evaluation failure", code)
+	}
+}
+
+// TestEnforcer_UninitializedEvaluator_UsesGenericCode covers the defensive
+// "evaluator is not initialized" branch directly — an enabled policy whose
+// evaluator is nil should not normally occur via the real loading path
+// (loadPolicy only skips evaluator init for disabled policies), so this
+// constructs the PolicyEnforcer's internal state directly rather than trying
+// to race the real startup path. Confirms this branch is now classified with
+// POL_GENERIC_ERROR, consistent with the other two CheckPolicy failure modes.
+func TestEnforcer_UninitializedEvaluator_UsesGenericCode(t *testing.T) {
+	enforcer := &PolicyEnforcer{
+		config: &Config{Enabled: true},
+		defaultPolicy: &loadedPolicy{
+			config:    &PolicyConfig{Enabled: true},
+			evaluator: nil,
+		},
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err := enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error when evaluator is nil, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
 	}
 }
 
@@ -1314,7 +1420,7 @@ func TestExtractStructuredViolations_ObjectItemEdgeCases(t *testing.T) {
 		},
 	}
 
-	got := extractStructuredViolations(m)
+	got := extractStructuredViolations(context.Background(), m)
 	want := []model.Error{
 		{Message: "plain string violation"},
 		{Code: "POL_CONSENT_REQUIRED", Message: "consent required"},
@@ -1328,6 +1434,82 @@ func TestExtractStructuredViolations_ObjectItemEdgeCases(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("violations[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+func TestParseViolationItem(t *testing.T) {
+	tests := []struct {
+		name   string
+		item   interface{}
+		wantOK bool
+		want   model.Error
+	}{
+		{
+			name:   "plain string",
+			item:   "some violation",
+			wantOK: true,
+			want:   model.Error{Message: "some violation"},
+		},
+		{
+			name:   "empty string is dropped",
+			item:   "",
+			wantOK: false,
+		},
+		{
+			name:   "coded object",
+			item:   map[string]interface{}{"code": "POL_KYC_REQUIRED", "message": "KYC required"},
+			wantOK: true,
+			want:   model.Error{Code: "POL_KYC_REQUIRED", Message: "KYC required"},
+		},
+		{
+			name:   "code only falls back to code as message",
+			item:   map[string]interface{}{"code": "POL_SANCTIONED_PARTY"},
+			wantOK: true,
+			want:   model.Error{Code: "POL_SANCTIONED_PARTY", Message: "POL_SANCTIONED_PARTY"},
+		},
+		{
+			name:   "empty object is dropped",
+			item:   map[string]interface{}{},
+			wantOK: false,
+		},
+		{
+			name:   "non-string message is ignored, code alone survives",
+			item:   map[string]interface{}{"code": "POL_GEO_RESTRICTED", "message": 12345},
+			wantOK: true,
+			want:   model.Error{Code: "POL_GEO_RESTRICTED", Message: "POL_GEO_RESTRICTED"},
+		},
+		{
+			name:   "non-string code is ignored, message alone survives",
+			item:   map[string]interface{}{"code": 12345, "message": "some message"},
+			wantOK: true,
+			want:   model.Error{Message: "some message"},
+		},
+		{
+			name:   "both non-string is dropped",
+			item:   map[string]interface{}{"code": 12345, "message": true},
+			wantOK: false,
+		},
+		{
+			name:   "unsupported type (number) is dropped",
+			item:   42,
+			wantOK: false,
+		},
+		{
+			name:   "unsupported type (nested list) is dropped",
+			item:   []interface{}{"nested"},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseViolationItem(context.Background(), tt.item)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got=%+v)", ok, tt.wantOK, got)
+			}
+			if ok && got != tt.want {
+				t.Errorf("got = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -405,6 +405,60 @@ violations contains msg if {
 	}
 }
 
+// TestEvaluator_BareStringResult_WithViolation and
+// TestEvaluator_BareStringResult_EmptyStringIsCompliant cover extractViolations'
+// top-level `case string:` branch (a bare single-string Rego result, not a
+// set) — the branch commit 0c496d6 routed through parseViolationItem but that
+// left it with 0% test coverage, flagged in self-review.
+func TestEvaluator_BareStringResult_WithViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+deny_reason := "order value exceeds limit" if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.deny_reason", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Message != "order value exceeds limit" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
+	}
+}
+
+func TestEvaluator_BareStringResult_EmptyStringIsCompliant(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+deny_reason := "" if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.deny_reason", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for empty string result, got %v", violations)
+	}
+}
+
 func TestEvaluator_RuntimeConfig(t *testing.T) {
 	policy := `
 package policy
@@ -1476,6 +1530,108 @@ func TestExtractStructuredViolations_ObjectItemEdgeCases(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("violations[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+// TestExtractStructuredViolations_MalformedShape_FallsBackToGenericViolation is
+// a regression test for a fail-open bug found in self-review: a map with only
+// one of "valid"/"violations", or either key present with the wrong JSON type,
+// was silently returned as nil — discarding any populated violations the map
+// carried and letting a request the policy clearly denied through as
+// compliant. This confirms the fix: any map that looks like an attempted
+// structured result but doesn't fully match the expected shape now falls back
+// to a generic denial instead of nil.
+func TestExtractStructuredViolations_MalformedShape_FallsBackToGenericViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+	}{
+		{
+			name: "violations present without valid",
+			m: map[string]interface{}{
+				"violations": []interface{}{
+					map[string]interface{}{"code": "POL_KYC_REQUIRED", "message": "kyc required"},
+				},
+			},
+		},
+		{
+			name: "valid present without violations",
+			m: map[string]interface{}{
+				"valid": false,
+			},
+		},
+		{
+			name: "valid has wrong type",
+			m: map[string]interface{}{
+				"valid":      "false",
+				"violations": []interface{}{"some violation"},
+			},
+		},
+		{
+			name: "violations has wrong type",
+			m: map[string]interface{}{
+				"valid":      false,
+				"violations": "some violation",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStructuredViolations(context.Background(), tt.m)
+			if len(got) != 1 || got[0].Message != "policy denied the request" {
+				t.Errorf("extractStructuredViolations(%+v) = %v, want a single generic denial violation — a malformed structured result must not be silently treated as compliant", tt.m, got)
+			}
+		})
+	}
+}
+
+// TestExtractStructuredViolations_NeitherKeyPresent_ReturnsNil confirms the
+// boundary the fix above must not cross: a map with neither "valid" nor
+// "violations" isn't an attempt at this format at all (some other, unrelated
+// map result at this query path) and should still be ignored, not treated as
+// a denial.
+func TestExtractStructuredViolations_NeitherKeyPresent_ReturnsNil(t *testing.T) {
+	got := extractStructuredViolations(context.Background(), map[string]interface{}{"foo": "bar"})
+	if got != nil {
+		t.Errorf("expected nil for a map with neither valid nor violations key, got %v", got)
+	}
+}
+
+// TestEnforcer_StructuredResult_MissingValidKey_StillDenies is the CheckPolicy
+// end-to-end counterpart: confirms a structured result missing "valid" (e.g.
+// an incomplete migration to the structured shape) still denies the request
+// and the violation's code survives to the final NACK, rather than being
+// silently allowed.
+func TestEnforcer_StructuredResult_MissingValidKey_StillDenies(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+result := {"violations": [{"code": "POL_KYC_REQUIRED", "message": "kyc required"}]} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.result\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a structured result missing the \"valid\" key must not be silently allowed")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
 	}
 }
 

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -459,6 +459,37 @@ deny_reason := "" if {
 	}
 }
 
+// TestEvaluator_UnsupportedResultType_FallsBackToGenericViolation is a
+// regression test for a fail-open bug found in self-review: extractViolations'
+// type switch had no default case, so a query result of any type other than
+// the four documented shapes (bool, string, []interface{}, map[string]interface{})
+// — e.g. a bare number from a policy authoring mistake — matched nothing and
+// was silently dropped with zero violations. This confirms the fix: an
+// unrecognized result type now falls back to one generic violation instead of
+// being silently treated as compliant.
+func TestEvaluator_UnsupportedResultType_FallsBackToGenericViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violation_count := 1 if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violation_count", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 || violations[0].Message != genericDenialMessage {
+		t.Errorf("expected 1 generic denial violation for an unsupported result type, got %v — a policy result of an unrecognized type must not be silently allowed", violations)
+	}
+}
+
 func TestEvaluator_RuntimeConfig(t *testing.T) {
 	policy := `
 package policy
@@ -1578,7 +1609,7 @@ func TestExtractStructuredViolations_MalformedShape_FallsBackToGenericViolation(
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := extractStructuredViolations(context.Background(), tt.m)
-			if len(got) != 1 || got[0].Message != "policy denied the request" {
+			if len(got) != 1 || got[0].Message != genericDenialMessage {
 				t.Errorf("extractStructuredViolations(%+v) = %v, want a single generic denial violation — a malformed structured result must not be silently treated as compliant", tt.m, got)
 			}
 		})

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -252,8 +252,8 @@ violations contains msg if {
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
 	}
-	if violations[0] != "value is negative" {
-		t.Errorf("unexpected violation: %q", violations[0])
+	if violations[0].Message != "value is negative" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
 	}
 }
 
@@ -457,7 +457,7 @@ violations contains "from_file" if { input.bad }
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "from_file" {
+	if len(violations) != 1 || violations[0].Message != "from_file" {
 		t.Errorf("expected [from_file], got %v", violations)
 	}
 }
@@ -497,7 +497,7 @@ violations contains "order too large" if { is_high_value }
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "order too large" {
+	if len(violations) != 1 || violations[0].Message != "order too large" {
 		t.Errorf("expected [order too large], got %v", violations)
 	}
 
@@ -672,8 +672,148 @@ violations contains "blocked" if { input.context.action == "confirm" }
 	}
 
 	// Should be a BadReqErr
-	if _, ok := err.(*model.BadReqErr); !ok {
-		t.Errorf("expected *model.BadReqErr, got %T: %v", err, err)
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+
+	// The Rego policy above only emits a plain violation string, so the
+	// aggregate code falls back to the generic bucket.
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR for an unclassified plain-string violation", code)
+	}
+}
+
+// TestEnforcer_NonCompliant_PropagatesCode confirms a Rego policy emitting a
+// coded violation ({"code": "POL_...", "message": "..."}) has that code
+// survive all the way to CheckPolicy's returned NACK — not just extracted by
+// the Evaluator in isolation.
+func TestEnforcer_NonCompliant_PropagatesCode(t *testing.T) {
+	policy := `
+package policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+  input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.result\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error for non-compliant message, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	beErr := badReqErr.BecknError()
+	if beErr.Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("BecknError().Code = %s, want POL_GEO_RESTRICTED", beErr.Code)
+	}
+	if !strings.Contains(beErr.Message, "delivery not offered in this region") {
+		t.Errorf("BecknError().Message = %q, want it to contain the violation text", beErr.Message)
+	}
+}
+
+// TestEnforcer_EvaluationError_UsesGenericCode confirms a failure to evaluate
+// the policy at all (as opposed to a clean deny decision) is classified as
+// POL_GENERIC_ERROR — it's an evaluation failure, not a policy denial, so no
+// more specific POL_* code applies.
+func TestEnforcer_EvaluationError_UsesGenericCode(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains "blocked" if { input.context.action == "confirm" }
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	// Malformed JSON body reaches ev.Evaluate (parseRequestContext degrades
+	// gracefully on invalid JSON, so CheckPolicy still selects this policy).
+	ctx := makeStepCtx("confirm", `not valid json`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error for malformed body, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR for an evaluation failure", code)
+	}
+}
+
+func TestViolationCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		violations []model.Error
+		want       string
+	}{
+		{
+			name:       "first non-empty code wins",
+			violations: []model.Error{{Message: "m1"}, {Code: "POL_KYC_REQUIRED", Message: "m2"}, {Code: "POL_GEO_RESTRICTED", Message: "m3"}},
+			want:       "POL_KYC_REQUIRED",
+		},
+		{
+			name:       "no violation has a code falls back to generic",
+			violations: []model.Error{{Message: "m1"}, {Message: "m2"}},
+			want:       "POL_GENERIC_ERROR",
+		},
+		{
+			name:       "empty slice falls back to generic",
+			violations: nil,
+			want:       "POL_GENERIC_ERROR",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := violationCode(tt.violations); got != tt.want {
+				t.Errorf("violationCode() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestViolationMessages(t *testing.T) {
+	violations := []model.Error{
+		{Code: "POL_KYC_REQUIRED", Message: "m1"},
+		{Message: "m2"},
+	}
+	got := violationMessages(violations)
+	want := []string{"m1", "m2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("violationMessages() = %v, want %v", got, want)
 	}
 }
 
@@ -1017,8 +1157,8 @@ violations contains msg if {
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
 	}
-	if violations[0] != "item item1: quantity must be > 0" {
-		t.Errorf("unexpected violation: %q", violations[0])
+	if violations[0].Message != "item item1: quantity must be > 0" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
 	}
 
 	// Compliant input
@@ -1037,6 +1177,98 @@ violations contains msg if {
 	}
 	if len(violations) != 0 {
 		t.Errorf("expected 0 violations for compliant input, got %v", violations)
+	}
+}
+
+// TestEvaluator_StructuredResult_WithCodedViolations exercises the additive
+// violation shape: a Rego policy MAY emit {"code": "POL_...", "message": "..."}
+// objects instead of plain strings, and extractStructuredViolations preserves
+// the Code. Existing policies that only emit plain strings are unaffected —
+// verified by the "message" fallback and mixed-shape cases below.
+func TestEvaluator_StructuredResult_WithCodedViolations(t *testing.T) {
+	policy := `
+package retail.policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+  input.message.fulfillment.region == "restricted-zone"
+}
+`
+	dir := writePolicyDir(t, "policy.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.retail.policy.result", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"message": {"fulfillment": {"region": "restricted-zone"}}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("violations[0].Code = %q, want POL_GEO_RESTRICTED", violations[0].Code)
+	}
+	if violations[0].Message != "delivery not offered in this region" {
+		t.Errorf("violations[0].Message = %q, want %q", violations[0].Message, "delivery not offered in this region")
+	}
+}
+
+// TestEvaluator_StructuredResult_MixedCodedAndPlainViolations confirms a
+// policy can mix legacy plain-string violations with coded ones in the same
+// result — the plain one gets no Code (left for the caller's generic
+// fallback), the coded one keeps its classification.
+func TestEvaluator_StructuredResult_MixedCodedAndPlainViolations(t *testing.T) {
+	policy := `
+package retail.policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains "unclassified legacy violation" if {
+  input.trigger == "legacy"
+}
+
+violations contains {"code": "POL_KYC_REQUIRED", "message": "KYC verification required"} if {
+  input.trigger == "coded"
+}
+`
+	dir := writePolicyDir(t, "policy.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.retail.policy.result", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"trigger": "coded"}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Code != "POL_KYC_REQUIRED" || violations[0].Message != "KYC verification required" {
+		t.Errorf("unexpected violation: %+v", violations[0])
 	}
 }
 
@@ -1062,8 +1294,40 @@ result := {
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "policy denied the request" {
+	if len(violations) != 1 || violations[0].Message != "policy denied the request" {
 		t.Errorf("expected ['policy denied the request'], got %v", violations)
+	}
+}
+
+// TestExtractStructuredViolations_ObjectItemEdgeCases unit-tests the
+// object-shaped violation item parsing directly, without needing a real Rego
+// policy — covering the code-only fallback and empty-item-skip branches that
+// the Rego-driven tests above don't exercise.
+func TestExtractStructuredViolations_ObjectItemEdgeCases(t *testing.T) {
+	m := map[string]interface{}{
+		"valid": false,
+		"violations": []interface{}{
+			"plain string violation",
+			map[string]interface{}{"code": "POL_CONSENT_REQUIRED", "message": "consent required"},
+			map[string]interface{}{"code": "POL_SANCTIONED_PARTY"}, // no message: falls back to code
+			map[string]interface{}{},                               // neither code nor message: skipped
+		},
+	}
+
+	got := extractStructuredViolations(m)
+	want := []model.Error{
+		{Message: "plain string violation"},
+		{Code: "POL_CONSENT_REQUIRED", Message: "consent required"},
+		{Code: "POL_SANCTIONED_PARTY", Message: "POL_SANCTIONED_PARTY"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violations[%d] = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }
 

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -332,6 +332,79 @@ violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offe
 	}
 }
 
+// TestEvaluator_BareSetResult_UnparseableItem_FallsBackToGenericViolation is a
+// regression test for a fail-open bug found in self-review: once
+// parseViolationItem started dropping empty-string items (to correctly reject
+// malformed coded objects), a bare-set violation whose only item was an empty
+// string would parse to zero violations with no fallback — unlike the
+// structured {"valid",...} format, which falls back to a generic violation
+// when valid=false but the violations list is empty. This confirms the fix:
+// a non-empty set that yields zero parseable items still produces one
+// generic violation.
+func TestEvaluator_BareSetResult_UnparseableItem_FallsBackToGenericViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains msg if {
+    input.context.action == "confirm"
+    msg := ""
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violations", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"context": {"action": "confirm"}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 fallback violation, got %d: %v — a non-empty violations set must not be silently dropped just because its item didn't parse", len(violations), violations)
+	}
+	if violations[0].Message == "" {
+		t.Errorf("expected a non-empty fallback message, got empty")
+	}
+}
+
+// TestEnforcer_BareSetResult_UnparseableItem_StillDenies is the CheckPolicy
+// end-to-end counterpart: confirms a bare-set violation with an unparseable
+// item still denies the request (not silently allows it).
+func TestEnforcer_BareSetResult_UnparseableItem_StillDenies(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains msg if {
+    input.context.action == "confirm"
+    msg := ""
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a non-empty violations set must not be silently allowed just because its item didn't parse")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
+	}
+}
+
 func TestEvaluator_RuntimeConfig(t *testing.T) {
 	policy := `
 package policy
@@ -877,37 +950,6 @@ func TestEnforcer_UninitializedEvaluator_UsesGenericCode(t *testing.T) {
 	}
 	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
 		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
-	}
-}
-
-func TestViolationCode(t *testing.T) {
-	tests := []struct {
-		name       string
-		violations []model.Error
-		want       string
-	}{
-		{
-			name:       "first non-empty code wins",
-			violations: []model.Error{{Message: "m1"}, {Code: "POL_KYC_REQUIRED", Message: "m2"}, {Code: "POL_GEO_RESTRICTED", Message: "m3"}},
-			want:       "POL_KYC_REQUIRED",
-		},
-		{
-			name:       "no violation has a code falls back to generic",
-			violations: []model.Error{{Message: "m1"}, {Message: "m2"}},
-			want:       "POL_GENERIC_ERROR",
-		},
-		{
-			name:       "empty slice falls back to generic",
-			violations: nil,
-			want:       "POL_GENERIC_ERROR",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := violationCode(tt.violations); got != tt.want {
-				t.Errorf("violationCode() = %s, want %s", got, tt.want)
-			}
-		})
 	}
 }
 

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -448,6 +448,9 @@ const genericDenialMessage = "policy denied the request"
 //   - bool: false = denied ("policy denied the request"), true = allowed.
 //   - string: non-empty = violation message, no code.
 //   - empty/undefined: allowed (no violations).
+//   - any other type (e.g. a bare number, or an explicit Rego null): not a
+//     recognized decision shape, so treated the same as a malformed result —
+//     one generic violation, rather than being silently ignored.
 func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, error) {
 	if len(rs) == 0 {
 		return nil, nil
@@ -485,6 +488,9 @@ func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, e
 				if vs := extractStructuredViolations(ctx, v); vs != nil {
 					violations = append(violations, vs...)
 				}
+			default:
+				log.Debugf(ctx, "OPAPolicyChecker: policy result has unsupported type %T (%+v); treating as a denial", v, v)
+				violations = append(violations, model.Error{Message: genericDenialMessage})
 			}
 		}
 	}
@@ -549,7 +555,10 @@ func extractStructuredViolations(ctx context.Context, m map[string]interface{}) 
 	valid, validOK := validRaw.(bool)
 	violationsList, violationsOK := violationsRaw.([]interface{})
 
-	if !hasValid || !hasViolations || !validOK || !violationsOK {
+	// A missing key always type-asserts to !OK too, so checking just the OK
+	// results (rather than also hasValid/hasViolations) already covers both
+	// "key absent" and "key present with the wrong type".
+	if !validOK || !violationsOK {
 		log.Debugf(ctx, "OPAPolicyChecker: malformed structured policy result (expected {\"valid\": bool, \"violations\": [...]}), got %+v; treating as a denial", m)
 		return []model.Error{{Message: genericDenialMessage}}
 	}

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -435,7 +435,9 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, e
 //     object {"code": "POL_...", "message": "..."} (Code is preserved).
 //   - []interface{} / set: each item may be a plain string (legacy, no code) or
 //     an object {"code": "POL_...", "message": "..."} (Code is preserved) — the
-//     same two shapes accepted by the structured format above.
+//     same two shapes accepted by the structured format above. A non-empty set
+//     that yields zero parseable items still produces one generic violation,
+//     mirroring the structured format's invalid-with-no-violations fallback.
 //   - bool: false = denied ("policy denied the request"), true = allowed.
 //   - string: non-empty = violation message, no code.
 //   - empty/undefined: allowed (no violations).
@@ -455,16 +457,24 @@ func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, e
 				}
 			case string:
 				// single violation string
-				if v != "" {
-					violations = append(violations, model.Error{Message: v})
+				if e, ok := parseViolationItem(ctx, v); ok {
+					violations = append(violations, e)
 				}
 			case []interface{}:
 				// Result is a list (from set)
+				var itemViolations []model.Error
 				for _, item := range v {
 					if e, ok := parseViolationItem(ctx, item); ok {
-						violations = append(violations, e)
+						itemViolations = append(itemViolations, e)
 					}
 				}
+				// A non-empty set is itself a deny signal — don't let every item
+				// failing to parse (e.g. an empty string, or a malformed/unsupported
+				// item) silently flip the result to compliant.
+				if len(v) > 0 && len(itemViolations) == 0 {
+					itemViolations = append(itemViolations, model.Error{Message: "policy denied the request"})
+				}
+				violations = append(violations, itemViolations...)
 			case map[string]interface{}:
 				if vs := extractStructuredViolations(ctx, v); vs != nil {
 					violations = append(violations, vs...)

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/security/artifactverifier"
 )
 
@@ -402,8 +403,11 @@ func fetchPolicy(rawURL string, fetchTimeout time.Duration) (string, string, err
 }
 
 // Evaluate runs the compiled policy against a JSON message body.
-// Returns a list of violation strings (empty = compliant).
-func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]string, error) {
+// Returns a list of violations (empty = compliant). Each violation's Code is
+// set only when the Rego result explicitly provided one (see
+// extractStructuredViolations) — otherwise it's left empty for the caller to
+// fall back to a generic classification.
+func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, error) {
 	var input interface{}
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, fmt.Errorf("failed to parse message body as JSON: %w", err)
@@ -417,7 +421,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]string, error)
 	// Fail-closed for bundles: if the query returned no result, the policy_query_path
 	// is likely misconfigured or the rule doesn't exist in the bundle.
 	if e.failOnUndefined && len(rs) == 0 {
-		return []string{fmt.Sprintf("policy query %q returned no result (undefined)", e.query)}, nil
+		return []model.Error{{Message: fmt.Sprintf("policy query %q returned no result (undefined)", e.query)}}, nil
 	}
 
 	return extractViolations(rs)
@@ -425,35 +429,37 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]string, error)
 
 // extractViolations pulls violations from the OPA result set.
 // Supported query output formats:
-//   - map with {"valid": bool, "violations": []string}: structured policy_query_path result
-//   - []string / set of strings: each string is a violation message
-//   - bool: false = denied ("policy denied the request"), true = allowed
-//   - string: non-empty = violation message
-//   - empty/undefined: allowed (no violations)
-func extractViolations(rs rego.ResultSet) ([]string, error) {
+//   - map with {"valid": bool, "violations": [...]}: structured policy_query_path
+//     result. Each violation entry may be a plain string (legacy, no code) or an
+//     object {"code": "POL_...", "message": "..."} (Code is preserved).
+//   - []string / set of strings: each string is a violation message, no code.
+//   - bool: false = denied ("policy denied the request"), true = allowed.
+//   - string: non-empty = violation message, no code.
+//   - empty/undefined: allowed (no violations).
+func extractViolations(rs rego.ResultSet) ([]model.Error, error) {
 	if len(rs) == 0 {
 		return nil, nil
 	}
 
-	var violations []string
+	var violations []model.Error
 	for _, result := range rs {
 		for _, expr := range result.Expressions {
 			switch v := expr.Value.(type) {
 			case bool:
 				// allow/deny pattern: false = denied
 				if !v {
-					violations = append(violations, "policy denied the request")
+					violations = append(violations, model.Error{Message: "policy denied the request"})
 				}
 			case string:
 				// single violation string
 				if v != "" {
-					violations = append(violations, v)
+					violations = append(violations, model.Error{Message: v})
 				}
 			case []interface{}:
 				// Result is a list (from set)
 				for _, item := range v {
 					if s, ok := item.(string); ok {
-						violations = append(violations, s)
+						violations = append(violations, model.Error{Message: s})
 					}
 				}
 			case map[string]interface{}:
@@ -468,9 +474,12 @@ func extractViolations(rs rego.ResultSet) ([]string, error) {
 }
 
 // extractStructuredViolations handles the policy_query_path result format:
-// {"valid": bool, "violations": []string}
-// Returns the violation strings if the map matches this format, or nil if it doesn't.
-func extractStructuredViolations(m map[string]interface{}) []string {
+// {"valid": bool, "violations": [...]}. Each item in "violations" is either a
+// plain string (legacy — Code left empty) or an object {"code": "POL_...",
+// "message": "..."} (Code preserved for the caller's classification).
+// Returns the parsed violations if the map matches this format, or nil if it
+// doesn't.
+func extractStructuredViolations(m map[string]interface{}) []model.Error {
 	validRaw, hasValid := m["valid"]
 	violationsRaw, hasViolations := m["violations"]
 
@@ -490,19 +499,30 @@ func extractStructuredViolations(m map[string]interface{}) []string {
 
 	// If valid is true and violations is empty, no violations
 	if valid && len(violationsList) == 0 {
-		return []string{}
+		return []model.Error{}
 	}
 
-	var violations []string
+	var violations []model.Error
 	for _, item := range violationsList {
-		if s, ok := item.(string); ok {
-			violations = append(violations, s)
+		switch v := item.(type) {
+		case string:
+			violations = append(violations, model.Error{Message: v})
+		case map[string]interface{}:
+			message, _ := v["message"].(string)
+			code, _ := v["code"].(string)
+			if message == "" && code == "" {
+				continue
+			}
+			if message == "" {
+				message = code
+			}
+			violations = append(violations, model.Error{Code: code, Message: message})
 		}
 	}
 
 	// If valid is false but violations is empty, report a generic violation
 	if !valid && len(violations) == 0 {
-		violations = append(violations, "policy denied the request")
+		violations = append(violations, model.Error{Message: "policy denied the request"})
 	}
 
 	return violations

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
+	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/security/artifactverifier"
 )
@@ -424,7 +425,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, e
 		return []model.Error{{Message: fmt.Sprintf("policy query %q returned no result (undefined)", e.query)}}, nil
 	}
 
-	return extractViolations(rs)
+	return extractViolations(ctx, rs)
 }
 
 // extractViolations pulls violations from the OPA result set.
@@ -432,11 +433,13 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, e
 //   - map with {"valid": bool, "violations": [...]}: structured policy_query_path
 //     result. Each violation entry may be a plain string (legacy, no code) or an
 //     object {"code": "POL_...", "message": "..."} (Code is preserved).
-//   - []string / set of strings: each string is a violation message, no code.
+//   - []interface{} / set: each item may be a plain string (legacy, no code) or
+//     an object {"code": "POL_...", "message": "..."} (Code is preserved) — the
+//     same two shapes accepted by the structured format above.
 //   - bool: false = denied ("policy denied the request"), true = allowed.
 //   - string: non-empty = violation message, no code.
 //   - empty/undefined: allowed (no violations).
-func extractViolations(rs rego.ResultSet) ([]model.Error, error) {
+func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, error) {
 	if len(rs) == 0 {
 		return nil, nil
 	}
@@ -458,12 +461,12 @@ func extractViolations(rs rego.ResultSet) ([]model.Error, error) {
 			case []interface{}:
 				// Result is a list (from set)
 				for _, item := range v {
-					if s, ok := item.(string); ok {
-						violations = append(violations, model.Error{Message: s})
+					if e, ok := parseViolationItem(ctx, item); ok {
+						violations = append(violations, e)
 					}
 				}
 			case map[string]interface{}:
-				if vs := extractStructuredViolations(v); vs != nil {
+				if vs := extractStructuredViolations(ctx, v); vs != nil {
 					violations = append(violations, vs...)
 				}
 			}
@@ -473,13 +476,49 @@ func extractViolations(rs rego.ResultSet) ([]model.Error, error) {
 	return violations, nil
 }
 
+// parseViolationItem converts one item from a Rego violations list/set into a
+// model.Error. Supported shapes: a plain string (legacy, Code left empty), or
+// an object {"code": "POL_...", "message": "..."} (Code preserved). Returns
+// ok=false for anything else (wrong types, or both code and message empty),
+// logging a debug line so a malformed Rego policy's output isn't silently
+// invisible.
+func parseViolationItem(ctx context.Context, item interface{}) (model.Error, bool) {
+	switch v := item.(type) {
+	case string:
+		if v == "" {
+			return model.Error{}, false
+		}
+		return model.Error{Message: v}, true
+	case map[string]interface{}:
+		message, msgIsString := v["message"].(string)
+		code, codeIsString := v["code"].(string)
+		if rawMsg := v["message"]; rawMsg != nil && !msgIsString {
+			log.Debugf(ctx, "OPAPolicyChecker: violation item has a non-string \"message\" (%T); ignoring", rawMsg)
+		}
+		if rawCode := v["code"]; rawCode != nil && !codeIsString {
+			log.Debugf(ctx, "OPAPolicyChecker: violation item has a non-string \"code\" (%T); ignoring", rawCode)
+		}
+		if message == "" && code == "" {
+			log.Debugf(ctx, "OPAPolicyChecker: dropping violation item with no usable code or message: %+v", v)
+			return model.Error{}, false
+		}
+		if message == "" {
+			message = code
+		}
+		return model.Error{Code: code, Message: message}, true
+	default:
+		log.Debugf(ctx, "OPAPolicyChecker: dropping violation item of unsupported type %T", item)
+		return model.Error{}, false
+	}
+}
+
 // extractStructuredViolations handles the policy_query_path result format:
-// {"valid": bool, "violations": [...]}. Each item in "violations" is either a
-// plain string (legacy — Code left empty) or an object {"code": "POL_...",
-// "message": "..."} (Code preserved for the caller's classification).
-// Returns the parsed violations if the map matches this format, or nil if it
-// doesn't.
-func extractStructuredViolations(m map[string]interface{}) []model.Error {
+// {"valid": bool, "violations": [...]}. Each item in "violations" is parsed by
+// parseViolationItem — either a plain string (legacy — Code left empty) or an
+// object {"code": "POL_...", "message": "..."} (Code preserved for the
+// caller's classification). Returns the parsed violations if the map matches
+// this format, or nil if it doesn't.
+func extractStructuredViolations(ctx context.Context, m map[string]interface{}) []model.Error {
 	validRaw, hasValid := m["valid"]
 	violationsRaw, hasViolations := m["violations"]
 
@@ -504,19 +543,8 @@ func extractStructuredViolations(m map[string]interface{}) []model.Error {
 
 	var violations []model.Error
 	for _, item := range violationsList {
-		switch v := item.(type) {
-		case string:
-			violations = append(violations, model.Error{Message: v})
-		case map[string]interface{}:
-			message, _ := v["message"].(string)
-			code, _ := v["code"].(string)
-			if message == "" && code == "" {
-				continue
-			}
-			if message == "" {
-				message = code
-			}
-			violations = append(violations, model.Error{Code: code, Message: message})
+		if e, ok := parseViolationItem(ctx, item); ok {
+			violations = append(violations, e)
 		}
 	}
 

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -428,11 +428,18 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, e
 	return extractViolations(ctx, rs)
 }
 
+// genericDenialMessage is used whenever a policy result clearly signals a
+// denial (a non-empty deny-shaped value, or a malformed attempt at one) but
+// its content can't be parsed into a more specific violation.
+const genericDenialMessage = "policy denied the request"
+
 // extractViolations pulls violations from the OPA result set.
 // Supported query output formats:
 //   - map with {"valid": bool, "violations": [...]}: structured policy_query_path
 //     result. Each violation entry may be a plain string (legacy, no code) or an
-//     object {"code": "POL_...", "message": "..."} (Code is preserved).
+//     object {"code": "POL_...", "message": "..."} (Code is preserved). A map
+//     that doesn't fully match this shape (a missing or wrong-typed key) still
+//     produces one generic violation rather than being silently ignored.
 //   - []interface{} / set: each item may be a plain string (legacy, no code) or
 //     an object {"code": "POL_...", "message": "..."} (Code is preserved) — the
 //     same two shapes accepted by the structured format above. A non-empty set
@@ -453,7 +460,7 @@ func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, e
 			case bool:
 				// allow/deny pattern: false = denied
 				if !v {
-					violations = append(violations, model.Error{Message: "policy denied the request"})
+					violations = append(violations, model.Error{Message: genericDenialMessage})
 				}
 			case string:
 				// single violation string
@@ -462,19 +469,18 @@ func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, e
 				}
 			case []interface{}:
 				// Result is a list (from set)
-				var itemViolations []model.Error
+				lenBefore := len(violations)
 				for _, item := range v {
 					if e, ok := parseViolationItem(ctx, item); ok {
-						itemViolations = append(itemViolations, e)
+						violations = append(violations, e)
 					}
 				}
 				// A non-empty set is itself a deny signal — don't let every item
 				// failing to parse (e.g. an empty string, or a malformed/unsupported
 				// item) silently flip the result to compliant.
-				if len(v) > 0 && len(itemViolations) == 0 {
-					itemViolations = append(itemViolations, model.Error{Message: "policy denied the request"})
+				if len(v) > 0 && len(violations) == lenBefore {
+					violations = append(violations, model.Error{Message: genericDenialMessage})
 				}
-				violations = append(violations, itemViolations...)
 			case map[string]interface{}:
 				if vs := extractStructuredViolations(ctx, v); vs != nil {
 					violations = append(violations, vs...)
@@ -527,23 +533,25 @@ func parseViolationItem(ctx context.Context, item interface{}) (model.Error, boo
 // parseViolationItem — either a plain string (legacy — Code left empty) or an
 // object {"code": "POL_...", "message": "..."} (Code preserved for the
 // caller's classification). Returns the parsed violations if the map matches
-// this format, or nil if it doesn't.
+// this format; nil if the map has neither key (not an attempt at this format
+// at all — some other, unrelated map result); or one generic denial if the
+// map has only one of the two keys, or either key has the wrong type (a
+// malformed attempt at this format must not be silently treated as
+// compliant).
 func extractStructuredViolations(ctx context.Context, m map[string]interface{}) []model.Error {
 	validRaw, hasValid := m["valid"]
 	violationsRaw, hasViolations := m["violations"]
 
-	if !hasValid || !hasViolations {
+	if !hasValid && !hasViolations {
 		return nil
 	}
 
-	valid, ok := validRaw.(bool)
-	if !ok {
-		return nil
-	}
+	valid, validOK := validRaw.(bool)
+	violationsList, violationsOK := violationsRaw.([]interface{})
 
-	violationsList, ok := violationsRaw.([]interface{})
-	if !ok {
-		return nil
+	if !hasValid || !hasViolations || !validOK || !violationsOK {
+		log.Debugf(ctx, "OPAPolicyChecker: malformed structured policy result (expected {\"valid\": bool, \"violations\": [...]}), got %+v; treating as a denial", m)
+		return []model.Error{{Message: genericDenialMessage}}
 	}
 
 	// If valid is true and violations is empty, no violations
@@ -560,7 +568,7 @@ func extractStructuredViolations(ctx context.Context, m map[string]interface{}) 
 
 	// If valid is false but violations is empty, report a generic violation
 	if !valid && len(violations) == 0 {
-		violations = append(violations, model.Error{Message: "policy denied the request"})
+		violations = append(violations, model.Error{Message: genericDenialMessage})
 	}
 
 	return violations


### PR DESCRIPTION
Closes #865. Part of the #861 EPIC. Builds on #862/#863/#864 (already merged into this branch).

## Cross-team dependency, and how this ticket handles it

`opapolicychecker`'s OPA result contract today carries no machine-readable discriminator — `extractViolations`/`extractStructuredViolations` only ever produced plain human-readable strings (`{"valid": bool, "violations": []string}` or similar). Real per-violation classification onto specific `POL_*` codes requires the Rego policy bundles themselves to emit a structured code, which is out of onix's Go-code scope (coordination with nirmalnr's OPA/policy cluster, #642/#643/#649).

This PR takes the **additive, backward-compatible** path discussed and agreed on: extend the contract so a Rego policy *may* emit `{"code": "POL_...", "message": "..."}` instead of a plain string, while every existing policy (which only emits plain strings) is completely unaffected. Given today's actual Rego policies, most real violations will still land on `POL_GENERIC_ERROR` until policy bundles adopt the structured shape — that's an honest, correctly-scoped outcome, not a shortfall of this ticket.

## What changed

- **`evaluator.go`**: `Evaluate`/`extractViolations`/`extractStructuredViolations` now return `[]model.Error` instead of `[]string`. Each violation item in the structured `{"valid": bool, "violations": [...]}` shape can now be either a plain string (legacy, `Code` left empty) or an object `{"code": "POL_...", "message": "..."}` (Code preserved).
- **`enforcer.go`**: `CheckPolicy`'s three return points are classified distinctly:
  - "evaluator not initialized" → `POL_GENERIC_ERROR` (infra issue, not a policy decision, but still classified rather than left on the legacy generic string — fixed during self-review, since two reviewers independently flagged the inconsistency of leaving this one path uncoded).
  - "policy evaluation error" → `POL_GENERIC_ERROR`.
  - Actual violations → first non-empty per-violation code wins (same aggregation approach as #863's `SchemaValidationErr`, now shared via `model.FirstNonEmptyCode`), falling back to `POL_GENERIC_ERROR` when every violation is still unclassified plain text. `Message` keeps joining every violation's text as before — only `Code` selection changed.
- **`pkg/model/error.go`**: `BadReqErr` gains `Code` + `NewCodedBadReqErr(code, err)`, mirroring `SignValidationErr`'s pattern from #864. `NewBadReqErr`'s default is unchanged (legacy `"Bad Request"` string) since `BadReqErr` is shared across several other plugins outside this ticket's scope.
- **Consolidation**: extracted a shared `codedErr` struct (`Code` field + `Unwrap()` + a `resolveCode` helper) that `SignValidationErr` (#864) and `BadReqErr` both embed now, instead of each independently duplicating the same constructor/fallback boilerplate — worth doing now since the pattern had already repeated twice across two tickets. This is transparent to every existing caller via Go's field-promotion through struct embedding (`signErr.Code`, `errors.Is`/`errors.As` all keep working unchanged); only 4 direct struct literals inside `pkg/model/error_test.go` needed updating to the nested-embed syntax, and the compiler caught all of them.
- **Self-review fixes**: a shared `parseViolationItem(ctx, item)` helper now backs every per-item parse site (`extractViolations`' bare-set and single-string cases, `extractStructuredViolations`' list) instead of each hand-rolling its own logic; a bare-set (`[]interface{}`) result that yields zero parseable violations from a non-empty raw set now falls back to one generic violation instead of silently returning empty — mirroring the structured format's existing `valid=false`-with-no-violations fallback, and closing a fail-open path where a malformed or empty-string item under the bare-set query style would have been silently treated as compliant. Two further review rounds found and closed the same fail-open pattern in two more places: `extractStructuredViolations` now falls back to a generic denial (rather than silently returning `nil`) when a structured result has only one of `valid`/`violations`, or either key has the wrong JSON type; and `extractViolations`' outer type switch now has a `default` case, so a query result of any type outside the four documented shapes (e.g. a bare number from a policy authoring mistake) also falls back to a generic denial instead of being silently dropped with zero violations.

## Migration required

- The wire-visible `code` field for `opapolicychecker`'s policy-denial NACKs — including the "evaluator not initialized" infra-error path — changes from a fixed generic string (`"Bad Request"`) to `POL_*` values (mostly `POL_GENERIC_ERROR` today, more specific values as Rego policies adopt the structured violation shape). Any consumer matching on the old fixed string for this plugin's denials needs to update accordingly.
- **Behavior change, not just a code change**: if you already run a Rego policy under the bare-set query style (`query: data.policy.violations` returning a set, as opposed to the structured `{"valid","violations"}` shape) whose set can contain a coded violation object, a malformed item, or an empty-string item, that item was previously silently dropped and the request was incorrectly **allowed**. It is now correctly **denied**. Review any bare-set policy for this pattern before upgrading if you're relying on the old (incorrect) pass-through behavior.
- **Same behavior change, two more paths**: (1) a policy using the structured `{"valid","violations"}` query shape whose result is missing one of those two keys, or has either key with the wrong JSON type, was previously silently **allowed** (any real violations it carried were discarded) and is now correctly **denied**. (2) a policy whose query result is some other type entirely (not bool/string/set/structured-map — e.g. a bare number from an authoring mistake) was previously silently **allowed** and is now correctly **denied**. Review any policy that could hit either shape before upgrading.

## Testing

- `go build` / `go vet` clean across all touched packages.
- Full repo test suite passes.
- 100% coverage on every new/touched function (`NewCodedBadReqErr`, `resolveCode`, `Unwrap`, `parseViolationItem`, `violationMessages`, `model.FirstNonEmptyCode`, `extractStructuredViolations`, the object-item parsing branches).
- New tests: `BadReqErr`/`resolveCode` unit tests, Rego-driven coded/mixed-violation tests, a direct unit test for the object-item edge cases (code-only fallback, empty-item skip), end-to-end `CheckPolicy` tests confirming a code survives to the final NACK, and regression tests for each self-review fail-open fix (bare-set coded-violation-object, bare-set all-items-unparseable, structured-format missing/wrong-typed keys, and unsupported top-level result type), each at both the `Evaluate`/direct-function level and the end-to-end `CheckPolicy` level where applicable.

Marked as draft — same review-cycle pattern as the prior tickets in this EPIC before this comes out of draft.

