### PR TITLE
reqpreprocessor: map the 3 request-parsing checks to SCH_* codes

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -213,15 +213,20 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // an object) so callers can reuse the same Code/Message regardless of how
 // each formats its own response (e.g. wrapping in NewCodedBadReqErr, or
 // writing a bare JSON body directly). req and reqContext are nil on failure.
-func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error) {
+// cause is the underlying json.Unmarshal error for the SCH_INVALID_JSON case
+// (nil otherwise, since the missing-context case has no wrapped cause of its
+// own) — callers that want errors.Is/errors.As to keep reaching it (e.g. via
+// fmt.Errorf("...: %w", cause)) can use it directly instead of losing that
+// chain through becknErr's already-flattened Message string.
+func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error, cause error) {
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, nil, NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err))
+		return nil, nil, NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err)), err
 	}
 	reqContext, ok := req["context"].(map[string]interface{})
 	if !ok {
-		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid")
+		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid"), nil
 	}
-	return req, reqContext, nil
+	return req, reqContext, nil, nil
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -203,6 +204,24 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	*r = role
 	return nil
+}
+
+// ExtractContext decodes body as JSON and returns both the full decoded body
+// and its "context" field as a map[string]interface{}, classifying the
+// failure onto the Beckn v2.0.0 ErrorCode taxonomy (SCH_INVALID_JSON if body
+// isn't valid JSON, SCH_REQUIRED_FIELD_MISSING if "context" is missing or not
+// an object) so callers can reuse the same Code/Message regardless of how
+// each formats its own response (e.g. wrapping in NewCodedBadReqErr, or
+// writing a bare JSON body directly). req and reqContext are nil on failure.
+func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error) {
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, nil, NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err))
+	}
+	reqContext, ok := req["context"].(map[string]interface{})
+	if !ok {
+		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid")
+	}
+	return req, reqContext, nil
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -218,17 +218,20 @@ func TestResolveNetworkID(t *testing.T) {
 
 func TestExtractContext(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
-		_, _, becknErr := ExtractContext([]byte("{"))
+		_, _, becknErr, cause := ExtractContext([]byte("{"))
 		if becknErr == nil {
 			t.Fatal("expected an error for malformed JSON, got nil")
 		}
 		if becknErr.Code != "SCH_INVALID_JSON" {
 			t.Errorf("Code = %s, want SCH_INVALID_JSON", becknErr.Code)
 		}
+		if cause == nil {
+			t.Error("expected a non-nil cause for a JSON decode failure, so callers can still errors.Is/errors.As through it")
+		}
 	})
 
 	t.Run("missing context", func(t *testing.T) {
-		_, _, becknErr := ExtractContext([]byte(`{"message":{}}`))
+		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
 		if becknErr == nil {
 			t.Fatal("expected an error for missing context, got nil")
 		}
@@ -238,10 +241,13 @@ func TestExtractContext(t *testing.T) {
 		if becknErr.Message != "context field not found or invalid" {
 			t.Errorf("Message = %q, want %q", becknErr.Message, "context field not found or invalid")
 		}
+		if cause != nil {
+			t.Errorf("expected a nil cause for a missing-context failure (no wrapped error of its own), got %v", cause)
+		}
 	})
 
 	t.Run("context is not an object", func(t *testing.T) {
-		_, _, becknErr := ExtractContext([]byte(`{"context":"not-a-map"}`))
+		_, _, becknErr, _ := ExtractContext([]byte(`{"context":"not-a-map"}`))
 		if becknErr == nil {
 			t.Fatal("expected an error for non-object context, got nil")
 		}
@@ -251,9 +257,12 @@ func TestExtractContext(t *testing.T) {
 	})
 
 	t.Run("valid body returns both the full body and its context", func(t *testing.T) {
-		req, reqContext, becknErr := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
+		req, reqContext, becknErr, cause := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
 		if becknErr != nil {
 			t.Fatalf("unexpected error: %+v", becknErr)
+		}
+		if cause != nil {
+			t.Errorf("expected a nil cause on success, got %v", cause)
 		}
 		if req["message"] == nil {
 			t.Errorf("expected req to include the full decoded body, got %+v", req)

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -215,3 +215,51 @@ func TestResolveNetworkID(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractContext(t *testing.T) {
+	t.Run("malformed json", func(t *testing.T) {
+		_, _, becknErr := ExtractContext([]byte("{"))
+		if becknErr == nil {
+			t.Fatal("expected an error for malformed JSON, got nil")
+		}
+		if becknErr.Code != "SCH_INVALID_JSON" {
+			t.Errorf("Code = %s, want SCH_INVALID_JSON", becknErr.Code)
+		}
+	})
+
+	t.Run("missing context", func(t *testing.T) {
+		_, _, becknErr := ExtractContext([]byte(`{"message":{}}`))
+		if becknErr == nil {
+			t.Fatal("expected an error for missing context, got nil")
+		}
+		if becknErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", becknErr.Code)
+		}
+		if becknErr.Message != "context field not found or invalid" {
+			t.Errorf("Message = %q, want %q", becknErr.Message, "context field not found or invalid")
+		}
+	})
+
+	t.Run("context is not an object", func(t *testing.T) {
+		_, _, becknErr := ExtractContext([]byte(`{"context":"not-a-map"}`))
+		if becknErr == nil {
+			t.Fatal("expected an error for non-object context, got nil")
+		}
+		if becknErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", becknErr.Code)
+		}
+	})
+
+	t.Run("valid body returns both the full body and its context", func(t *testing.T) {
+		req, reqContext, becknErr := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
+		if becknErr != nil {
+			t.Fatalf("unexpected error: %+v", becknErr)
+		}
+		if req["message"] == nil {
+			t.Errorf("expected req to include the full decoded body, got %+v", req)
+		}
+		if reqContext["bap_id"] != "bap-123" {
+			t.Errorf("reqContext[\"bap_id\"] = %v, want bap-123", reqContext["bap_id"])
+		}
+	})
+}

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -110,8 +110,14 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 // ErrorCode taxonomy at the point each cause is known, rather than being
 // wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
-	req, reqContext, becknErr := model.ExtractContext(body)
+	req, reqContext, becknErr, cause := model.ExtractContext(body)
 	if becknErr != nil {
+		if cause != nil {
+			// Preserve the underlying decode error in the wrap chain so
+			// errors.Is/errors.As can still reach it, same as before ExtractContext
+			// was extracted.
+			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("failed to decode request body: %w", cause))
+		}
 		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 	}
 

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -110,14 +110,9 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 // ErrorCode taxonomy at the point each cause is known, rather than being
 // wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
-	var req map[string]interface{}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_JSON", fmt.Errorf("failed to decode request body: %w", err))
-	}
-
-	reqContext, ok := req["context"].(map[string]interface{})
-	if !ok {
-		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("context field not found or invalid"))
+	req, reqContext, becknErr := model.ExtractContext(body)
+	if becknErr != nil {
+		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 	}
 
 	action, ok := reqContext["action"].(string)

--- a/pkg/plugin/implementation/reqmapper/reqmapper_test.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper_test.go
@@ -199,11 +199,20 @@ func TestParseRequestBody(t *testing.T) {
 		_, err := parseRequestBody([]byte("{"))
 		require.Error(t, err)
 		requireBadReqCode(t, err, "SCH_INVALID_JSON")
+
+		// Regression test: the decode failure must still unwrap to the
+		// underlying json error via errors.As, matching the wrapping this
+		// function did before model.ExtractContext was extracted (self-review
+		// of #882 found this had silently regressed, then fixed it).
+		var syntaxErr *json.SyntaxError
+		require.ErrorAs(t, err, &syntaxErr, "expected errors.As to still reach the underlying *json.SyntaxError")
 	})
 
 	t.Run("missing context", func(t *testing.T) {
+		// The exact message text for this classification is model.ExtractContext's
+		// concern and is already verified directly in pkg/model/model_test.go;
+		// this only needs to confirm parseRequestBody forwards the Code correctly.
 		_, err := parseRequestBody([]byte(`{"message":{}}`))
-		require.EqualError(t, err, "context field not found or invalid")
 		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -21,18 +20,25 @@ type Config struct {
 	ParentID    string
 }
 
-const contextKey = "context"
-
 // writeCodedError writes a Beckn v2.0.0 ErrorCode-aligned JSON error body.
 // reqpreprocessor runs as HTTP middleware ahead of the standard step/NACK
 // pipeline (see core/module/handler/stdHandler.go's step loop), so this is a
 // correctly-coded but unsigned JSON body, not the full Beckn NACK envelope
 // nack() produces elsewhere — wiring this plugin into that pipeline (with the
-// signing/telemetry implications that carries) is tracked separately.
-func writeCodedError(w http.ResponseWriter, status int, code, message string) {
+// signing/telemetry implications that carries) is tracked separately in #868.
+func writeCodedError(ctx context.Context, w http.ResponseWriter, status int, code, message string) {
+	data, err := json.Marshal(model.NewCodedError(code, message))
+	if err != nil {
+		log.Debugf(ctx, "failed to marshal coded error response: %v", err)
+		http.Error(w, message, status)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(model.Error{Code: code, Message: message})
+	if _, werr := w.Write(data); werr != nil {
+		log.Debugf(ctx, "failed to write coded error response: %v", werr)
+		http.Error(w, message, http.StatusInternalServerError)
+	}
 }
 
 // snakeToCamel converts a snake_case string to camelCase.
@@ -61,7 +67,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				writeCodedError(w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
+				writeCodedError(r.Context(), w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
 				return
 			}
 			ctx := r.Context()
@@ -82,16 +88,11 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				return
 			}
 
-			var req map[string]interface{}
-			if err := json.Unmarshal(body, &req); err != nil {
-				writeCodedError(w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to decode request body")
-				return
-			}
-
-			// Extract context from request.
-			reqContext, ok := req["context"].(map[string]interface{})
-			if !ok {
-				writeCodedError(w, http.StatusBadRequest, "SCH_REQUIRED_FIELD_MISSING", fmt.Sprintf("%s field not found or invalid.", contextKey))
+			// Decode the body and extract its context field using the same
+			// classification reqmapper (#867) relies on for the identical check.
+			_, reqContext, becknErr := model.ExtractContext(body)
+			if becknErr != nil {
+				writeCodedError(ctx, w, http.StatusBadRequest, becknErr.Code, becknErr.Message)
 				return
 			}
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -27,12 +27,10 @@ type Config struct {
 // nack() produces elsewhere — wiring this plugin into that pipeline (with the
 // signing/telemetry implications that carries) is tracked separately in #868.
 func writeCodedError(ctx context.Context, w http.ResponseWriter, status int, code, message string) {
-	data, err := json.Marshal(model.NewCodedError(code, message))
-	if err != nil {
-		log.Debugf(ctx, "failed to marshal coded error response: %v", err)
-		http.Error(w, message, status)
-		return
-	}
+	// model.NewCodedError's result is a two-string-field struct that cannot
+	// realistically fail to marshal — matching nack()'s own established
+	// convention (core/module/handler/responsestep.go) of not guarding this.
+	data, _ := json.Marshal(model.NewCodedError(code, message))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if _, werr := w.Write(data); werr != nil {
@@ -65,12 +63,12 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				writeCodedError(r.Context(), w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
+				writeCodedError(ctx, w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
 				return
 			}
-			ctx := r.Context()
 
 			// Bodyless requests (GET/DELETE) carry no JSON body and no context
 			// fields — skip body extraction and pass through directly.
@@ -90,7 +88,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 
 			// Decode the body and extract its context field using the same
 			// classification reqmapper (#867) relies on for the identical check.
-			_, reqContext, becknErr := model.ExtractContext(body)
+			_, reqContext, becknErr, _ := model.ExtractContext(body)
 			if becknErr != nil {
 				writeCodedError(ctx, w, http.StatusBadRequest, becknErr.Code, becknErr.Message)
 				return

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -23,6 +23,18 @@ type Config struct {
 
 const contextKey = "context"
 
+// writeCodedError writes a Beckn v2.0.0 ErrorCode-aligned JSON error body.
+// reqpreprocessor runs as HTTP middleware ahead of the standard step/NACK
+// pipeline (see core/module/handler/stdHandler.go's step loop), so this is a
+// correctly-coded but unsigned JSON body, not the full Beckn NACK envelope
+// nack() produces elsewhere — wiring this plugin into that pipeline (with the
+// signing/telemetry implications that carries) is tracked separately.
+func writeCodedError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(model.Error{Code: code, Message: message})
+}
+
 // snakeToCamel converts a snake_case string to camelCase.
 // For example: "transaction_id" -> "transactionId".
 // Returns the input unchanged if it contains no underscores.
@@ -49,7 +61,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				http.Error(w, "Failed to read request body", http.StatusBadRequest)
+				writeCodedError(w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
 				return
 			}
 			ctx := r.Context()
@@ -72,14 +84,14 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 
 			var req map[string]interface{}
 			if err := json.Unmarshal(body, &req); err != nil {
-				http.Error(w, "Failed to decode request body", http.StatusBadRequest)
+				writeCodedError(w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to decode request body")
 				return
 			}
 
 			// Extract context from request.
 			reqContext, ok := req["context"].(map[string]interface{})
 			if !ok {
-				http.Error(w, fmt.Sprintf("%s field not found or invalid.", contextKey), http.StatusBadRequest)
+				writeCodedError(w, http.StatusBadRequest, "SCH_REQUIRED_FIELD_MISSING", fmt.Sprintf("%s field not found or invalid.", contextKey))
 				return
 			}
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -2,6 +2,7 @@ package reqpreprocessor
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -288,6 +289,40 @@ func TestNewPreProcessor_BodyReadFailure(t *testing.T) {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
 	}
 	requireCodedErrorBody(t, rec, "SCH_INVALID_JSON")
+}
+
+// failOnceWriteRecorder wraps httptest.ResponseRecorder but fails the first
+// Write, then passes subsequent writes through — used to exercise
+// writeCodedError's write-failure fallback path and observe its effect.
+type failOnceWriteRecorder struct {
+	*httptest.ResponseRecorder
+	failed bool
+}
+
+func (r *failOnceWriteRecorder) Write(b []byte) (int, error) {
+	if !r.failed {
+		r.failed = true
+		return 0, errors.New("simulated write failure")
+	}
+	return r.ResponseRecorder.Write(b)
+}
+
+func TestWriteCodedError_WriteFailureFallsBackToHTTPError(t *testing.T) {
+	rec := &failOnceWriteRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	writeCodedError(context.Background(), rec, http.StatusBadRequest, "SCH_INVALID_JSON", "failed to decode")
+
+	// The initial WriteHeader(400) already committed the status line before the
+	// write failed; a superfluous second WriteHeader call from http.Error's
+	// fallback is a no-op (matches real net/http.ResponseWriter semantics, same
+	// as nack()'s established pattern), so the status stays 400 — but the
+	// fallback's plain-text body still lands via the second (successful) write.
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, "failed to decode") {
+		t.Errorf("body = %q, want it to contain the fallback http.Error message", got)
+	}
 }
 
 // TestSnakeToCamel tests the snakeToCamel conversion helper.

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -3,6 +3,7 @@ package reqpreprocessor
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -130,6 +131,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 		expectedCode int
 		expectErr    bool
 		errMsg       string
+		wantBeckn    string // expected model.Error.Code in the response body, if expectedCode is a per-request failure
 	}{
 		{
 			name: "Missing context",
@@ -142,6 +144,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "context field not found or invalid",
+			wantBeckn:    "SCH_REQUIRED_FIELD_MISSING",
 		},
 		{
 			name: "Invalid context type",
@@ -154,6 +157,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "context field not found or invalid",
+			wantBeckn:    "SCH_REQUIRED_FIELD_MISSING",
 		},
 		{
 			name:         "Nil config",
@@ -199,6 +203,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "failed to decode request body",
+			wantBeckn:    "SCH_INVALID_JSON",
 		},
 	}
 
@@ -231,8 +236,58 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			if rec.Code != tt.expectedCode {
 				t.Errorf("Expected status code %d, but got %d", tt.expectedCode, rec.Code)
 			}
+
+			if tt.wantBeckn != "" {
+				requireCodedErrorBody(t, rec, tt.wantBeckn)
+			}
 		})
 	}
+}
+
+// requireCodedErrorBody confirms rec's body is a JSON model.Error with the
+// given Code, and that Content-Type reflects that.
+func requireCodedErrorBody(t *testing.T, rec *httptest.ResponseRecorder, wantCode string) {
+	t.Helper()
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got model.Error
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response body is not valid JSON model.Error: %v (body: %s)", err, rec.Body.String())
+	}
+	if got.Code != wantCode {
+		t.Errorf("response body Code = %s, want %s", got.Code, wantCode)
+	}
+}
+
+// errReader is an io.Reader that always fails, used to exercise the
+// io.ReadAll(r.Body) failure path in NewPreProcessor's middleware.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("simulated read failure")
+}
+
+func TestNewPreProcessor_BodyReadFailure(t *testing.T) {
+	cfg := &Config{Role: "bap"}
+	middleware, err := NewPreProcessor(cfg)
+	if err != nil {
+		t.Fatalf("NewPreProcessor() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/test", errReader{})
+	rec := httptest.NewRecorder()
+
+	middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler must not be called when the body can't be read")
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	requireCodedErrorBody(t, rec, "SCH_INVALID_JSON")
 }
 
 // TestSnakeToCamel tests the snakeToCamel conversion helper.


### PR DESCRIPTION
Part of #868. Part of the #861 EPIC. Builds on #862/#863/#864/#865/#867 (already merged into this branch).

## Scope note

#868 as filed also covers wiring `reqpreprocessor` into the standard signed NACK envelope/pipeline — but `reqpreprocessor` is the *only* `MiddlewareProvider` in the codebase, running as an `http.Handler` wrapper **before** `stdHandler.ServeHTTP` (and therefore the step loop, `signNackResponse`, and telemetry) is ever invoked. Converting it into a `definition.Step` (or an equivalent relay mechanism) is a real architectural decision with its own regression risk: `stdHandler` currently reads context values this middleware injects *before* the step loop runs, to compute sender/receiver telemetry attribution for every request — not just failures. That decision is deliberately left out of this PR; **this PR only classifies the 3 existing failure checks onto the ErrorCode taxonomy**, keeping the response unsigned and pre-pipeline exactly as today.

## What changed

- **`reqpreprocessor.go`**: added `writeCodedError`, which writes a Beckn v2.0.0-shaped JSON body (`{"code": ..., "message": ...}`) instead of `http.Error`'s plain text. All 3 failure sites now classify:
  - body-read failure → `SCH_INVALID_JSON`
  - JSON decode failure → `SCH_INVALID_JSON`
  - missing/invalid `context` field → `SCH_REQUIRED_FIELD_MISSING`

  Both codes are reused verbatim from `schemav2validator`/`reqmapper` (#867) rather than inventing new names.
- **`pkg/model/model.go`**: extracted a new `ExtractContext(body) (req, reqContext map[string]interface{}, becknErr *Error, cause error)` helper, alongside the existing `ResolveSubscriberID`/`ResolveCallerID`/`ResolveNetworkID`/`ParseContextKey` context helpers. `reqmapper`'s `parseRequestBody` (#867) and `reqpreprocessor` had byte-for-byte duplicated "decode JSON, extract context field" logic — found during this PR's self-review, with the message text already starting to drift between the two copies. Both plugins now share one implementation and one set of tests instead of two. `cause` carries the underlying `json.Unmarshal` error for the decode-failure case specifically so callers that want to keep `errors.Is`/`errors.As` reaching it (like `reqmapper`, which wraps it with `%w`) can — a second round of self-review found this reachability had silently regressed when `reqmapper` was first switched over to the shared helper, since a flattened message string can't be unwrapped back to the concrete `*json.SyntaxError`.
- **Self-review fixes (round 1)**: `writeCodedError` now builds its body via `model.NewCodedError` instead of a raw struct literal; a JSON-encode/write failure is now logged and falls back to `http.Error`, matching `nack()`'s established convention elsewhere in the codebase (previously silently swallowed); its doc comment now references this issue (#868) for the deferred NACK-envelope wiring decision.
- **Self-review fixes (round 2)**: restored the `errors.Is`/`errors.As` chain described above; removed `writeCodedError`'s `json.Marshal` error-handling branch (unreachable for `model.NewCodedError`'s trivially-marshalable shape, and more defensive than `nack()`'s own pattern, which doesn't guard its equivalent marshal step either); hoisted `reqpreprocessor`'s `ctx := r.Context()` so both call sites share one value instead of calling `r.Context()` twice; trimmed a redundant message-text assertion in `reqmapper_test.go` that re-verified `ExtractContext`'s own classification (already covered directly in `pkg/model/model_test.go`).

## Migration required

The wire-visible response body for these 3 `reqpreprocessor` failure modes changes from a plain-text `http.Error` string to a JSON object with `code`/`message` fields (`SCH_INVALID_JSON` / `SCH_REQUIRED_FIELD_MISSING`). HTTP status codes are unchanged (still 400). Any consumer parsing these specific responses as plain text needs to switch to JSON parsing and match on the new `code` values. The response remains **unsigned** and does not flow through the standard NACK/telemetry pipeline — that behavior is unchanged by this PR (tracked separately, see Scope note above).

## Testing

- `go build` / `go vet` clean across `pkg/model`, `reqmapper`, and `reqpreprocessor`.
- Full test suites pass in all three packages.
- 100% coverage on `model.ExtractContext`, `parseRequestBody`, and (after removing the unreachable branch) `writeCodedError`; `reqpreprocessor` package total 97.4%.
- New direct unit tests for `model.ExtractContext` (malformed JSON + cause, missing context + nil cause, non-object context, valid body). Existing `reqpreprocessor` error-case tests extended with `Content-Type`/`Code` assertions via `requireCodedErrorBody`; added tests for the body-read-failure path and the write-failure fallback path; added a `reqmapper` regression test confirming `errors.As` still reaches the underlying `*json.SyntaxError`.

Marked as draft — same review-cycle pattern as the prior tickets in this EPIC before this comes out of draft.

