### PR TITLE
encrypter/decrypter/publisher/vcvalidator: classify BadReqErr usage into correct codes

### DIFF
--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -170,6 +170,17 @@ func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
+//
+// The "Signature Validation Error: " message prefix was accurate for this
+// type's original sole caller (signvalidator.go, exclusively real signature
+// failures). vcvalidator (see #870/#884) also constructs SignValidationErr
+// for non-signature causes — expiry, revocation, DID-resolution failures,
+// issuer mismatch — via NewCodedSignValidationErr, so the human-readable
+// message can now read e.g. "Signature Validation Error: CREDENTIAL_EXPIRED:
+// ...". The structured Code field is correct either way; only this message
+// text is misleading for those causes. Deliberately left as-is: fixing it is
+// a cross-cutting change affecting every caller of this type, deferred
+// rather than folded into #884's scope.
 func (e *SignValidationErr) BecknError() *Error {
 	return &Error{
 		Code:    e.resolveCode(defaultSignValidationCode),

--- a/pkg/plugin/implementation/decrypter/decrypter.go
+++ b/pkg/plugin/implementation/decrypter/decrypter.go
@@ -27,12 +27,12 @@ func New(ctx context.Context) (*decrypter, func() error, error) {
 func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Decode the Base64 encoded encrypted data.
@@ -68,11 +68,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create private key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create public key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/decrypter/decrypter.go
+++ b/pkg/plugin/implementation/decrypter/decrypter.go
@@ -27,12 +27,12 @@ func New(ctx context.Context) (*decrypter, func() error, error) {
 func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Decode the Base64 encoded encrypted data.
@@ -68,11 +68,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create private key: %w", err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create public key: %w", err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/decrypter/decrypter.go
+++ b/pkg/plugin/implementation/decrypter/decrypter.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/ecdh"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/zenazn/pkcs7pad"
@@ -37,7 +38,7 @@ func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64
 	// Decode the Base64 encoded encrypted data.
 	messageByte, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("failed to decode encrypted data: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to decode encrypted data: %w", err))
 	}
 
 	aesCipher, err := createAESCipher(privateKeyBytes, publicKeyBytes)
@@ -47,7 +48,7 @@ func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64
 
 	blocksize := aesCipher.BlockSize()
 	if len(messageByte)%blocksize != 0 {
-		return "", fmt.Errorf("ciphertext is not a multiple of the blocksize")
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", errors.New("ciphertext is not a multiple of the blocksize"))
 	}
 
 	for i := 0; i < len(messageByte); i += aesCipher.BlockSize() {

--- a/pkg/plugin/implementation/decrypter/decrypter_test.go
+++ b/pkg/plugin/implementation/decrypter/decrypter_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 
@@ -133,11 +134,7 @@ func TestDecrypterFailure(t *testing.T) {
 		privateKey    string
 		publicKey     string
 		expectedErr   string
-		// wantCode is checked via requireBadReqCode when non-empty. Key-material
-		// validity failures (private/public key format or size) are left blank
-		// for now — #870 flagged these as needing confirmation they're ever
-		// wire-derived before assigning a code, since decrypter has no
-		// production caller in this codebase today.
+		// wantCode is checked via requireBadReqCode when non-empty.
 		wantCode string
 	}{
 		{
@@ -146,6 +143,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "invalid-base64!@#$",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Invalid public key format",
@@ -153,6 +151,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "invalid-base64!@#$",
 			expectedErr:   "invalid public key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Invalid encrypted data format",
@@ -168,6 +167,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Empty public key",
@@ -175,6 +175,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "",
 			expectedErr:   "invalid public key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Invalid base64 data",
@@ -190,6 +191,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    base64.StdEncoding.EncodeToString([]byte("short")),
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to create private key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Invalid public key size",
@@ -197,6 +199,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     base64.StdEncoding.EncodeToString([]byte("short")),
 			expectedErr:   "failed to create public key",
+			wantCode:      "SCH_INVALID_FORMAT",
 		},
 		{
 			name:          "Invalid block size",
@@ -233,12 +236,19 @@ func TestDecrypterFailure(t *testing.T) {
 }
 
 // requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode.
+// requireBadReqCode asserts err unwraps (via errors.As, matching how
+// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
+// wantCode. createAESCipher's callers re-wrap its errors in an outer
+// fmt.Errorf, so a raw type assertion would miss a coded error returned from
+// there even though production code (nackBecknError) finds it fine via
+// errors.As — mirrors encrypter_test.go's helper of the same name, which
+// needed this for the identical reason.
 func requireBadReqCode(t *testing.T, err error, wantCode string) {
 	t.Helper()
 
-	badReqErr, ok := err.(*model.BadReqErr)
-	if !ok {
-		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	var badReqErr *model.BadReqErr
+	if !errors.As(err, &badReqErr) {
+		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
 	}
 	if code := badReqErr.BecknError().Code; code != wantCode {
 		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)

--- a/pkg/plugin/implementation/decrypter/decrypter_test.go
+++ b/pkg/plugin/implementation/decrypter/decrypter_test.go
@@ -143,7 +143,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "invalid-base64!@#$",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid public key format",
@@ -151,7 +151,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "invalid-base64!@#$",
 			expectedErr:   "invalid public key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid encrypted data format",
@@ -167,7 +167,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Empty public key",
@@ -175,7 +175,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "",
 			expectedErr:   "invalid public key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid base64 data",
@@ -191,7 +191,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    base64.StdEncoding.EncodeToString([]byte("short")),
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to create private key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid public key size",
@@ -199,7 +199,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     base64.StdEncoding.EncodeToString([]byte("short")),
 			expectedErr:   "failed to create public key",
-			wantCode:      "SCH_INVALID_FORMAT",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid block size",
@@ -235,7 +235,6 @@ func TestDecrypterFailure(t *testing.T) {
 	}
 }
 
-// requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode.
 // requireBadReqCode asserts err unwraps (via errors.As, matching how
 // nackBecknError itself classifies errors) to a *model.BadReqErr carrying
 // wantCode. createAESCipher's callers re-wrap its errors in an outer

--- a/pkg/plugin/implementation/decrypter/decrypter_test.go
+++ b/pkg/plugin/implementation/decrypter/decrypter_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/zenazn/pkcs7pad"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Helper function to generate valid test keys.
@@ -131,6 +133,12 @@ func TestDecrypterFailure(t *testing.T) {
 		privateKey    string
 		publicKey     string
 		expectedErr   string
+		// wantCode is checked via requireBadReqCode when non-empty. Key-material
+		// validity failures (private/public key format or size) are left blank
+		// for now — #870 flagged these as needing confirmation they're ever
+		// wire-derived before assigning a code, since decrypter has no
+		// production caller in this codebase today.
+		wantCode string
 	}{
 		{
 			name:          "Invalid private key format",
@@ -152,6 +160,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to decode encrypted data",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Empty private key",
@@ -173,6 +182,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to decode encrypted data",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid private key size",
@@ -194,6 +204,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "ciphertext is not a multiple of the blocksize",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 	}
 
@@ -214,7 +225,23 @@ func TestDecrypterFailure(t *testing.T) {
 					t.Errorf("Expected error containing %q, got %q", tt.expectedErr, err.Error())
 				}
 			}
+			if tt.wantCode != "" {
+				requireBadReqCode(t, err, tt.wantCode)
+			}
 		})
+	}
+}
+
+// requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/encrypter/encrypter.go
+++ b/pkg/plugin/implementation/encrypter/encrypter.go
@@ -24,12 +24,12 @@ func New(ctx context.Context) (*encrypter, func() error, error) {
 func (e *encrypter) Encrypt(ctx context.Context, data string, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Convert the input string to a byte slice.
@@ -51,11 +51,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, model.NewBadReqErr(fmt.Errorf("failed to create private key: %w", err))
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, model.NewBadReqErr(fmt.Errorf("failed to create public key: %w", err))
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/encrypter/encrypter.go
+++ b/pkg/plugin/implementation/encrypter/encrypter.go
@@ -24,12 +24,12 @@ func New(ctx context.Context) (*encrypter, func() error, error) {
 func (e *encrypter) Encrypt(ctx context.Context, data string, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Convert the input string to a byte slice.
@@ -51,11 +51,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create private key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT", fmt.Errorf("failed to create public key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/encrypter/encrypter_test.go
+++ b/pkg/plugin/implementation/encrypter/encrypter_test.go
@@ -160,9 +160,11 @@ func TestEncryptFailure(t *testing.T) {
 				t.Errorf("Encrypt() error = %v, want error containing %q", err, tt.errorContains)
 			}
 			// All malformed-key-material failures above are classified as
-			// SCH_INVALID_FORMAT (a base64 or X25519 key-decode failure is a
-			// format problem, not a schema/missing-field/network one).
-			requireBadReqCode(t, err, "SCH_INVALID_FORMAT")
+			// AUT_SIGNATURE_INVALID, matching signvalidator.go's precedent for
+			// undecodable signature/key material: verification-relevant key
+			// material is inherently an AUT_* concern even when the proximate
+			// cause is bad encoding, not a request-schema problem.
+			requireBadReqCode(t, err, "AUT_SIGNATURE_INVALID")
 		})
 	}
 }

--- a/pkg/plugin/implementation/encrypter/encrypter_test.go
+++ b/pkg/plugin/implementation/encrypter/encrypter_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Helper function to generate a test X25519 key pair.
@@ -156,7 +159,29 @@ func TestEncryptFailure(t *testing.T) {
 			if err != nil && !strings.Contains(err.Error(), tt.errorContains) {
 				t.Errorf("Encrypt() error = %v, want error containing %q", err, tt.errorContains)
 			}
+			// All malformed-key-material failures above are classified as
+			// SCH_INVALID_FORMAT (a base64 or X25519 key-decode failure is a
+			// format problem, not a schema/missing-field/network one).
+			requireBadReqCode(t, err, "SCH_INVALID_FORMAT")
 		})
+	}
+}
+
+// requireBadReqCode asserts err unwraps (via errors.As, matching how
+// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
+// wantCode. createAESCipher's callers re-wrap its errors in an outer
+// fmt.Errorf, so a raw type assertion would miss the coded error even though
+// production code (core/module/handler/responsestep.go's nackBecknError)
+// finds it fine via errors.As.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	var badReqErr *model.BadReqErr
+	if !errors.As(err, &badReqErr) {
+		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/publisher/publisher.go
+++ b/pkg/plugin/implementation/publisher/publisher.go
@@ -118,7 +118,7 @@ func (p *Publisher) Publish(ctx context.Context, routingKey string, msg []byte) 
 
 	if err != nil {
 		log.Errorf(ctx, err, "Publish failed for Exchange: %s, RoutingKey: %s", p.Config.Exchange, routingKey)
-		return model.NewBadReqErr(fmt.Errorf("publish message failed: %w", err))
+		return model.NewCodedBadReqErr("NET_DOWNSTREAM_UNAVAILABLE", fmt.Errorf("publish message failed: %w", err))
 	}
 
 	log.Infof(ctx, "Message published successfully to Exchange: %s, RoutingKey: %s", p.Config.Exchange, routingKey)

--- a/pkg/plugin/implementation/publisher/publisher_test.go
+++ b/pkg/plugin/implementation/publisher/publisher_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/rabbitmq/amqp091-go"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 func TestGetConnURLSuccess(t *testing.T) {
@@ -232,6 +234,16 @@ func TestPublishFailure(t *testing.T) {
 	err := p.Publish(context.Background(), "", []byte(`{"test": true}`))
 	if err == nil {
 		t.Error("expected error from failed publish, got nil")
+	}
+
+	// A RabbitMQ publish failure is a downstream-infrastructure problem, not
+	// a caller bad-request — classified as NET_DOWNSTREAM_UNAVAILABLE.
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "NET_DOWNSTREAM_UNAVAILABLE" {
+		t.Errorf("BecknError().Code = %s, want NET_DOWNSTREAM_UNAVAILABLE", code)
 	}
 }
 

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator.go
@@ -81,7 +81,7 @@ func (s *step) Run(ctx *model.StepContext) error {
 	// revocation fetch, so an unbounded count would let a single request tie up
 	// a handler goroutine indefinitely.
 	if len(creds) > s.cfg.MaxCredentials {
-		ve := failf(failStructure, "request carries %d credentials, exceeding maxCredentials=%d",
+		ve := failf(failStructure, codeSchSchemaValidation, "request carries %d credentials, exceeding maxCredentials=%d",
 			len(creds), s.cfg.MaxCredentials)
 		log.Errorf(ctx, ve, "validateVC: action=%s rejected", action)
 		return nackErr(ve)
@@ -103,20 +103,22 @@ func (s *step) Run(ctx *model.StepContext) error {
 // NACK mapping understands: a structurally broken credential is a Bad
 // Request, while every other failure (proof, issuer, expiry, revocation,
 // resolution) means the credential's authenticity could not be established,
-// which maps to Unauthorized. The machine-readable failure class stays at the
-// start of the NACK error message (e.g. "CREDENTIAL_REVOKED: …").
+// which maps to Unauthorized. Either way the specific Beckn v2.0.0 ErrorCode
+// ve carries (set at the failf call site) rides along on the wire. The
+// machine-readable failure class also stays at the start of the NACK error
+// message (e.g. "CREDENTIAL_REVOKED: …").
 func nackErr(ve *vcError) error {
 	if ve.class == failStructure {
-		return model.NewBadReqErr(ve)
+		return model.NewCodedBadReqErr(ve.code, ve)
 	}
-	return model.NewSignValidationErr(ve)
+	return model.NewCodedSignValidationErr(ve.code, ve)
 }
 
 func asVCError(err error) *vcError {
 	if ve, ok := err.(*vcError); ok {
 		return ve
 	}
-	return &vcError{class: failStructure, msg: err.Error()}
+	return &vcError{class: failStructure, code: codeSchSchemaValidation, msg: err.Error()}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator.go
@@ -107,6 +107,15 @@ func (s *step) Run(ctx *model.StepContext) error {
 // ve carries (set at the failf call site) rides along on the wire. The
 // machine-readable failure class also stays at the start of the NACK error
 // message (e.g. "CREDENTIAL_REVOKED: …").
+//
+// Known limitation (see #870/#884): every non-failStructure class routes to
+// SignValidationErr, which core/module/handler/responsestep.go always maps
+// to HTTP 401 — including failResolution's NET_TIMEOUT/NET_DOWNSTREAM_UNAVAILABLE
+// codes, which then surface under a 401 rather than a network-appropriate
+// status. Splitting the HTTP-status mapping by Code family (not just Go
+// type) would fix this but is a nackBecknError-level change affecting every
+// plugin that returns SignValidationErr, deferred rather than folded into
+// #870/#884's classification-only scope.
 func nackErr(ve *vcError) error {
 	if ve.class == failStructure {
 		return model.NewCodedBadReqErr(ve.code, ve)

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -333,14 +334,32 @@ func TestResolutionCode(t *testing.T) {
 		{"network, not a timeout", fmt.Errorf("did:web fetch https://x: dial tcp: no such host"), codeNetDownstreamUnavailable},
 		{"non-network", fmt.Errorf("did method %q not allowed (allowed: [key jwk web])", "example"), codeAutKeyNotFound},
 		{
-			"real Go http.Client timeout, detected via Timeout() interface not message text",
-			fmt.Errorf("did:web fetch https://x: %w", &fakeTimeoutErr{msg: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}),
+			// msg deliberately contains no "timeout" substring anywhere, so
+			// this only passes if isTimeoutErr actually consults the
+			// Timeout() interface rather than falling back to string
+			// matching.
+			"timeout detected via Timeout() interface, not message text",
+			fmt.Errorf("did:web fetch https://x: %w", &fakeTimeoutErr{msg: "context deadline exceeded (no server response)"}),
 			codeNetTimeout,
 		},
 		{
 			"ordinary non-2xx HTTP status is not a network failure",
 			fmt.Errorf("did:web fetch https://x: http 404 for https://x"),
 			codeAutKeyNotFound,
+		},
+		{
+			// A real *url.Error (what http.Client.Do returns) wrapping a TLS
+			// failure — message text contains none of "dial"/"no such
+			// host"/"connection"/"timeout", so this only passes if isNetErr's
+			// errors.As(*url.Error) type check is actually working.
+			"real *url.Error (TLS failure) is a network failure despite no recognizable substring",
+			fmt.Errorf("did:web fetch https://x: %w", &url.Error{Op: "Get", URL: "https://x", Err: errors.New("tls: failed to verify certificate: x509: certificate signed by unknown authority")}),
+			codeNetDownstreamUnavailable,
+		},
+		{
+			"real *url.Error wrapping a genuine timeout",
+			fmt.Errorf("did:web fetch https://x: %w", &url.Error{Op: "Get", URL: "https://x", Err: &fakeTimeoutErr{msg: "context deadline exceeded (no server response)"}}),
+			codeNetTimeout,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
@@ -81,13 +81,14 @@ func TestVectors(t *testing.T) {
 	cases := []struct {
 		file      string
 		wantClass failClass // "" => must be accepted
+		wantCode  string    // checked when wantClass is non-empty
 	}{
-		{"didkey-unrevoked.json", ""},
-		{"didkey-revoked.json", failRevoked},
-		{"didjwk-unrevoked.json", ""},
-		{"didjwk-revoked.json", failRevoked},
-		{"didweb-unrevoked.json", ""},
-		{"didweb-revoked.json", failRevoked},
+		{"didkey-unrevoked.json", "", ""},
+		{"didkey-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
+		{"didjwk-unrevoked.json", "", ""},
+		{"didjwk-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
+		{"didweb-unrevoked.json", "", ""},
+		{"didweb-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
 	}
 
 	for _, tc := range cases {
@@ -108,7 +109,7 @@ func TestVectors(t *testing.T) {
 				}
 				return
 			}
-			assertClass(t, err, tc.wantClass)
+			assertClassCode(t, err, tc.wantClass, tc.wantCode)
 		})
 	}
 }
@@ -156,21 +157,21 @@ func TestTamperedSignature(t *testing.T) {
 
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failProof)
+	assertClassCode(t, err, failProof, codeAutSignatureInvalid)
 }
 
 func TestExpired(t *testing.T) {
 	v := testVerifier(nil)
 	v.now = func() time.Time { return time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC) }
 	err := v.verify(context.Background(), vcBytes(t, loadVC(t)))
-	assertClass(t, err, failExpired)
+	assertClassCode(t, err, failExpired, codeAutKeyExpiredOrRevoked)
 }
 
 func TestNotYetValid(t *testing.T) {
 	v := testVerifier(nil)
 	v.now = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
 	err := v.verify(context.Background(), vcBytes(t, loadVC(t)))
-	assertClass(t, err, failExpired)
+	assertClassCode(t, err, failExpired, codeAutKeyExpiredOrRevoked)
 }
 
 func TestIssuerMismatch(t *testing.T) {
@@ -179,7 +180,7 @@ func TestIssuerMismatch(t *testing.T) {
 	vc["issuer"] = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failIssuer)
+	assertClassCode(t, err, failIssuer, codeAutUnauthorizedAction)
 }
 
 // TestDIDWebHappyPath builds a VC-JWT signed by an ed25519 key, publishes the
@@ -231,7 +232,9 @@ func TestDIDWebUnreachableFailsClosed(t *testing.T) {
 	})
 	v.now = fixedNow
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failResolution)
+	// "dial tcp: no such host" is network-caused (isNetErr) but not a timeout,
+	// so it lands on NET_DOWNSTREAM_UNAVAILABLE rather than NET_TIMEOUT.
+	assertClassCode(t, err, failResolution, codeNetDownstreamUnavailable)
 
 	// fail-open should let it through.
 	cfg.FailOpen = true
@@ -281,7 +284,7 @@ func dediVC(t *testing.T, statusCode int) (*verifier, json.RawMessage) {
 
 func TestDEDIRevoked(t *testing.T) {
 	v, raw := dediVC(t, 200) // DEDI record exists → revoked
-	assertClass(t, v.verify(context.Background(), raw), failRevoked)
+	assertClassCode(t, v.verify(context.Background(), raw), failRevoked, codeAutKeyExpiredOrRevoked)
 }
 
 func TestDEDINotRevoked(t *testing.T) {
@@ -303,7 +306,83 @@ func TestDataIntegrityProofRejectedWhenRequired(t *testing.T) {
 	}
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failProof)
+	assertClassCode(t, err, failProof, codeAutSignatureInvalid)
+}
+
+// TestResolutionCode exercises resolutionCode's three-way split directly: a
+// timeout is NET_TIMEOUT, another network cause (matched by the same isNetErr
+// heuristic) is NET_DOWNSTREAM_UNAVAILABLE, and anything else — the key
+// genuinely couldn't be found rather than an unreachable network — is
+// AUT_KEY_NOT_FOUND.
+func TestResolutionCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"network timeout", fmt.Errorf("did:web fetch https://x: dial tcp: i/o timeout"), codeNetTimeout},
+		{"network, not a timeout", fmt.Errorf("did:web fetch https://x: dial tcp: no such host"), codeNetDownstreamUnavailable},
+		{"non-network", fmt.Errorf("did method %q not allowed (allowed: [key jwk web])", "example"), codeAutKeyNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolutionCode(tt.err); got != tt.want {
+				t.Errorf("resolutionCode(%v) = %s, want %s", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNoProof asserts a credential with no proof block at all is distinguished
+// from every other proof failure: AUT_SIGNATURE_MISSING, not
+// AUT_SIGNATURE_INVALID.
+func TestNoProof(t *testing.T) {
+	vc := map[string]any{
+		"issuer":            "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+		"credentialSubject": map[string]any{"id": "x"},
+	}
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failProof, codeAutSignatureMissing)
+}
+
+// TestUnsupportedDIDMethodIsKeyNotFound asserts a resolution failure caused by
+// a disallowed/unsupported DID method (not a network problem) is classified
+// AUT_KEY_NOT_FOUND rather than a NET_* code.
+func TestUnsupportedDIDMethodIsKeyNotFound(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	did := "did:example:abc"
+	kid := did + "#key-1"
+	jwt := signVCJWT(t, priv, kid, did, "did:key:z6MkSubject", fixedNow())
+	vc := map[string]any{
+		"issuer":            did,
+		"credentialSubject": map[string]any{"id": "did:key:z6MkSubject"},
+		"proof":             map[string]any{"type": "JsonWebSignature2020", "jwt": jwt},
+	}
+	v := testVerifier(nil)
+	v.now = fixedNow
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failResolution, codeAutKeyNotFound)
+}
+
+// TestMalformedCredentialJSON asserts a credential body that isn't valid JSON
+// at all is classified SCH_INVALID_JSON, distinct from a well-formed-but-
+// incomplete credential (SCH_REQUIRED_FIELD_MISSING).
+func TestMalformedCredentialJSON(t *testing.T) {
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), json.RawMessage(`{"issuer": "x", "credentialSubject": {`))
+	assertClassCode(t, err, failStructure, codeSchInvalidJSON)
+}
+
+// TestMalformedCredentialStatus asserts an unparseable credentialStatus is
+// classified SCH_INVALID_JSON, same as any other malformed-JSON structural
+// failure.
+func TestMalformedCredentialStatus(t *testing.T) {
+	vc := loadVC(t)
+	vc["credentialStatus"] = 123 // neither an object nor an array
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failStructure, codeSchInvalidJSON)
 }
 
 func TestConfigRequiresActions(t *testing.T) {
@@ -433,6 +512,9 @@ func TestStepNackErrorTypes(t *testing.T) {
 		if !strings.Contains(err.Error(), string(failIssuer)) {
 			t.Fatalf("failure class missing from error: %v", err)
 		}
+		if code := signErr.BecknError().Code; code != codeAutUnauthorizedAction {
+			t.Fatalf("BecknError().Code = %s, want %s", code, codeAutUnauthorizedAction)
+		}
 	})
 	t.Run("structural failure is BadReqErr", func(t *testing.T) {
 		vc := map[string]any{ // no issuer → failStructure
@@ -446,6 +528,9 @@ func TestStepNackErrorTypes(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), string(failStructure)) {
 			t.Fatalf("failure class missing from error: %v", err)
+		}
+		if code := badReq.BecknError().Code; code != codeSchRequiredFieldMissing {
+			t.Fatalf("BecknError().Code = %s, want %s", code, codeSchRequiredFieldMissing)
 		}
 	})
 }
@@ -480,6 +565,9 @@ func TestStepMaxCredentials(t *testing.T) {
 	}
 	if !strings.Contains(runErr.Error(), "maxCredentials") {
 		t.Fatalf("expected cap rejection, got: %v", runErr)
+	}
+	if code := badReq.BecknError().Code; code != codeSchSchemaValidation {
+		t.Fatalf("BecknError().Code = %s, want %s", code, codeSchSchemaValidation)
 	}
 
 	// At the cap it must fall through to per-credential verification.
@@ -570,6 +658,13 @@ func TestRedirectCap(t *testing.T) {
 
 func assertClass(t *testing.T, err error, want failClass) {
 	t.Helper()
+	assertClassCode(t, err, want, "")
+}
+
+// assertClassCode asserts err is a *vcError with the given class, and — when
+// wantCode is non-empty — the given Beckn v2.0.0 ErrorCode too.
+func assertClassCode(t *testing.T, err error, want failClass, wantCode string) {
+	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error of class %s, got nil", want)
 	}
@@ -579,6 +674,9 @@ func assertClass(t *testing.T, err error, want failClass) {
 	}
 	if ve.class != want {
 		t.Fatalf("expected class %s, got %s (%s)", want, ve.class, ve.msg)
+	}
+	if wantCode != "" && ve.code != wantCode {
+		t.Fatalf("expected code %s, got %s (%s)", wantCode, ve.code, ve.msg)
 	}
 }
 

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
@@ -314,15 +314,34 @@ func TestDataIntegrityProofRejectedWhenRequired(t *testing.T) {
 // heuristic) is NET_DOWNSTREAM_UNAVAILABLE, and anything else — the key
 // genuinely couldn't be found rather than an unreachable network — is
 // AUT_KEY_NOT_FOUND.
+// fakeTimeoutErr implements the timeouter interface (Timeout() bool) the way
+// *url.Error/net.Error do — its message text deliberately contains no
+// "timeout" substring, so a test built on it only passes if isTimeoutErr
+// actually uses the interface rather than falling back to string matching.
+type fakeTimeoutErr struct{ msg string }
+
+func (e *fakeTimeoutErr) Error() string { return e.msg }
+func (e *fakeTimeoutErr) Timeout() bool { return true }
+
 func TestResolutionCode(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want string
 	}{
-		{"network timeout", fmt.Errorf("did:web fetch https://x: dial tcp: i/o timeout"), codeNetTimeout},
+		{"network timeout (string fallback)", fmt.Errorf("did:web fetch https://x: dial tcp: i/o timeout"), codeNetTimeout},
 		{"network, not a timeout", fmt.Errorf("did:web fetch https://x: dial tcp: no such host"), codeNetDownstreamUnavailable},
 		{"non-network", fmt.Errorf("did method %q not allowed (allowed: [key jwk web])", "example"), codeAutKeyNotFound},
+		{
+			"real Go http.Client timeout, detected via Timeout() interface not message text",
+			fmt.Errorf("did:web fetch https://x: %w", &fakeTimeoutErr{msg: "context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}),
+			codeNetTimeout,
+		},
+		{
+			"ordinary non-2xx HTTP status is not a network failure",
+			fmt.Errorf("did:web fetch https://x: http 404 for https://x"),
+			codeAutKeyNotFound,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -340,6 +359,21 @@ func TestNoProof(t *testing.T) {
 	vc := map[string]any{
 		"issuer":            "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
 		"credentialSubject": map[string]any{"id": "x"},
+	}
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failProof, codeAutSignatureMissing)
+}
+
+// TestProofPresentButEmpty asserts a credential whose proof object exists but
+// has neither jwt nor proofValue is classified the same as no proof at all
+// (AUT_SIGNATURE_MISSING) — both mean there's no usable proof content, so
+// they shouldn't be split across two different codes.
+func TestProofPresentButEmpty(t *testing.T) {
+	vc := map[string]any{
+		"issuer":            "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+		"credentialSubject": map[string]any{"id": "x"},
+		"proof":             map[string]any{"type": "SomeProofType"},
 	}
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
@@ -655,11 +689,6 @@ func TestRedirectCap(t *testing.T) {
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────
-
-func assertClass(t *testing.T, err error, want failClass) {
-	t.Helper()
-	assertClassCode(t, err, want, "")
-}
 
 // assertClassCode asserts err is a *vcError with the given class, and — when
 // wantCode is non-empty — the given Beckn v2.0.0 ErrorCode too.

--- a/pkg/plugin/implementation/vcvalidator/verify.go
+++ b/pkg/plugin/implementation/vcvalidator/verify.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"syscall"
@@ -93,12 +94,6 @@ func resolutionCode(err error) string {
 	if !isNetErr(err) {
 		return codeAutKeyNotFound
 	}
-	return netFailureCode(err)
-}
-
-// netFailureCode picks between the two network-failure codes. Call only
-// when isNetErr(err) is already known true.
-func netFailureCode(err error) string {
 	if isTimeoutErr(err) {
 		return codeNetTimeout
 	}
@@ -108,7 +103,10 @@ func netFailureCode(err error) string {
 // timeouter is implemented by *url.Error (returned from http.Client.Do,
 // including for did:web/DEDI fetches) and other stdlib network errors — a
 // reliable signal independent of the wrapped error's message text or
-// casing, reachable through %w-wrapping via errors.As.
+// casing, reachable through %w-wrapping via errors.As. Duck-typed by design
+// (any Timeout() bool method matches); no conflicting implementation exists
+// in this codebase today, but a future unrelated type defining the same
+// method name would be silently treated as a network-timeout signal.
 type timeouter interface{ Timeout() bool }
 
 // isTimeoutErr reports whether err is a timeout, preferring the standard
@@ -269,13 +267,10 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 
 	key, err := resolveDID(ctx, header.Kid, header.Alg, v.cfg, v.fetch)
 	if err != nil {
-		if netErr := isNetErr(err); netErr {
-			if v.cfg.FailOpen {
-				return nil
-			}
-			return failf(failResolution, netFailureCode(err), "resolve %q: %v", header.Kid, err)
+		if isNetErr(err) && v.cfg.FailOpen {
+			return nil
 		}
-		return failf(failResolution, codeAutKeyNotFound, "resolve %q: %v", header.Kid, err)
+		return failf(failResolution, resolutionCode(err), "resolve %q: %v", header.Kid, err)
 	}
 
 	// Alg-confusion protection: the header alg must match the resolved key.
@@ -382,17 +377,26 @@ func isNetErr(err error) bool {
 	if err == nil {
 		return false
 	}
+	// *url.Error is what http.Client.Do returns for ANY failure to complete
+	// the round trip — dial, DNS, TLS handshake, connection reset, timeout,
+	// context cancellation — regardless of message text. It's a reliable
+	// type-based signal, reachable through %w-wrapping (e.g. resolveDIDWeb's
+	// "did:web fetch %s: %w") via errors.As. Deliberately does NOT match on
+	// message substrings like "fetch" or "http " (httpFetcher's own non-2xx-
+	// status message, "http %d for %s") — those appeared unconditionally
+	// regardless of cause and previously caused a completed round trip that
+	// merely returned a bad status to be misclassified as a network failure;
+	// that case correctly falls through to AUT_KEY_NOT_FOUND below, since a
+	// non-2xx response is never itself a *url.Error.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
 	if isTimeoutErr(err) {
 		return true
 	}
-	// Deliberately excludes "http " (httpFetcher's own non-2xx-status message,
-	// "http %d for %s") and "fetch" (resolveDIDWeb's static "did:web fetch %s: "
-	// wrap prefix, added unconditionally around whatever fetch() returns —
-	// including that same non-2xx message, so it carries no real signal about
-	// the underlying cause). A completed round trip that returned a bad status
-	// code is not a network failure; it means the resource genuinely wasn't
-	// found or the server rejected it, which resolutionCode maps to
-	// AUT_KEY_NOT_FOUND rather than a NET_* code.
+	// Fallback for synthetic/test errors with no real *url.Error in their
+	// chain (e.g. hand-built fmt.Errorf strings used in unit tests).
 	s := err.Error()
 	return strings.Contains(s, "dial") || strings.Contains(s, "no such host") ||
 		strings.Contains(s, "connection")

--- a/pkg/plugin/implementation/vcvalidator/verify.go
+++ b/pkg/plugin/implementation/vcvalidator/verify.go
@@ -13,6 +13,7 @@ import (
 	"crypto/elliptic"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -63,9 +64,9 @@ const (
 	// concept) — this is the closest existing bucket, reusing the pattern
 	// keymanager/simplekeymanager already established for key lifecycle
 	// expiry. Flagged in the PR description as a taxonomy-completeness gap.
-	codeAutKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
-	codeAutKeyNotFound         = "AUT_KEY_NOT_FOUND"
-	codeNetTimeout             = "NET_TIMEOUT"
+	codeAutKeyExpiredOrRevoked   = "AUT_KEY_EXPIRED_OR_REVOKED"
+	codeAutKeyNotFound           = "AUT_KEY_NOT_FOUND"
+	codeNetTimeout               = "NET_TIMEOUT"
 	codeNetDownstreamUnavailable = "NET_DOWNSTREAM_UNAVAILABLE"
 )
 
@@ -92,10 +93,33 @@ func resolutionCode(err error) string {
 	if !isNetErr(err) {
 		return codeAutKeyNotFound
 	}
-	if strings.Contains(err.Error(), "timeout") {
+	return netFailureCode(err)
+}
+
+// netFailureCode picks between the two network-failure codes. Call only
+// when isNetErr(err) is already known true.
+func netFailureCode(err error) string {
+	if isTimeoutErr(err) {
 		return codeNetTimeout
 	}
 	return codeNetDownstreamUnavailable
+}
+
+// timeouter is implemented by *url.Error (returned from http.Client.Do,
+// including for did:web/DEDI fetches) and other stdlib network errors — a
+// reliable signal independent of the wrapped error's message text or
+// casing, reachable through %w-wrapping via errors.As.
+type timeouter interface{ Timeout() bool }
+
+// isTimeoutErr reports whether err is a timeout, preferring the standard
+// Timeout() bool interface and falling back to a case-insensitive substring
+// match for errors that don't implement it (e.g. synthetic/test errors).
+func isTimeoutErr(err error) bool {
+	var te timeouter
+	if errors.As(err, &te) {
+		return te.Timeout()
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout")
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +231,9 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 			}
 		}
 	} else {
-		return failf(failProof, codeAutSignatureInvalid, "proof has neither jwt nor proofValue")
+		// No jwt and no proofValue means no usable proof content at all — the
+		// same defect as cred.Proof == nil above, just one level deeper.
+		return failf(failProof, codeAutSignatureMissing, "proof has neither jwt nor proofValue")
 	}
 
 	// 3. Revocation.
@@ -243,10 +269,13 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 
 	key, err := resolveDID(ctx, header.Kid, header.Alg, v.cfg, v.fetch)
 	if err != nil {
-		if isNetErr(err) && v.cfg.FailOpen {
-			return nil
+		if netErr := isNetErr(err); netErr {
+			if v.cfg.FailOpen {
+				return nil
+			}
+			return failf(failResolution, netFailureCode(err), "resolve %q: %v", header.Kid, err)
 		}
-		return failf(failResolution, resolutionCode(err), "resolve %q: %v", header.Kid, err)
+		return failf(failResolution, codeAutKeyNotFound, "resolve %q: %v", header.Kid, err)
 	}
 
 	// Alg-confusion protection: the header alg must match the resolved key.
@@ -353,10 +382,20 @@ func isNetErr(err error) bool {
 	if err == nil {
 		return false
 	}
+	if isTimeoutErr(err) {
+		return true
+	}
+	// Deliberately excludes "http " (httpFetcher's own non-2xx-status message,
+	// "http %d for %s") and "fetch" (resolveDIDWeb's static "did:web fetch %s: "
+	// wrap prefix, added unconditionally around whatever fetch() returns —
+	// including that same non-2xx message, so it carries no real signal about
+	// the underlying cause). A completed round trip that returned a bad status
+	// code is not a network failure; it means the resource genuinely wasn't
+	// found or the server rejected it, which resolutionCode maps to
+	// AUT_KEY_NOT_FOUND rather than a NET_* code.
 	s := err.Error()
-	return strings.Contains(s, "fetch") || strings.Contains(s, "http ") ||
-		strings.Contains(s, "dial") || strings.Contains(s, "timeout") ||
-		strings.Contains(s, "no such host") || strings.Contains(s, "connection")
+	return strings.Contains(s, "dial") || strings.Contains(s, "no such host") ||
+		strings.Contains(s, "connection")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/plugin/implementation/vcvalidator/verify.go
+++ b/pkg/plugin/implementation/vcvalidator/verify.go
@@ -46,16 +46,56 @@ const (
 	failIssuer     failClass = "ISSUER_MISMATCH"
 )
 
-// vcError is a credential validation failure with a machine-readable class.
+// Beckn v2.0.0 ErrorCode values this package classifies its failures onto.
+// Named locally (rather than inlined at each of the ~20 call sites below,
+// unlike the single-use-per-plugin convention elsewhere in this codebase)
+// since several codes here are reused across many sites and a typo in a
+// string literal wouldn't be caught by the compiler.
+const (
+	codeSchInvalidJSON          = "SCH_INVALID_JSON"
+	codeSchRequiredFieldMissing = "SCH_REQUIRED_FIELD_MISSING"
+	codeSchSchemaValidation     = "SCH_SCHEMA_VALIDATION_FAILED"
+	codeAutSignatureMissing     = "AUT_SIGNATURE_MISSING"
+	codeAutSignatureInvalid     = "AUT_SIGNATURE_INVALID"
+	codeAutUnauthorizedAction   = "AUT_UNAUTHORIZED_ACTION"
+	// No dedicated credential-expiry/revocation code exists in the v2.0.0
+	// taxonomy (CTX_TTL_EXPIRED is the beckn message TTL, a different
+	// concept) — this is the closest existing bucket, reusing the pattern
+	// keymanager/simplekeymanager already established for key lifecycle
+	// expiry. Flagged in the PR description as a taxonomy-completeness gap.
+	codeAutKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
+	codeAutKeyNotFound         = "AUT_KEY_NOT_FOUND"
+	codeNetTimeout             = "NET_TIMEOUT"
+	codeNetDownstreamUnavailable = "NET_DOWNSTREAM_UNAVAILABLE"
+)
+
+// vcError is a credential validation failure with a machine-readable class
+// and the Beckn v2.0.0 ErrorCode nackErr carries to the wire.
 type vcError struct {
 	class failClass
+	code  string
 	msg   string
 }
 
 func (e *vcError) Error() string { return string(e.class) + ": " + e.msg }
 
-func failf(class failClass, format string, a ...any) *vcError {
-	return &vcError{class: class, msg: fmt.Sprintf(format, a...)}
+func failf(class failClass, code, format string, a ...any) *vcError {
+	return &vcError{class: class, code: code, msg: fmt.Sprintf(format, a...)}
+}
+
+// resolutionCode picks the ErrorCode for a failResolution failure: a
+// network-caused resolution failure (detected via the same isNetErr
+// heuristic already used for FailOpen decisions) gets a NET_* code, anything
+// else (unsupported/disallowed DID method, malformed key material, no
+// matching verification method) means the key genuinely couldn't be found.
+func resolutionCode(err error) string {
+	if !isNetErr(err) {
+		return codeAutKeyNotFound
+	}
+	if strings.Contains(err.Error(), "timeout") {
+		return codeNetTimeout
+	}
+	return codeNetDownstreamUnavailable
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +125,7 @@ type proof struct {
 // object with an "id" field.
 func (c *credential) issuerDID() (string, error) {
 	if len(c.Issuer) == 0 {
-		return "", failf(failStructure, "credential has no issuer")
+		return "", failf(failStructure, codeSchRequiredFieldMissing, "credential has no issuer")
 	}
 	var s string
 	if err := json.Unmarshal(c.Issuer, &s); err == nil && s != "" {
@@ -97,7 +137,7 @@ func (c *credential) issuerDID() (string, error) {
 	if err := json.Unmarshal(c.Issuer, &obj); err == nil && obj.ID != "" {
 		return obj.ID, nil
 	}
-	return "", failf(failStructure, "credential issuer has no id")
+	return "", failf(failStructure, codeSchRequiredFieldMissing, "credential issuer has no id")
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +166,7 @@ func newVerifier(cfg *Config, fetch fetcher) *verifier {
 func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 	var cred credential
 	if err := json.Unmarshal(raw, &cred); err != nil {
-		return failf(failStructure, "cannot parse credential: %v", err)
+		return failf(failStructure, codeSchInvalidJSON, "cannot parse credential: %v", err)
 	}
 	issuer, err := cred.issuerDID()
 	if err != nil {
@@ -142,7 +182,7 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 
 	// 2. Proof.
 	if cred.Proof == nil {
-		return failf(failProof, "credential has no proof")
+		return failf(failProof, codeAutSignatureMissing, "credential has no proof")
 	}
 	if cred.Proof.JWT != "" {
 		if err := v.verifyJWTProof(ctx, &cred, issuer); err != nil {
@@ -153,7 +193,7 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 		// it requires RDF canonicalisation (URDNA2015), which this plugin does
 		// not implement.
 		if v.cfg.RequireProof {
-			return failf(failProof,
+			return failf(failProof, codeAutSignatureInvalid,
 				"proof type %q requires JSON-LD canonicalisation which is not supported; "+
 					"set requireProof=false to accept on expiry/revocation only",
 				cred.Proof.Type)
@@ -162,12 +202,12 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 		if vm := cred.Proof.VerificationMethod; vm != "" {
 			if _, err := resolveDID(ctx, vm, "", v.cfg, v.fetch); err != nil {
 				if !v.cfg.FailOpen {
-					return failf(failResolution, "verificationMethod %q did not resolve: %v", vm, err)
+					return failf(failResolution, resolutionCode(err), "verificationMethod %q did not resolve: %v", vm, err)
 				}
 			}
 		}
 	} else {
-		return failf(failProof, "proof has neither jwt nor proofValue")
+		return failf(failProof, codeAutSignatureInvalid, "proof has neither jwt nor proofValue")
 	}
 
 	// 3. Revocation.
@@ -186,7 +226,7 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 	token := cred.Proof.JWT
 	header, err := decodeJWTHeader(token)
 	if err != nil {
-		return failf(failProof, "%v", err)
+		return failf(failProof, codeAutSignatureInvalid, "%v", err)
 	}
 
 	// The signing key DID comes from the JWT `kid` (its controller). It MUST
@@ -197,7 +237,7 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 		signerDID = issuer
 	}
 	if base(signerDID) != base(issuer) {
-		return failf(failIssuer,
+		return failf(failIssuer, codeAutUnauthorizedAction,
 			"proof signer %q does not match issuer %q", signerDID, issuer)
 	}
 
@@ -206,18 +246,18 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 		if isNetErr(err) && v.cfg.FailOpen {
 			return nil
 		}
-		return failf(failResolution, "resolve %q: %v", header.Kid, err)
+		return failf(failResolution, resolutionCode(err), "resolve %q: %v", header.Kid, err)
 	}
 
 	// Alg-confusion protection: the header alg must match the resolved key.
 	if header.Alg != key.alg.String() {
-		return failf(failProof,
+		return failf(failProof, codeAutSignatureInvalid,
 			"header alg %q does not match issuer key algorithm %q", header.Alg, key.alg.String())
 	}
 
 	payload, err := jws.Verify([]byte(token), jws.WithKey(key.alg, key.pub))
 	if err != nil {
-		return failf(failProof, "signature verification failed: %v", err)
+		return failf(failProof, codeAutSignatureInvalid, "signature verification failed: %v", err)
 	}
 
 	// Validate JWT temporal claims (nbf/exp) too.
@@ -264,10 +304,10 @@ func (v *verifier) checkJWTClaims(payload []byte) error {
 	}
 	now := v.now().Unix()
 	if claims.Nbf != 0 && now < claims.Nbf {
-		return failf(failExpired, "credential not yet valid (nbf=%d, now=%d)", claims.Nbf, now)
+		return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential not yet valid (nbf=%d, now=%d)", claims.Nbf, now)
 	}
 	if claims.Exp != 0 && now > claims.Exp {
-		return failf(failExpired, "credential expired (exp=%d, now=%d)", claims.Exp, now)
+		return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential expired (exp=%d, now=%d)", claims.Exp, now)
 	}
 	return nil
 }
@@ -278,13 +318,13 @@ func (v *verifier) checkWindow(validFrom, validUntil string) error {
 	if validFrom != "" {
 		t, err := time.Parse(time.RFC3339, validFrom)
 		if err == nil && now.Before(t) {
-			return failf(failExpired, "credential not yet valid (validFrom=%s)", validFrom)
+			return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential not yet valid (validFrom=%s)", validFrom)
 		}
 	}
 	if validUntil != "" {
 		t, err := time.Parse(time.RFC3339, validUntil)
 		if err == nil && now.After(t) {
-			return failf(failExpired, "credential expired (validUntil=%s)", validUntil)
+			return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential expired (validUntil=%s)", validUntil)
 		}
 	}
 	return nil
@@ -663,7 +703,7 @@ type statusEntry struct {
 func (v *verifier) checkRevocation(ctx context.Context, raw json.RawMessage) error {
 	entries, err := parseStatusEntries(raw)
 	if err != nil {
-		return failf(failStructure, "credentialStatus: %v", err)
+		return failf(failStructure, codeSchInvalidJSON, "credentialStatus: %v", err)
 	}
 	for _, e := range entries {
 		// Only revocation-purpose entries gate acceptance. Empty purpose is
@@ -676,10 +716,10 @@ func (v *verifier) checkRevocation(ctx context.Context, raw json.RawMessage) err
 			if v.cfg.FailOpen {
 				continue
 			}
-			return failf(failResolution, "revocation check: %v", err)
+			return failf(failResolution, resolutionCode(err), "revocation check: %v", err)
 		}
 		if revoked {
-			return failf(failRevoked, "credential revoked via %s", e.statusURL())
+			return failf(failRevoked, codeAutKeyExpiredOrRevoked, "credential revoked via %s", e.statusURL())
 		}
 	}
 	return nil


### PR DESCRIPTION
Part of #870. Part of the #861 EPIC. Builds on #862/#867/#868/#869 (already merged into this branch).

## Scope note

#870 as filed asks to classify all four plugins' failure modes onto the correct ErrorCode family (SCH_*/AUT_*/NET_*/BIZ_*, determined per plugin). Researched each plugin's actual code first (one background research pass per plugin) before writing anything, following the same "only remap what's already produced today, no new detection logic" principle established in #869.

**vcvalidator** — the clear highest-value target. Already a fully-wired `definition.Step` with its own internal 6-way `failClass` taxonomy (`failStructure`/`failProof`/`failExpired`/`failRevoked`/`failResolution`/`failIssuer`) that previously collapsed into just 2 uncoded buckets (`BadReqErr` vs `SignValidationErr`) at `nackErr()`. This PR threads an explicit code through every `failf` call site instead. One genuine taxonomy gap: no dedicated credential-expiry/revocation code exists in the v2.0.0 enum (`CTX_TTL_EXPIRED` is the beckn message TTL, a different concept), so `failExpired`/`failRevoked` fall back to `AUT_KEY_EXPIRED_OR_REVOKED` as the closest existing bucket — the same pattern `keymanager`/`simplekeymanager` already use for key lifecycle expiry. Flagging this for whoever owns the taxonomy itself, not something this PR can fix.

**publisher** — one clean, high-value, low-risk fix: `Publish()`'s single RabbitMQ-failure wrap was mis-bucketed as `BadReqErr` (a downstream broker failure isn't the caller's bad request). Confirmed it flows through the exact same `errors.As(*model.BadReqErr)` plumbing as router/reqmapper (`core/module/handler/stdHandler.go`'s `route()` → `sendNack` → `nackBecknError`), so remapping to `NET_DOWNSTREAM_UNAVAILABLE` needed zero pipeline changes. Everything else in that file (`Validate`/`GetConnURL`/`New`'s connect/channel/exchange-declare errors) is bootstrap/module-init only and never reaches `nackBecknError` — same rationale as router's `New`/`loadRules` in #869, left unclassified.

**encrypter and decrypter** — both have **zero production callers anywhere in this codebase** (referenced only in `pkg/plugin/manager_test.go`). Per explicit direction, did the pure-remap sites anyway as low-risk future-proofing, since there's no live caller to regress and the remap itself carries no runtime risk today. All 10 failure sites across both plugins (4 in encrypter, 6 in decrypter — base64 key decode, X25519 key construction, and decrypter's malformed-ciphertext/blocksize checks) now classify uniformly as `AUT_SIGNATURE_INVALID`, matching `signvalidator.go`'s already-merged precedent for malformed signature/key material (its own code comment: this is the generic bucket since no more specific taxonomy value exists — see round-2 self-review below for how this landed).

Left unclassified in both, as genuine scope-surprise / judgment calls rather than picking a code under time pressure:
- `encrypter`'s ECDH low-order-point rejection (reachable today, but its correct code family is genuinely debatable — closer to a rejected-key security condition than a format problem).
- `decrypter`'s PKCS7-unpad-failure site — currently conflates "wrong/stale key" and "corrupted-in-transit ciphertext" into one generic symptom; distinguishing them would need new detection (e.g. an AEAD/HMAC tag check) that doesn't exist today.

## What changed

- **`pkg/plugin/implementation/vcvalidator/verify.go`**: `vcError` gained a `code` field; `failf` now takes an explicit code at every one of its ~20 call sites (`SCH_REQUIRED_FIELD_MISSING`/`SCH_INVALID_JSON`/`SCH_SCHEMA_VALIDATION_FAILED` for structural failures, `AUT_SIGNATURE_MISSING`/`AUT_SIGNATURE_INVALID` for proof failures, `AUT_UNAUTHORIZED_ACTION` for issuer mismatch, `AUT_KEY_EXPIRED_OR_REVOKED` for expiry/revocation). `resolutionCode(err)` helper splits `failResolution` failures into `NET_TIMEOUT`/`NET_DOWNSTREAM_UNAVAILABLE` (network-caused) vs `AUT_KEY_NOT_FOUND` (everything else — unsupported/disallowed DID method, malformed key material, no matching verification method).
- **`pkg/plugin/implementation/vcvalidator/vcvalidator.go`**: `nackErr()` now calls `model.NewCodedBadReqErr(ve.code, ve)` / `model.NewCodedSignValidationErr(ve.code, ve)` instead of the uncoded constructors; the `maxCredentials`-exceeded check and the `asVCError` defensive fallback both carry explicit codes too.
- **`pkg/plugin/implementation/publisher/publisher.go`**: `Publish()`'s error wrap → `model.NewCodedBadReqErr("NET_DOWNSTREAM_UNAVAILABLE", ...)`.
- **`pkg/plugin/implementation/encrypter/encrypter.go`**: all 4 sites → `model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", ...)`.
- **`pkg/plugin/implementation/decrypter/decrypter.go`**: all 6 sites → `model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", ...)` (2 of these needed wrapping in a `model.*Err` type for the first time — they were bare `fmt.Errorf` before, invisible to `errors.As`).

## Self-review fixes (round 1)

An 8-angle review round (matching the process from #867/#869/#883) found the classification work sound overall but surfaced real issues, all fixed:

- **Two real bugs in `resolutionCode`'s network-vs-not classification**: (1) the timeout check only matched a lowercase `"timeout"` substring, missing Go's actual `http.Client` timeout error text entirely. (2) `isNetErr` matched `"http "` and `"fetch"`, both of which appeared unconditionally in messages that were **not** network failures, causing a stable 404 for a nonexistent DID document to be misclassified as `NET_DOWNSTREAM_UNAVAILABLE` instead of `AUT_KEY_NOT_FOUND`.
- **Proof-classification asymmetry**: "proof has neither jwt nor proofValue" aligned to `AUT_SIGNATURE_MISSING`, matching "no proof at all" — same underlying defect (no verifiable content), previously split across two codes.
- **decrypter/encrypter consistency (first pass)**: decrypter's 4 key-material sites, structurally identical to encrypter's, had been left uncoded — classified to match encrypter (at the time, `SCH_INVALID_FORMAT`; see round 2 below for where this landed). Separately fixed a real bug independent of code choice: 2 of decrypter's sites (`createAESCipher`'s X25519 construction failures) weren't wrapped in any `model.*Err` type at all.
- Test helper and dead-code cleanup: `requireBadReqCode` unified on `errors.As`, dead `assertClass` helper removed, `gofmt` misalignment fixed.

## Self-review fixes (round 2)

A second 8-angle round, focused on verifying round 1's fixes actually landed correctly, found the round-1 `isNetErr` fix had overcorrected, plus a wider consistency question:

- **`isNetErr`'s round-1 fix regressed real transport failures**: removing `"fetch"`/`"http "` fixed the 404-misclassification bug, but also removed the catch-all that used to classify TLS/certificate errors, EOF, and `context.Canceled` as network — none of these implement `Timeout()` or match `"dial"`/`"no such host"`/`"connection"`. Worse, this made `verifyJWTProof`'s `FailOpen` gate skip entirely for these cases, so a deployment with `failOpen=true` (specifically to tolerate did:web flakiness) would find TLS misconfigurations always hard-reject. Fixed by checking `errors.As(err, &urlErr)` for `*url.Error` first — `http.Client.Do` always returns `*url.Error` for any failed round trip (dial, DNS, TLS, connection reset, timeout, context cancellation), reachable through `resolveDIDWeb`'s `%w`-wrap, while `httpFetcher`'s own non-2xx message is never itself a `*url.Error`. The substring/`Timeout()` fallback remains for synthetic/test errors without a real `*url.Error` in their chain.
- **Reverted `verifyJWTProof`'s restructuring**: round 1's fix for a double-computed `isNetErr` call didn't fully work (`isTimeoutErr` was still evaluated twice) and added a duplicated copy of `resolutionCode`'s branch logic. Reverted to calling `resolutionCode(err)` directly like the other 2 call sites, with a separate `isNetErr(err)` call for the `FailOpen` gate — simpler, and correct now that `isNetErr` itself is fixed.
- **Fixed a vacuous test**: the test added to prove `isTimeoutErr` consults the `Timeout()` interface (not message text) used a message that itself contained "timeout" (via "Client.Timeout"), so it would have passed even without the interface check. Reworded it, and added two new `*url.Error`-based cases (a TLS failure, a genuine wrapped timeout) that only pass with the fix in place.
- **Widened the encrypter/decrypter consistency fix**: `signvalidator.go` (already-merged EPIC #861 precedent) classifies its own malformed base64 key/signature bytes as `AUT_SIGNATURE_INVALID`, with an explicit comment stating this is the generic bucket since no more specific taxonomy value exists — directly contradicting round 1's `SCH_INVALID_FORMAT` choice for encrypter/decrypter's identical malformed-key-material sites. Switched all 10 sites across both plugins to `AUT_SIGNATURE_INVALID` to match the established precedent, rather than maintaining a third, inconsistent answer.
- Added code comments (not just PR-description prose) at the two call sites producing the two deliberately-deferred limitations below, so both are discoverable from the source tree itself.
- Removed a stale duplicate doc-comment line on `decrypter_test.go`'s `requireBadReqCode`.

**Filed separately, not fixed here**: round 2 also surfaced a pre-existing verification-bypass gap in `vcvalidator` — when `cfg.RequireProof` is `false` and a credential's `proofValue` is present but `verificationMethod` is empty, the credential is silently accepted with zero verification performed. This is a behavior bug in the verification engine, not an ErrorCode classification gap, and predates this PR — filed as #885.

Left unfixed per explicit direction (now documented in code, not just here): `SignValidationErr`'s hardcoded `"Signature Validation Error: "` message prefix, now also applied to vcvalidator's non-signature failure classes via `NewCodedSignValidationErr`. The structured `Code` field is correct; only the message text is misleading. Cross-cutting `pkg/model` concern affecting every caller of the type, deferred to a separate fix.

## Migration required

Wire-visible response changes for the reclassified failure modes:
- `vcvalidator`: every credential-validation NACK now carries a specific `code` instead of the legacy `"Bad Request"`/`"Unauthorized"` strings. HTTP status codes are unchanged (400 for structural, 401 for authenticity) — including for `resolutionCode`'s paths, so a `NET_TIMEOUT`/`NET_DOWNSTREAM_UNAVAILABLE` code can still appear under an HTTP 401 (a pre-existing code/status mismatch, documented in code as of round 2, not addressed here).
- `publisher`: a RabbitMQ publish failure now returns `code: "NET_DOWNSTREAM_UNAVAILABLE"` instead of `"Bad Request"`. HTTP status stays 400.
- `encrypter`/`decrypter`: no observable wire change today, since neither plugin has a live caller.

Any consumer matching on the old generic strings for these specific failures needs to switch to the new codes.

## Testing

- `go build ./...` / `go vet ./...` / `gofmt -l` clean (aside from the repo-wide pre-existing `*/cmd` plugin-package build quirk, unrelated to this change).
- `go test ./pkg/plugin/implementation/{encrypter,decrypter,publisher,vcvalidator}/... ./pkg/model/... ./core/module/handler/... ./pkg/plugin/implementation/signvalidator/... -cover`: all pass, no regressions in dependent packages.
- Coverage: `encrypter` 93.1%, `decrypter` 91.9% (both meet the ticket's ≥90% target), `publisher` 85.7%, `vcvalidator` 67.0%.
  - `publisher`'s gap is pre-existing (untested `ChannelFunc`/`ExchangeDeclare` bootstrap failure paths) — out of scope.
  - `vcvalidator`'s gap is also pre-existing and much larger than what this PR touches (base58 decode, JWK/DID-document parsing edge cases, HTTP fetchers, generic revocation mechanisms) — every classification branch this PR added or fixed has a direct test with an explicit Code assertion.
- Added `Code`/`BecknError().Code` assertions on every newly-classified path across all four plugins.
- `vcvalidator` specifically: `TestResolutionCode` now covers all 7 branches — string-fallback timeout/non-timeout/non-network, a `Timeout()`-interface case with no "timeout" substring in the message, an ordinary non-2xx HTTP status (not network), and two `*url.Error`-based cases (TLS failure, genuine wrapped timeout) proving the round-2 fix. `TestProofPresentButEmpty` covers the proof-classification fix.

Marked as draft — same review-cycle pattern as the prior tickets in this EPIC before this comes out of draft.
