### PR TITLE
reqmapper: map parseRequestBody failures to SCH_* codes

### DIFF
--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -93,7 +93,7 @@ func (s *reqMapperStep) Run(ctx *model.StepContext) error {
 func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte, error) {
 	parsed, err := parseRequestBody(body)
 	if err != nil {
-		return nil, model.NewBadReqErr(err)
+		return nil, err
 	}
 
 	mappedBody, err := s.engine.Transform(ctx, parsed.action, parsed.req, s.role)
@@ -105,20 +105,24 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 	return mappedBody, nil
 }
 
+// parseRequestBody parses the incoming request body and extracts the fields
+// the mapping engine needs. Failures are classified onto the Beckn v2.0.0
+// ErrorCode taxonomy at the point each cause is known, rather than being
+// wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
 	var req map[string]interface{}
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, fmt.Errorf("failed to decode request body: %w", err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_JSON", fmt.Errorf("failed to decode request body: %w", err))
 	}
 
 	reqContext, ok := req["context"].(map[string]interface{})
 	if !ok {
-		return nil, errors.New("context field not found or invalid")
+		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("context field not found or invalid"))
 	}
 
 	action, ok := reqContext["action"].(string)
 	if !ok || action == "" {
-		return nil, errors.New("action field not found or invalid")
+		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("action field not found or invalid"))
 	}
 
 	return &parsedRequest{

--- a/pkg/plugin/implementation/reqmapper/reqmapper_test.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper_test.go
@@ -189,29 +189,48 @@ func TestReqMapperStepRun_EmptyBody(t *testing.T) {
 		Body:    nil,
 	}
 
-	require.Error(t, step.Run(ctx))
+	err = step.Run(ctx)
+	require.Error(t, err)
+	requireBadReqCode(t, err, "SCH_INVALID_JSON")
 }
 
 func TestParseRequestBody(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		_, err := parseRequestBody([]byte("{"))
 		require.Error(t, err)
+		requireBadReqCode(t, err, "SCH_INVALID_JSON")
 	})
 
 	t.Run("missing context", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"message":{}}`))
 		require.EqualError(t, err, "context field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("missing action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("empty action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{"action":""},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
+}
+
+// requireBadReqCode confirms err is a *model.BadReqErr classified with wantCode.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
+	}
 }
 
 func TestMappingEngineTransform(t *testing.T) {


### PR DESCRIPTION
Closes #867. Part of the #861 EPIC. Builds on #862/#863/#864/#865 (already merged into this branch).

## Scope note

#867 originally described mapping "every transform failure" to SCH_*/BIZ_*. Investigating turned up that the cited `BadReqErr` (`reqmapper.go:96`) actually wraps `parseRequestBody` failures (malformed JSON, missing `context`/`action`) — a clean remap, same pattern as #863/#864/#865. The actual JSONata *transform*-evaluation failure currently has no error path at all: it's swallowed and silently falls back to the untransformed body. Classifying that would mean first turning that swallow-to-fallback behavior into a real NACK — new infrastructure, not a relabel. That's been split into standalone issue #880 and is **not** part of this PR. #867 and #861 have been updated accordingly.

## What changed

- **`reqmapper.go`**: `parseRequestBody`'s three failure sites now construct `model.NewCodedBadReqErr(code, err)` directly instead of returning a plain error for the caller to wrap generically:
  - JSON decode failure → `SCH_INVALID_JSON`
  - missing/invalid `context` field → `SCH_REQUIRED_FIELD_MISSING`
  - missing/empty `action` field → `SCH_REQUIRED_FIELD_MISSING`

  Both code strings are reused verbatim from `schemav2validator` (#863) rather than inventing new names. `transformBody` no longer re-wraps the result in a second generic `BadReqErr` — it returns the already-coded error as-is.

## Migration required

The wire-visible `code` field for `reqmapper`'s malformed-request NACKs (bad JSON, missing `context`/`action`) changes from a fixed generic string (`"Bad Request"`) to `SCH_INVALID_JSON`/`SCH_REQUIRED_FIELD_MISSING`. Any consumer matching on the old fixed string for this plugin's request-parsing failures needs to update accordingly. The JSONata transform-evaluation path's behavior (silent fallback to the untransformed body on failure) is unchanged by this PR.

## Testing

- `go build` / `go vet` clean.
- Full package test suite passes.
- 100% coverage on both touched functions (`parseRequestBody`, `transformBody`).
- Existing `TestParseRequestBody` subtests extended with `Code` assertions; `TestReqMapperStepRun_EmptyBody` extended to confirm the code survives end-to-end through `Run()`.

Marked as draft — same review-cycle pattern as the prior tickets in this EPIC before this comes out of draft.