### PR TITLE
model/responsestep/schemaversionmediator: align remaining NACK defaults to canonical ErrorCode taxonomy (#871)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1039,7 +1039,7 @@ schemaVersionMediator:
 | Key | Values | Default | Description |
 |---|---|---|---|
 | `nodeId` | string | — | **Required.** Three-part DeDi subscriber identity for this node (`namespace/registry/recordId`). Used at startup to load the local node manifest. |
-| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `schemaIncompatible` immediately. |
+| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `SCH_ADAPTATION_FAILED` immediately. |
 | `onFailure` | `reject` \| `passThrough` | `reject` | Applied when `action=translate` but no artifact can be fetched. `passThrough` forwards the untranslated payload — operator escape hatch only, not for production. |
 | `fetchTimeout` | duration string | `"30s"` | HTTP timeout for each artifact fetch (e.g. `"10s"`, `"1m"`). |
 | `artifactCacheTTL` | duration string | `"24h"` | How long to cache successfully fetched translation artifacts. |
@@ -1101,9 +1101,9 @@ modules:
 
 | Code | Cause |
 |---|---|
-| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
-| `schemaIncompatible` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
-| `schemaTranslationDataLoss` | Translation artifact dropped fields present in the source payload. Review the artifact. |
+| `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
+| `SCH_ADAPTATION_FAILED` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
+| `SCH_ADAPTATION_FAILED` | Translation artifact dropped fields present in the source payload. Review the artifact. |
 
 ---
 

--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -173,7 +173,7 @@ func msgID(ctx context.Context) string {
 // internalServerError generates a Beckn internal-server-error payload.
 func internalServerError(ctx context.Context) *model.Error {
 	return &model.Error{
-		Code:    http.StatusText(http.StatusInternalServerError),
+		Code:    "NET_INTERNAL_ERROR",
 		Message: fmt.Sprintf("Internal server error, MessageID: %s", ctx.Value(model.ContextKeyMsgID)),
 	}
 }

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -139,7 +139,7 @@ func TestSendNack(t *testing.T) {
 				},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"SCH_INVALID_FORMAT","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
 		},
 		{
 			name:     "SignValidationErr",
@@ -157,19 +157,19 @@ func TestSendNack(t *testing.T) {
 			name:     "BadReqErr",
 			err:      model.NewBadReqErr(errors.New("bad request error")),
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"BAD Request: bad request error"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"SCH_INVALID_FORMAT","message":"BAD Request: bad request error"}}}`,
 		},
 		{
 			name:     "NotFoundErr",
 			err:      model.NewNotFoundErr(errors.New("endpoint not found")),
 			status:   http.StatusNotFound,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Not Found","message":"Endpoint not found: endpoint not found"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"NET_ENTITY_NOT_FOUND","message":"Endpoint not found: endpoint not found"}}}`,
 		},
 		{
 			name:     "InternalServerError",
 			err:      errors.New("unexpected error"),
 			status:   http.StatusInternalServerError,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Internal Server Error","message":"Internal server error, MessageID: 123456"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"NET_INTERNAL_ERROR","message":"Internal server error, MessageID: 123456"}}}`,
 		},
 	}
 
@@ -183,7 +183,7 @@ func TestSendNack(t *testing.T) {
 			name:     "v2 SchemaValidationErr",
 			err:      model.NewBadReqErr(errors.New("field missing")),
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"Bad Request","message":"BAD Request: field missing"}}}`,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"SCH_INVALID_FORMAT","message":"BAD Request: field missing"}}}`,
 		},
 		{
 			name:     "v2 SignValidationErr",

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -62,11 +61,17 @@ func (e *SchemaValidationErr) Error() string {
 	return strings.Join(errorMessages, "; ")
 }
 
+// defaultSchemaValidationCode is used when a SchemaValidationErr (or one of
+// its underlying Errors) carries no more specific classification — the
+// closest generic bucket in the SCH_* taxonomy. Shared by both schemavalidator
+// (legacy, retiring) and schemav2validator, since both construct this type.
+const defaultSchemaValidationCode = "SCH_INVALID_FORMAT"
+
 // BecknError converts the SchemaValidationErr to an instance of Error.
 func (e *SchemaValidationErr) BecknError() *Error {
 	if len(e.Errors) == 0 {
 		return &Error{
-			Code:    http.StatusText(http.StatusBadRequest),
+			Code:    defaultSchemaValidationCode,
 			Message: "Schema validation error.",
 		}
 	}
@@ -95,7 +100,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    FirstNonEmptyCode(e.Errors, http.StatusText(http.StatusBadRequest)),
+		Code:    FirstNonEmptyCode(e.Errors, defaultSchemaValidationCode),
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
@@ -193,11 +198,17 @@ type BadReqErr struct {
 	codedErr
 }
 
+// defaultBadReqCode is used when a BadReqErr carries no more specific
+// classification — the closest generic bucket in the SCH_* taxonomy. Reused
+// across many callers rather than a dedicated bucket, since this fallback is
+// rarely hit once a caller adopts NewCodedBadReqErr.
+const defaultBadReqCode = "SCH_INVALID_FORMAT"
+
 // NewBadReqErr creates a new instance of BadReqErr from an error. Code is left
-// unset, so BecknError() falls back to the legacy "Bad Request" string — the
-// many existing callers of this constructor across the codebase keep that
-// behavior unchanged. Use NewCodedBadReqErr when the caller knows a more
-// specific taxonomy code.
+// unset, so BecknError() falls back to defaultBadReqCode — the many existing
+// callers of this constructor across the codebase keep that behavior
+// unchanged. Use NewCodedBadReqErr when the caller knows a more specific
+// taxonomy code.
 func NewBadReqErr(err error) *BadReqErr {
 	return &BadReqErr{codedErr{error: err}}
 }
@@ -212,25 +223,37 @@ func NewCodedBadReqErr(code string, err error) *BadReqErr {
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
 	return &Error{
-		Code:    e.resolveCode(http.StatusText(http.StatusBadRequest)),
+		Code:    e.resolveCode(defaultBadReqCode),
 		Message: "BAD Request: " + e.Error(),
 	}
 }
 
+// defaultNotFoundCode is used when a NotFoundErr carries no more specific
+// classification — the closest generic bucket in the NET_* taxonomy.
+const defaultNotFoundCode = "NET_ENTITY_NOT_FOUND"
+
 // NotFoundErr occurs when a requested endpoint is not found.
 type NotFoundErr struct {
-	error
+	codedErr
 }
 
-// NewNotFoundErr creates a new instance of NotFoundErr from an error.
+// NewNotFoundErr creates a new instance of NotFoundErr from an error. Code is
+// left unset, so BecknError() falls back to defaultNotFoundCode. Use
+// NewCodedNotFoundErr when the caller knows a more specific taxonomy code.
 func NewNotFoundErr(err error) *NotFoundErr {
-	return &NotFoundErr{err}
+	return &NotFoundErr{codedErr{error: err}}
+}
+
+// NewCodedNotFoundErr creates a NotFoundErr classified with an explicit
+// taxonomy code, for callers that already know the specific cause.
+func NewCodedNotFoundErr(code string, err error) *NotFoundErr {
+	return &NotFoundErr{codedErr{Code: code, error: err}}
 }
 
 // BecknError converts the NotFoundErr to an instance of Error.
 func (e *NotFoundErr) BecknError() *Error {
 	return &Error{
-		Code:    http.StatusText(http.StatusNotFound),
+		Code:    e.resolveCode(defaultNotFoundCode),
 		Message: "Endpoint not found: " + e.Error(),
 	}
 }

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
 func NewNotFoundErrf(format string, a ...any) *NotFoundErr {
-	return &NotFoundErr{fmt.Errorf(format, a...)}
+	return &NotFoundErr{codedErr{error: fmt.Errorf(format, a...)}}
 }
 
 // NewBadReqErrf creates a new BadReqErr with a formatted error message.
@@ -81,7 +80,7 @@ func TestSchemaValidationErr_BecknError(t *testing.T) {
 	}
 
 	beErr := schemaErr.BecknError()
-	expected := "Bad Request"
+	expected := "SCH_INVALID_FORMAT"
 	if beErr.Code != expected {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Code, expected)
@@ -155,12 +154,12 @@ func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
 			want: "SCH_INVALID_ENUM",
 		},
 		{
-			name: "no entry has a code falls back to the legacy default",
+			name: "no entry has a code falls back to the default",
 			errs: []Error{
 				{Message: "m1"},
 				{Message: "m2"},
 			},
-			want: "Bad Request",
+			want: "SCH_INVALID_FORMAT",
 		},
 	}
 
@@ -272,7 +271,7 @@ func TestResolveCode(t *testing.T) {
 		want        string
 	}{
 		{"explicit code wins", "AUT_KEY_EXPIRED_OR_REVOKED", "AUT_SIGNATURE_INVALID", "AUT_KEY_EXPIRED_OR_REVOKED"},
-		{"empty code falls back to default", "", "Bad Request", "Bad Request"},
+		{"empty code falls back to default", "", "AUT_SIGNATURE_INVALID", "AUT_SIGNATURE_INVALID"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,8 +311,8 @@ func TestBadReqErr_BecknError(t *testing.T) {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
 	}
-	if beErr.Code != "Bad Request" {
-		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default unchanged for NewBadReqErr callers", beErr.Code)
+	if beErr.Code != "SCH_INVALID_FORMAT" {
+		t.Errorf("beErr.Code = %s, want the SCH_INVALID_FORMAT default unchanged for NewBadReqErr callers", beErr.Code)
 	}
 }
 
@@ -334,8 +333,8 @@ func TestBadReqErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
 	badReqErr := &BadReqErr{codedErr{error: errors.New("invalid input")}}
 	beErr := badReqErr.BecknError()
 
-	if beErr.Code != "Bad Request" {
-		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default when Code is unset", beErr.Code)
+	if beErr.Code != "SCH_INVALID_FORMAT" {
+		t.Errorf("beErr.Code = %s, want the SCH_INVALID_FORMAT default when Code is unset", beErr.Code)
 	}
 }
 
@@ -376,6 +375,31 @@ func TestNotFoundErr_BecknError(t *testing.T) {
 	if beErr.Message != expectedMsg {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
+	}
+	if beErr.Code != "NET_ENTITY_NOT_FOUND" {
+		t.Errorf("beErr.Code = %s, want NET_ENTITY_NOT_FOUND (default classification)", beErr.Code)
+	}
+}
+
+func TestNewCodedNotFoundErr_BecknError(t *testing.T) {
+	notFoundErr := NewCodedNotFoundErr("NET_ENTITY_NOT_FOUND", errors.New("subscriber not registered"))
+	beErr := notFoundErr.BecknError()
+
+	if beErr.Code != "NET_ENTITY_NOT_FOUND" {
+		t.Errorf("beErr.Code = %s, want NET_ENTITY_NOT_FOUND", beErr.Code)
+	}
+	expectedMsg := "Endpoint not found: subscriber not registered"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestNotFoundErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	notFoundErr := NewCodedNotFoundErr("NET_ENTITY_NOT_FOUND", sentinel)
+
+	if !errors.Is(notFoundErr, sentinel) {
+		t.Errorf("errors.Is(notFoundErr, sentinel) = false, want true via Unwrap()")
 	}
 }
 
@@ -421,7 +445,7 @@ func TestSchemaValidationErr_BecknError_NoErrors(t *testing.T) {
 	beErr := schemaValidationErr.BecknError()
 
 	expectedMsg := "Schema validation error."
-	expectedCode := http.StatusText(http.StatusBadRequest)
+	expectedCode := "SCH_INVALID_FORMAT"
 
 	if beErr.Message != expectedMsg {
 		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)

--- a/pkg/plugin/implementation/schemaversionmediator/README.md
+++ b/pkg/plugin/implementation/schemaversionmediator/README.md
@@ -24,7 +24,7 @@
 
 On every inbound request, `Mediate` runs the following sequence:
 
-1. **Cold-start guard** — if the local node manifest was absent, unreachable, or had no `schemaObjects` at startup (or if `nodeId` was not set in config), every call is rejected immediately with `subscriberNotOnboarded`.
+1. **Cold-start guard** — if the local node manifest was absent, unreachable, or had no `schemaObjects` at startup (or if `nodeId` was not set in config), every call is rejected immediately with `SCH_SUBSCRIBER_NOT_FOUND`.
 2. **Identity extraction** — reads `networkId`/`network_id` from the payload `context` block; reads the counterparty subscriber ID from `ContextKeyRemoteID` (set by `reqpreprocessor`). If either is empty the payload passes through unchanged.
 3. **Target manifest selection** — direction-aware:
    - **Receiver handler** (`bapTxnReceiver`, `bppTxnReceiver`): uses the local node manifest loaded at startup. No network call at request time.
@@ -32,7 +32,7 @@ On every inbound request, `Mediate` runs the following sequence:
 4. **Compatibility check** — walks the payload for `@context`+`@type` pairs and compares them against the target manifest's `schemaObjects`. If all objects are at a supported version, the payload passes through unchanged.
 5. **Artifact fetch** — for each incompatible schema object, derives the artifact URL from the target manifest's `baseUrl`, canonical version, and the source version, then fetches it over HTTP.
 6. **Translation** — composes the fetched artifacts into a single JSONata expression (`$merge([$, patch1, patch2, ...])`) and executes it against the `message` subtree of the payload in one pass.
-7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `schemaTranslationDataLoss`.
+7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `SCH_ADAPTATION_FAILED`.
 8. **Patch** — replaces the `message` field in `ctx.Body` with the translated output.
 
 ---
@@ -78,11 +78,11 @@ plugins:
 **`action` values:**
 
 - `translate` — attempt translation for each incompatible schema object; apply `onFailure` if any artifact is unavailable.
-- `reject` — return `schemaIncompatible` immediately without attempting translation.
+- `reject` — return `SCH_ADAPTATION_FAILED` immediately without attempting translation.
 
 **`onFailure` values (only evaluated when `action=translate`):**
 
-- `reject` — return `schemaIncompatible` when an artifact cannot be fetched.
+- `reject` — return `SCH_ADAPTATION_FAILED` when an artifact cannot be fetched.
 - `passThrough` — forward the untranslated payload. Operator escape hatch for false-mismatch situations (e.g. stale local manifest during rollout). Not recommended for production.
 
 ---
@@ -134,7 +134,7 @@ At startup, `New` calls `ManifestLoader.GetBySubscriberID` using the `nodeId` co
 - The manifest document cannot be fetched or parsed
 - The manifest contains no `schemaObjects`
 
-While `notOnboarded` is set, every `Mediate` call returns `subscriberNotOnboarded` immediately. The adapter must be restarted after the local node manifest is published to DeDi and `nodeId` is correctly set in config.
+While `notOnboarded` is set, every `Mediate` call returns `SCH_SUBSCRIBER_NOT_FOUND` immediately. The adapter must be restarted after the local node manifest is published to DeDi and `nodeId` is correctly set in config.
 
 ---
 
@@ -214,13 +214,13 @@ The artifact at that URL must contain a JSONata expression that transforms a `v2
 
 ## Error Codes
 
-All errors returned by `Mediate` are of type `*MediationError`, which carries a camelCase `Code` field. The handler uses this to build a structured Beckn NACK response.
+All errors returned by `Mediate` are of type `*MediationError`, which carries a `Code` field aligned with the Beckn v2.0.0 `ErrorCode` taxonomy's `SCH_*` prefix. Note: `MediationError` is not yet wired into the handler's NACK-building dispatch (`nackBecknError`) — today these codes are not surfaced on the wire; a `MediationError` currently falls through to a generic internal-error NACK.
 
 | Code | Cause | Resolution |
 |---|---|---|
-| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
-| `schemaIncompatible` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
-| `schemaTranslationDataLoss` | Translation dropped fields present in the source payload | Review translation artifact — it must not remove fields from the source |
+| `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
+| `SCH_ADAPTATION_FAILED` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
+| `SCH_ADAPTATION_FAILED` | Translation dropped fields present in the source payload (not yet implemented — no code path currently constructs this case) | Review translation artifact — it must not remove fields from the source |
 
 Plain (non-`MediationError`) errors may also be returned for malformed payloads (e.g. missing `message` field). The handler treats these as HTTP 400 Bad Request with a generic error body — distinct from the structured NACK produced by `MediationError`.
 
@@ -240,7 +240,7 @@ Artifacts are cached in memory with configurable positive and negative TTLs. The
 
 After translation, the plugin compares the flattened dot-notation key paths of the source `message` subtree against the translated output. Any key present in the source but absent in the output is considered a dropped field.
 
-**Current behaviour:** data loss always causes rejection with `schemaTranslationDataLoss`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
+**Current behaviour:** data loss always causes rejection with `SCH_ADAPTATION_FAILED`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
 
 **Array handling:** array elements are treated as opaque leaf values. Element-level drops within an array are not detected — only object key presence is compared.
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -430,7 +430,7 @@ func (p *provider) New(ctx context.Context, loader definition.ManifestLoader, cf
 func (m *mediator) Mediate(ctx *model.StepContext) error {
 	if m.notOnboarded {
 		return &MediationError{
-			Code:    "subscriberNotOnboarded",
+			Code:    "SCH_SUBSCRIBER_NOT_FOUND",
 			Message: "Local node manifest is missing or has no schemaObjects. Publish your manifest to DeDi before going live.",
 		}
 	}
@@ -480,7 +480,7 @@ func (m *mediator) Mediate(ctx *model.StepContext) error {
 
 	if m.policy.Action == PolicyActionReject {
 		return &MediationError{
-			Code:    "schemaIncompatible",
+			Code:    "SCH_ADAPTATION_FAILED",
 			Message: fmt.Sprintf("payload contains %d incompatible schema object(s) and policy is reject", len(needs)),
 		}
 	}
@@ -586,7 +586,7 @@ func (m *mediator) applyOnFailure(cause error) error {
 		return nil
 	}
 	return &MediationError{
-		Code:    "schemaIncompatible",
+		Code:    "SCH_ADAPTATION_FAILED",
 		Message: "schema version mediation failed; check adapter logs for details",
 		cause:   cause,
 	}
@@ -646,7 +646,7 @@ func patchMessageSubtree(body, translated []byte) ([]byte, error) {
 type MediationError struct {
 	Code          string
 	Message       string
-	DroppedFields []string // non-nil only for schemaTranslationDataLoss
+	DroppedFields []string // non-nil only for SCH_ADAPTATION_FAILED (data-loss variant)
 	cause         error    // internal; use errors.Unwrap to access
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -1321,8 +1321,8 @@ func TestMediate_NotOnboarded(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "subscriberNotOnboarded" {
-		t.Errorf("expected subscriberNotOnboarded, got %q", me.Code)
+	if me.Code != "SCH_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("expected SCH_SUBSCRIBER_NOT_FOUND, got %q", me.Code)
 	}
 }
 
@@ -1350,8 +1350,8 @@ func TestMediate_CounterpartyManifestUnavailable_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1405,8 +1405,8 @@ func TestMediate_ActionReject_OnIncompatible(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1434,8 +1434,8 @@ func TestMediate_ArtifactNotFound_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 

--- a/pkg/plugin/implementation/vcvalidator/README.md
+++ b/pkg/plugin/implementation/vcvalidator/README.md
@@ -89,7 +89,7 @@ The NACK body matches beckn-onix's v2 shape and is signed by the handler
 (`Signature` response header) like every other pipeline NACK:
 
 ```json
-{"message":{"status":"NACK","messageId":"…","error":{"code":"Unauthorized","message":"Signature Validation Error: CREDENTIAL_REVOKED: …"}}}
+{"message":{"status":"NACK","messageId":"…","error":{"code":"AUT_KEY_EXPIRED_OR_REVOKED","message":"Signature Validation Error: CREDENTIAL_REVOKED: …"}}}
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
- Closes the last legacy-code gaps in EPIC #861: `SchemaValidationErr`/`BadReqErr` default -> `SCH_INVALID_FORMAT`, `NotFoundErr` default -> new `NET_ENTITY_NOT_FOUND` (added `codedErr` embedding + `NewCodedNotFoundErr`, which didn't exist before), `internalServerError()` in responsestep.go -> `NET_INTERNAL_ERROR`.
- Renames `schemaversionmediator`'s camelCase `MediationError` codes onto the `SCH_*` taxonomy (`subscriberNotOnboarded` -> `SCH_SUBSCRIBER_NOT_FOUND`, `schemaIncompatible`/`schemaTranslationDataLoss` -> `SCH_ADAPTATION_FAILED`) for consistency, even though that type isn't yet wired into `nackBecknError`'s NACK dispatch — that gap is called out in the docs, not fixed here (explicit decision, no follow-up ticket filed).
- Updates `vcvalidator/README.md`'s stale `"Unauthorized"` worked example and `schemaversionmediator/README.md` + `CONFIG.md`'s error-code tables to match.

Scope was narrowed from the original #871 ticket text: e2e test suite updates, partner-facing migration docs, and external consumer audit were explicitly dropped (not deferred) — see updated issue body on #871.

## Test plan
- [x] `go build ./...` (pre-existing `cmd` plugin-mode "errors" unrelated to this change)
- [x] `go test ./...` passes
- [x] Manually verified no remaining legacy `http.StatusText`/`"Bad Request"`/`"Not Found"`/`"Internal Server Error"` literals in non-test source

Closes #871
