### PR TITLE
router: map request-parsing failures to SCH_* codes

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -227,6 +228,20 @@ func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[str
 		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid"), nil
 	}
 	return req, reqContext, nil, nil
+}
+
+// WrapExtractContextErr converts an ExtractContext failure (becknErr, cause)
+// into a *BadReqErr carrying becknErr's Code, for callers that need an error
+// value rather than the bare *Error ExtractContext returns. When cause is
+// non-nil (the SCH_INVALID_JSON case), it's wrapped with prefix via %w so
+// errors.Is/errors.As still reach it; the SCH_REQUIRED_FIELD_MISSING case has
+// no cause of its own, so becknErr.Message is used directly. Only call this
+// when becknErr is non-nil.
+func WrapExtractContextErr(prefix string, becknErr *Error, cause error) *BadReqErr {
+	if cause != nil {
+		return NewCodedBadReqErr(becknErr.Code, fmt.Errorf("%s: %w", prefix, cause))
+	}
+	return NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,6 +1,11 @@
 package model
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestIsKeyStatusUsable(t *testing.T) {
 	tests := []struct {
@@ -269,6 +274,36 @@ func TestExtractContext(t *testing.T) {
 		}
 		if reqContext["bap_id"] != "bap-123" {
 			t.Errorf("reqContext[\"bap_id\"] = %v, want bap-123", reqContext["bap_id"])
+		}
+	})
+}
+
+func TestWrapExtractContextErr(t *testing.T) {
+	t.Run("with cause, wraps prefix and preserves errors.As reachability", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte("{"))
+		err := WrapExtractContextErr("error parsing request body", becknErr, cause)
+
+		if err.Code != "SCH_INVALID_JSON" {
+			t.Errorf("Code = %s, want SCH_INVALID_JSON", err.Code)
+		}
+		if !strings.Contains(err.Error(), "error parsing request body") {
+			t.Errorf("Error() = %q, want it to contain the given prefix", err.Error())
+		}
+		var syntaxErr *json.SyntaxError
+		if !errors.As(err, &syntaxErr) {
+			t.Error("expected errors.As to reach the underlying *json.SyntaxError")
+		}
+	})
+
+	t.Run("without cause, uses becknErr.Message directly", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
+		err := WrapExtractContextErr("unused prefix", becknErr, cause)
+
+		if err.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", err.Code)
+		}
+		if !strings.Contains(err.Error(), "context field not found or invalid") {
+			t.Errorf("Error() = %q, want it to contain becknErr.Message", err.Error())
 		}
 	})
 }

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -112,13 +112,7 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 func parseRequestBody(body []byte) (*parsedRequest, error) {
 	req, reqContext, becknErr, cause := model.ExtractContext(body)
 	if becknErr != nil {
-		if cause != nil {
-			// Preserve the underlying decode error in the wrap chain so
-			// errors.Is/errors.As can still reach it, same as before ExtractContext
-			// was extracted.
-			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("failed to decode request body: %w", cause))
-		}
-		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
+		return nil, model.WrapExtractContextErr("failed to decode request body", becknErr, cause)
 	}
 
 	action, ok := reqContext["action"].(string)

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -238,10 +237,7 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	// map decodes of the same body.
 	_, reqContext, becknErr, cause := model.ExtractContext(body)
 	if becknErr != nil {
-		if cause != nil {
-			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("error parsing request body: %w", cause))
-		}
-		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
+		return nil, model.WrapExtractContextErr("error parsing request body", becknErr, cause)
 	}
 
 	// Checks legacy snake_case (bpp_uri, bap_uri), then camelCase (bppUri,

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -2,7 +2,7 @@ package router
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -232,35 +232,27 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 		return r.routeBodyless(endpoint, rawQuery)
 	}
 
-	// Parse domain and version via typed struct.
-	var requestBody struct {
-		Context struct {
-			Domain  string `json:"domain"`
-			Version string `json:"version"`
-		} `json:"context"`
-	}
-	if err := json.Unmarshal(body, &requestBody); err != nil {
-		return nil, fmt.Errorf("error parsing request body: %w", err)
+	// Decode the body and extract its context field using the same
+	// classification reqmapper (#867) and reqpreprocessor (#868) rely on for
+	// the identical check, instead of router's own separate typed-struct and
+	// map decodes of the same body.
+	_, reqContext, becknErr, cause := model.ExtractContext(body)
+	if becknErr != nil {
+		if cause != nil {
+			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("error parsing request body: %w", cause))
+		}
+		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 	}
 
-	// Parse context as a map solely to resolve URI fields. Checks legacy
-	// snake_case (bpp_uri, bap_uri), then camelCase (bppUri, bapUri), then
-	// the new Beckn spec v2 names (receiverUri, senderUri).
-	var uriBody struct {
-		Context map[string]interface{} `json:"context"`
-	}
-	if err := json.Unmarshal(body, &uriBody); err != nil {
-		return nil, fmt.Errorf("error parsing request body: %w", err)
-	}
-	if uriBody.Context == nil {
-		return nil, fmt.Errorf("context field not found or invalid in request body")
-	}
-	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri", "receiverUri")
-	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri", "senderUri")
+	// Checks legacy snake_case (bpp_uri, bap_uri), then camelCase (bppUri,
+	// bapUri), then the new Beckn spec v2 names (receiverUri, senderUri).
+	bppURI := getContextString(reqContext, "bpp_uri", "bppUri", "receiverUri")
+	bapURI := getContextString(reqContext, "bap_uri", "bapUri", "senderUri")
+	version := getContextString(reqContext, "version")
 
 	// For v2.x.x, ignore domain and use wildcard; for v1.x.x, use actual domain
-	domain := requestBody.Context.Domain
-	if isV2Version(requestBody.Context.Version) {
+	domain := getContextString(reqContext, "domain")
+	if isV2Version(version) {
 		domain = "*"
 	}
 
@@ -268,26 +260,26 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	domainRules, ok := r.rules[domain]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("no routing rules found for version %s", requestBody.Context.Version)
+			return nil, fmt.Errorf("no routing rules found for version %s", version)
 		}
-		return nil, fmt.Errorf("no routing rules found for domain %s", requestBody.Context.Domain)
+		return nil, fmt.Errorf("no routing rules found for domain %s", domain)
 	}
 
-	versionRules, ok := domainRules[requestBody.Context.Version]
+	versionRules, ok := domainRules[version]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("no routing rules found for version %s", requestBody.Context.Version)
+			return nil, fmt.Errorf("no routing rules found for version %s", version)
 		}
-		return nil, fmt.Errorf("no routing rules found for domain %s version %s", requestBody.Context.Domain, requestBody.Context.Version)
+		return nil, fmt.Errorf("no routing rules found for domain %s version %s", domain, version)
 	}
 
 	route, ok := versionRules[endpoint]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("endpoint '%s' is not supported for version %s in routing config", endpoint, requestBody.Context.Version)
+			return nil, fmt.Errorf("endpoint '%s' is not supported for version %s in routing config", endpoint, version)
 		}
 		return nil, fmt.Errorf("endpoint '%s' is not supported for domain %s and version %s in routing config",
-			endpoint, requestBody.Context.Domain, requestBody.Context.Version)
+			endpoint, domain, version)
 	}
 	// Handle BPP/BAP routing with request URIs.
 	// Both legacy ("bpp"/"bap") and new spec v2 ("receiver"/"sender") values are accepted.
@@ -381,7 +373,8 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string)
 	}
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT",
+			fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err))
 	}
 	targetURL.Path = joinPath(targetURL, endpoint)
 	if rawQuery != "" {

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -533,6 +533,12 @@ func TestRouteFailure(t *testing.T) {
 		endpointAction string
 		body           string
 		wantErr        string
+		// wantCode is checked via requireBadReqCode when non-empty. Failure
+		// modes that remain unclassified (plain fmt.Errorf, no model.Error)
+		// leave this blank — see #869's scope note on why domain/version/
+		// endpoint config-lookup misses and missing-URI-with-no-fallback are
+		// deliberately left out of this ticket's SCH_* realignment.
+		wantCode string
 	}{
 		{
 			name:           "Unsupported endpoint",
@@ -568,6 +574,15 @@ func TestRouteFailure(t *testing.T) {
 			endpointAction: "select",
 			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "htp:// invalid-url"}}`,
 			wantErr:        `invalid BPP URI - htp:// invalid-url in request body for select: parse "htp:// invalid-url": invalid character " " in host name`,
+			wantCode:       "SCH_INVALID_FORMAT",
+		},
+		{
+			name:           "Malformed JSON body",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {`,
+			wantErr:        "error parsing request body",
+			wantCode:       "SCH_INVALID_JSON",
 		},
 	}
 
@@ -580,7 +595,24 @@ func TestRouteFailure(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("Route(%q, %q) = %v, want error containing %q", tt.endpointAction, tt.body, err, tt.wantErr)
 			}
+			if tt.wantCode != "" {
+				requireBadReqCode(t, err, tt.wantCode)
+			}
 		})
+	}
+}
+
+// requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode,
+// mirroring reqmapper_test.go's helper of the same name for the same check.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 
@@ -873,6 +905,7 @@ func TestRouteNilContext(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "context field not found or invalid") {
 		t.Errorf("Route() with missing context = %v, want error containing 'context field not found or invalid'", err)
 	}
+	requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 }
 
 // TestV1DomainRequired tests that domain is required for v1 configs


### PR DESCRIPTION
Part of #869. Part of the #861 EPIC. Builds on #862/#867/#868 (already merged into this branch).

## Scope note

#869 as filed asks to classify router's failures onto the `NET_*` family (`NET_TIMEOUT`, `NET_DOWNSTREAM_UNAVAILABLE`, `NET_CALLBACK_FAILED`, `NET_ACK_TIMEOUT`, `NET_OVERLOADED`, `NET_NOT_IMPLEMENTED`, `NET_INTERNAL_ERROR`). Investigating router.go's actual code first: it is a pure config-lookup component — it parses the request body, looks up domain/version/endpoint in an in-memory map built at bootup, and returns a target. It never makes an outbound HTTP call itself, so none of the network-failure codes (`NET_TIMEOUT`, `NET_DOWNSTREAM_UNAVAILABLE`, `NET_CALLBACK_FAILED`, `NET_ACK_TIMEOUT`, `NET_OVERLOADED`) can ever be produced here — those can only fire from the actual dispatch code in `core/module/handler/stdHandler.go`'s reverse-proxy path (which today has no custom `ErrorHandler`, so a live connection failure bypasses the NACK envelope entirely) and `pkg/plugin/implementation/publisher/publisher.go`'s `Publish()` (which currently wraps MQ failures as `BadReqErr`, already the wrong bucket). Making those reachable requires new error-classification infrastructure, not a remap — deferred to a follow-up ticket once NET_* handling across the dispatch layer is designed holistically, matching the precedent set by #866/#880's scope splits.

Domain/version/endpoint config-lookup misses and the missing-BAP/BPP-URI-with-no-fallback-configured case are also left unclassified for the same reason — they'd need a `NET_*` code (closest fit `NET_NOT_IMPLEMENTED`) and are deferred alongside the item above rather than picking a code under time pressure. Self-review flagged that this leaves the deferred cases in a *sharper* inconsistency than typical partial migration: in `handleProtocolMapping`, the missing-URI-with-no-fallback branch sits a few lines from the now-coded invalid-URI-format branch on the exact same field, and a client keyed off "code present = don't retry" could wrongly retry the deferred, permanent-misconfiguration cases. Noting this explicitly for the follow-up ticket to prioritize rather than leaving it implicit.

Bootstrap/config-loading errors (`New`, `loadRules`, `validateRules`) fire at process startup from a static YAML file, before any HTTP request exists, and never reach `nackBecknError` — no `ErrorCode` applies to them; the process simply fails to start today, unchanged by this PR.

**This PR only classifies the failures in `Route()`/`handleProtocolMapping()` that are already produced today and don't require any new detection logic** — a pure realignment of existing failures onto the taxonomy, not new error paths.

## What changed

- **`router.go`**: replaced router's own duplicated "decode JSON via a typed struct for domain/version, decode JSON again via a generic map for the context object" logic with `model.ExtractContext` — the helper #868 introduced for the identical pattern in `reqmapper`/`reqpreprocessor`. This closes the "third duplicate site" gap flagged during #882's review. `domain`/`version` are now read off the same `reqContext` map as the URI fields via the existing `getContextString` helper, instead of a separate strict-typed struct decode.
  - Malformed JSON body → `SCH_INVALID_JSON`
  - Missing/invalid `context` field → `SCH_REQUIRED_FIELD_MISSING`
  - Invalid BAP/BPP URI string in the body (`handleProtocolMapping`) → `SCH_INVALID_FORMAT`

  All three wrap via `model.NewCodedBadReqErr`, the same pattern `reqmapper`/`reqpreprocessor` use — `core/module/handler/responsestep.go`'s `nackBecknError` already type-switches on `*model.BadReqErr` via `errors.As`, and `addRouteStep.Run` (`core/module/handler/step.go`) already wraps `Route()`'s error with `fmt.Errorf("...: %w", err)`, so the `errors.As` chain reaches the new `*model.BadReqErr` with **no changes needed to `step.go`**.

## Migration required

The wire-visible response for these 3 failure modes changes from an uncoded, generic 500 `"Internal Server Error"` to a 400 with `code` set to `SCH_INVALID_JSON` / `SCH_REQUIRED_FIELD_MISSING` / `SCH_INVALID_FORMAT`. Any consumer that was relying on the generic 500 for these specific router failures needs to switch to matching on the new codes and the now-400 status.

One behavioral nuance from consolidating onto `model.ExtractContext`: `domain`/`version` are no longer decoded via a strict-typed struct, so a non-string JSON value for either field (e.g. `"domain": 123`) no longer produces a decode error. This matches how `reqmapper`/`reqpreprocessor` already behave (they never type-checked these fields either), but self-review sharpened the impact: for **v2 requests specifically, this is a fail-open** — `domain` is force-overwritten to `"*"` for v2 regardless of its value, so a malformed-type `domain` field is never even inspected, and the request now **routes successfully end-to-end where it used to be rejected** at JSON-decode time. For v1 requests (where domain is actually used), the same silent `""` instead degrades into a misleading, still-uncoded `"no routing rules found for domain "` message rather than a clear parse error — same outcome (rejected), worse diagnostics. Neither case is currently covered by a test. Flagging this precisely rather than leaving the original, vaguer framing, since two independent self-review passes converged on it as the most significant open item — left as a known, disclosed tradeoff in this PR per its agreed scope (pure SCH_*/format realignment, no new detection logic), but a strong candidate for a fast-follow fix.

## Self-review fixes (round 1)

`router.go` and `reqmapper.go` each independently built the same `becknErr`/`cause` → `*model.BadReqErr` wrapping block after adopting `model.ExtractContext`, differing only in the wrap-message prefix — a new duplicate introduced by this PR on top of the one #868 already closed. Extracted `model.WrapExtractContextErr(prefix string, becknErr *Error, cause error) *BadReqErr` as the single implementation both callers use now, with its own direct unit tests in `model_test.go` (100% coverage) rather than relying solely on `router`/`reqmapper`'s tests to exercise it indirectly.

## Testing

- `go build ./...` / `go vet ./...` clean (aside from the repo-wide pre-existing `*/cmd` plugin-package build quirk, unrelated to this change — confirmed identical on `main`).
- `go test ./pkg/model/... ./pkg/plugin/implementation/router/... ./pkg/plugin/implementation/reqmapper/... -cover`: all pass. Coverage: `router` 93.9% (≥90% target from the ticket's acceptance criteria), `reqmapper` 75.2%, `model` 72.9% (`WrapExtractContextErr` and `ExtractContext` both 100%).
- Extended `TestRouteFailure` with a malformed-JSON case and `wantCode` assertions (via a `requireBadReqCode` helper mirroring `reqmapper_test.go`'s) on the newly-classified paths; extended `TestRouteNilContext` with the same Code check.
- Added `TestWrapExtractContextErr` in `pkg/model/model_test.go` covering both the with-cause (errors.As reachability preserved) and without-cause branches.
- All pre-existing `router`, `reqmapper`, and `core/module/handler` (`addRouteStep`) tests pass unchanged.

## Self-review fixes (round 2)

Round 2 re-reviewed the round-1 fix commit specifically (the `WrapExtractContextErr` extraction) across all 8 angles; 7 of 8 came back clean, confirming the extraction is behavior-preserving, non-duplicative, and minimal. One non-blocking finding: `WrapExtractContextErr`'s name doesn't signal that it always produces a `*BadReqErr` specifically, and this codebase already treats the `SCH_*` code family as legitimately multi-typed (`schemav2validator.go` wraps some of its own `SCH_*` failures in `*model.SchemaValidationErr` instead, since `nackBecknError` formats the two NACK shapes differently) — a future `ExtractContext` caller reaching for this helper by default could get the wrong error shape for their context. Left as-is for this PR (not a functional defect, just a naming/doc-comment clarity note for whoever next adds an `ExtractContext` caller to keep in mind).

Went through 2 rounds of manual self-review (8-angle process) before coming out of draft, matching the prior tickets in this EPIC.

