### PR TITLE
Align NACK error responses with Beckn v2.0.0 ErrorCode taxonomy

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1039,7 +1039,7 @@ schemaVersionMediator:
 | Key | Values | Default | Description |
 |---|---|---|---|
 | `nodeId` | string | — | **Required.** Three-part DeDi subscriber identity for this node (`namespace/registry/recordId`). Used at startup to load the local node manifest. |
-| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `schemaIncompatible` immediately. |
+| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `SCH_ADAPTATION_FAILED` immediately. |
 | `onFailure` | `reject` \| `passThrough` | `reject` | Applied when `action=translate` but no artifact can be fetched. `passThrough` forwards the untranslated payload — operator escape hatch only, not for production. |
 | `fetchTimeout` | duration string | `"30s"` | HTTP timeout for each artifact fetch (e.g. `"10s"`, `"1m"`). |
 | `artifactCacheTTL` | duration string | `"24h"` | How long to cache successfully fetched translation artifacts. |
@@ -1101,9 +1101,9 @@ modules:
 
 | Code | Cause |
 |---|---|
-| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
-| `schemaIncompatible` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
-| `schemaTranslationDataLoss` | Translation artifact dropped fields present in the source payload. Review the artifact. |
+| `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
+| `SCH_ADAPTATION_FAILED` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
+| `SCH_ADAPTATION_FAILED` | Translation artifact dropped fields present in the source payload. Review the artifact. |
 
 ---
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1039,7 +1039,7 @@ schemaVersionMediator:
 | Key | Values | Default | Description |
 |---|---|---|---|
 | `nodeId` | string | — | **Required.** Three-part DeDi subscriber identity for this node (`namespace/registry/recordId`). Used at startup to load the local node manifest. |
-| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `SCH_ADAPTATION_FAILED` immediately. |
+| `action` | `translate` \| `reject` | `translate` | What to do when schema objects are incompatible. `translate` fetches and applies an artifact; `reject` returns `SCH_SCHEMA_ADAPTATION_FAILED` immediately. |
 | `onFailure` | `reject` \| `passThrough` | `reject` | Applied when `action=translate` but no artifact can be fetched. `passThrough` forwards the untranslated payload — operator escape hatch only, not for production. |
 | `fetchTimeout` | duration string | `"30s"` | HTTP timeout for each artifact fetch (e.g. `"10s"`, `"1m"`). |
 | `artifactCacheTTL` | duration string | `"24h"` | How long to cache successfully fetched translation artifacts. |
@@ -1102,8 +1102,7 @@ modules:
 | Code | Cause |
 |---|---|
 | `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup. Restart after publishing the manifest to DeDi. |
-| `SCH_ADAPTATION_FAILED` | Incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`. |
-| `SCH_ADAPTATION_FAILED` | Translation artifact dropped fields present in the source payload. Review the artifact. |
+| `SCH_SCHEMA_ADAPTATION_FAILED` | Two causes share this code: (1) incompatible schema objects and `action=reject`, or artifact fetch failed and `onFailure=reject`; (2) translation artifact dropped fields present in the source payload — review the artifact. |
 
 ---
 

--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -79,6 +79,7 @@ func nackBecknError(ctx context.Context, err error) (*model.Error, int, model.St
 	var badReqErr *model.BadReqErr
 	var notFoundErr *model.NotFoundErr
 	var ackNoCallbackErr *model.AckNoCallbackErr
+	var becknErrorer model.BecknErrorer
 
 	switch {
 	case errors.As(err, &schemaErr):
@@ -94,6 +95,11 @@ func nackBecknError(ctx context.Context, err error) (*model.Error, int, model.St
 			return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
 		}
 		return ackNoCallbackErr.BecknError(), http.StatusAccepted, ackNoCallbackErr.Status
+	case errors.As(err, &becknErrorer):
+		// Any other error type that implements BecknErrorer (e.g.
+		// schemaversionmediator's MediationError) — classified onto the
+		// taxonomy by its own package without core needing to import it.
+		return becknErrorer.BecknError(), http.StatusBadRequest, model.StatusNACK
 	default:
 		return internalServerError(ctx), http.StatusInternalServerError, model.StatusNACK
 	}

--- a/core/module/handler/responsestep.go
+++ b/core/module/handler/responsestep.go
@@ -173,7 +173,7 @@ func msgID(ctx context.Context) string {
 // internalServerError generates a Beckn internal-server-error payload.
 func internalServerError(ctx context.Context) *model.Error {
 	return &model.Error{
-		Code:    http.StatusText(http.StatusInternalServerError),
+		Code:    "NET_INTERNAL_ERROR",
 		Message: fmt.Sprintf("Internal server error, MessageID: %s", ctx.Value(model.ContextKeyMsgID)),
 	}
 }

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -134,12 +134,12 @@ func TestSendNack(t *testing.T) {
 			name: "SchemaValidationErr",
 			err: &model.SchemaValidationErr{
 				Errors: []model.Error{
-					{Paths: "/path1", Message: "Error 1"},
-					{Paths: "/path2", Message: "Error 2"},
+					{Details: &model.ErrorDetails{Path: "/path1"}, Message: "Error 1"},
+					{Details: &model.ErrorDetails{Path: "/path2"}, Message: "Error 2"},
 				},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","paths":"/path1;/path2","message":"Error 1; Error 2"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
 		},
 		{
 			name:     "SignValidationErr",
@@ -363,11 +363,11 @@ func TestNack_1(t *testing.T) {
 			name: "Schema Validation Error",
 			err: &model.Error{
 				Code:    "BAD_REQUEST",
-				Paths:   "/test/path",
 				Message: "Invalid schema",
+				Details: &model.ErrorDetails{Path: "/test/path"},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"BAD_REQUEST","paths":"/test/path","message":"Invalid schema"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"BAD_REQUEST","message":"Invalid schema","details":{"path":"/test/path"}}}}`,
 		},
 		{
 			name: "Internal Server Error",

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
+// testBecknErrorer is a minimal model.BecknErrorer implementation, standing
+// in for any plugin-defined error type (e.g. schemaversionmediator's
+// MediationError) that classifies itself onto the taxonomy without being one
+// of nackBecknError's explicitly-named types.
+type testBecknErrorer struct {
+	code    string
+	message string
+}
+
+func (e *testBecknErrorer) Error() string { return e.message }
+func (e *testBecknErrorer) BecknError() *model.Error {
+	return &model.Error{Code: e.code, Message: e.message}
+}
+
 // ---------------------------------------------------------------------------
 // Response writer helpers
 // ---------------------------------------------------------------------------
@@ -170,6 +184,12 @@ func TestSendNack(t *testing.T) {
 			err:      errors.New("unexpected error"),
 			status:   http.StatusInternalServerError,
 			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"NET_INTERNAL_ERROR","message":"Internal server error, MessageID: 123456"}}}`,
+		},
+		{
+			name:     "BecknErrorer fallback (e.g. schemaversionmediator.MediationError)",
+			err:      &testBecknErrorer{code: "SCH_SUBSCRIBER_NOT_FOUND", message: "no manifest published"},
+			status:   http.StatusBadRequest,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"SCH_SUBSCRIBER_NOT_FOUND","message":"no manifest published"}}}`,
 		},
 	}
 

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -139,7 +139,7 @@ func TestSendNack(t *testing.T) {
 				},
 			},
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"SCH_INVALID_FORMAT","message":"Error 1; Error 2","details":{"path":"/path1;/path2"}}}}`,
 		},
 		{
 			name:     "SignValidationErr",
@@ -157,19 +157,19 @@ func TestSendNack(t *testing.T) {
 			name:     "BadReqErr",
 			err:      model.NewBadReqErr(errors.New("bad request error")),
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Bad Request","message":"BAD Request: bad request error"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"SCH_INVALID_FORMAT","message":"BAD Request: bad request error"}}}`,
 		},
 		{
 			name:     "NotFoundErr",
 			err:      model.NewNotFoundErr(errors.New("endpoint not found")),
 			status:   http.StatusNotFound,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Not Found","message":"Endpoint not found: endpoint not found"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"NET_ENTITY_NOT_FOUND","message":"Endpoint not found: endpoint not found"}}}`,
 		},
 		{
 			name:     "InternalServerError",
 			err:      errors.New("unexpected error"),
 			status:   http.StatusInternalServerError,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Internal Server Error","message":"Internal server error, MessageID: 123456"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"NET_INTERNAL_ERROR","message":"Internal server error, MessageID: 123456"}}}`,
 		},
 	}
 
@@ -183,7 +183,7 @@ func TestSendNack(t *testing.T) {
 			name:     "v2 SchemaValidationErr",
 			err:      model.NewBadReqErr(errors.New("field missing")),
 			status:   http.StatusBadRequest,
-			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"Bad Request","message":"BAD Request: field missing"}}}`,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"SCH_INVALID_FORMAT","message":"BAD Request: field missing"}}}`,
 		},
 		{
 			name:     "v2 SignValidationErr",

--- a/core/module/handler/responsestep_test.go
+++ b/core/module/handler/responsestep_test.go
@@ -145,7 +145,13 @@ func TestSendNack(t *testing.T) {
 			name:     "SignValidationErr",
 			err:      model.NewSignValidationErr(errors.New("signature invalid")),
 			status:   http.StatusUnauthorized,
-			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"Unauthorized","message":"Signature Validation Error: signature invalid"}}}`,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"AUT_SIGNATURE_INVALID","message":"Signature Validation Error: signature invalid"}}}`,
+		},
+		{
+			name:     "Coded SignValidationErr",
+			err:      model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", errors.New("no subscriber found with given credentials")),
+			status:   http.StatusUnauthorized,
+			expected: `{"message":{"ack":{"status":"NACK"},"error":{"code":"AUT_SUBSCRIBER_NOT_FOUND","message":"Signature Validation Error: no subscriber found with given credentials"}}}`,
 		},
 		{
 			name:     "BadReqErr",
@@ -181,9 +187,15 @@ func TestSendNack(t *testing.T) {
 		},
 		{
 			name:     "v2 SignValidationErr",
-			err:      model.NewSignValidationErr(errors.New("signature expired")),
+			err:      model.NewCodedSignValidationErr("AUT_SIGNATURE_INVALID", errors.New("signature expired")),
 			status:   http.StatusUnauthorized,
-			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"Unauthorized","message":"Signature Validation Error: signature expired"}}}`,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"AUT_SIGNATURE_INVALID","message":"Signature Validation Error: signature expired"}}}`,
+		},
+		{
+			name:     "v2 Coded SignValidationErr key expired",
+			err:      model.NewCodedSignValidationErr("AUT_KEY_EXPIRED_OR_REVOKED", errors.New("subscriber key is expired or revoked")),
+			status:   http.StatusUnauthorized,
+			expected: `{"message":{"status":"NACK","messageId":"msg-v2-1","error":{"code":"AUT_KEY_EXPIRED_OR_REVOKED","message":"Signature Validation Error: subscriber key is expired or revoked"}}}`,
 		},
 		{
 			name: "v2 AckNoCallbackErr ACK status",
@@ -476,10 +488,12 @@ type mockKM struct {
 	err    error
 }
 
-func (m *mockKM) GenerateKeyset() (*model.Keyset, error)                               { return nil, nil }
-func (m *mockKM) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error     { return nil }
-func (m *mockKM) DeleteKeyset(_ context.Context, _ string) error                      { return nil }
-func (m *mockKM) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) { return "", "", nil }
+func (m *mockKM) GenerateKeyset() (*model.Keyset, error)                          { return nil, nil }
+func (m *mockKM) InsertKeyset(_ context.Context, _ string, _ *model.Keyset) error { return nil }
+func (m *mockKM) DeleteKeyset(_ context.Context, _ string) error                  { return nil }
+func (m *mockKM) LookupNPKeys(_ context.Context, _, _ string) (string, string, error) {
+	return "", "", nil
+}
 func (m *mockKM) Keyset(_ context.Context, _ string) (*model.Keyset, error) {
 	return m.keyset, m.err
 }
@@ -916,7 +930,7 @@ func TestValidateAckSignatureStep_MissingSignature_AllStatusCodes_Degrades(t *te
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 		http.StatusNotFound,
-		http.StatusAccepted,        // 202 AckNoCallback
+		http.StatusAccepted, // 202 AckNoCallback
 		http.StatusInternalServerError,
 	}
 	for _, code := range codes {

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -194,7 +194,14 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 		log.Debugf(ctx, "Validating %v Header", model.AuthHeaderGateway)
 		if err := s.validate(ctx, headerValue, "", false); err != nil {
 			ctx.RespHeader.Set(model.UnaAuthorizedHeaderGateway, unauthHeader)
-			return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err))
+			// s.validate returns an already-classified *model.SignValidationErr for
+			// most failure paths (keymanager lookup, signvalidator crypto/timestamp
+			// checks) — wrap with plain fmt.Errorf (not model.NewSignValidationErr)
+			// so errors.As still finds that inner classification instead of
+			// shadowing it with a new, default-coded wrapper. Its own header-parse
+			// and algorithm-mismatch checks still return unclassified errors that
+			// fall through to a generic 500 either way; see #864 follow-up.
+			return fmt.Errorf("failed to validate %s: %w", model.AuthHeaderGateway, err)
 		}
 	}
 
@@ -202,7 +209,7 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	headerValue = ctx.Request.Header.Get(model.AuthHeaderSubscriber)
 	if len(headerValue) == 0 {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
-		return model.NewSignValidationErr(fmt.Errorf("%s missing", model.UnaAuthorizedHeaderSubscriber))
+		return model.NewCodedSignValidationErr("AUT_SIGNATURE_MISSING", fmt.Errorf("%s missing", model.UnaAuthorizedHeaderSubscriber))
 	}
 	reqSig, err := s.lookupCallbackRequestSig(ctx, headerValue)
 	if err != nil {
@@ -211,7 +218,9 @@ func (s *validateSignStep) validateHeaders(ctx *model.StepContext) error {
 	}
 	if err := s.validate(ctx, headerValue, reqSig, true); err != nil {
 		ctx.RespHeader.Set(model.UnaAuthorizedHeaderSubscriber, unauthHeader)
-		return model.NewSignValidationErr(fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err))
+		// Same reasoning as the gateway-header branch above: preserve s.validate's
+		// classification instead of shadowing it.
+		return fmt.Errorf("failed to validate %s: %w", model.AuthHeaderSubscriber, err)
 	}
 	return nil
 }

--- a/core/module/handler/step_test.go
+++ b/core/module/handler/step_test.go
@@ -222,7 +222,7 @@ func TestValidateSignStep_InitSteps_WithPayloadStore(t *testing.T) {
 // verify real signatures in unit tests.
 func testKeyset() *model.Keyset {
 	return &model.Keyset{
-		UniqueKeyID:   "key-1",
+		UniqueKeyID:    "key-1",
 		SigningPrivate: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 	}
 }
@@ -423,6 +423,55 @@ func TestValidateHeaders_SolicitedCallback_PreV2_FallsBackToValidate(t *testing.
 	}
 	if !sv.validateCalled {
 		t.Error("expected Validate to be called for pre-v2 version")
+	}
+}
+
+// TestValidateHeaders_PreservesClassifiedCode verifies that validateHeaders
+// propagates the AUT_* code a lower layer already classified (signvalidator's
+// Validate/ValidateAck or keymanager's LookupNPKeys) instead of shadowing it
+// with a fresh, default-coded model.NewSignValidationErr wrapper.
+func TestValidateHeaders_PreservesClassifiedCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		sv       *mockSignValidatorBasic
+		km       *mockKMBasic
+		wantCode string
+	}{
+		{
+			name:     "Validate returns a classified error",
+			sv:       &mockSignValidatorBasic{validateErr: model.NewCodedSignValidationErr("AUT_UNAUTHORIZED_ACTION", errors.New("identity mismatch"))},
+			km:       &mockKMBasic{publicKey: "pubKey=="},
+			wantCode: "AUT_UNAUTHORIZED_ACTION",
+		},
+		{
+			name:     "LookupNPKeys returns a classified error",
+			sv:       &mockSignValidatorBasic{},
+			km:       &mockKMBasic{lookupErr: model.NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", errors.New("no subscriber found with given credentials"))},
+			wantCode: "AUT_SUBSCRIBER_NOT_FOUND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step, _ := newValidateSignStep(tt.sv, tt.km, nil)
+			vStep := step.(*validateSignStep)
+
+			ctx := makeValidateStepCtx("2.0.0", "msg-vh-code", "bap.example.com",
+				providerInitiatedAuthHeader("bpp.example.com"),
+				`{"context":{"action":"on_search","messageId":"msg-vh-code","version":"2.0.0"}}`)
+
+			err := vStep.validateHeaders(ctx)
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != tt.wantCode {
+				t.Errorf("signErr.Code = %s, want %s (validateHeaders must not shadow the inner classification)", signErr.Code, tt.wantCode)
+			}
+		})
 	}
 }
 

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -112,20 +112,44 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 }
 
+// defaultSignValidationCode is used when a SignValidationErr carries no more
+// specific classification — the closest generic bucket in the AUT_* taxonomy.
+const defaultSignValidationCode = "AUT_SIGNATURE_INVALID"
+
 // SignValidationErr occurs when signature validation fails.
 type SignValidationErr struct {
+	// Code is the AUT_* taxonomy value for this failure's specific cause.
+	Code string
 	error
 }
 
-// NewSignValidationErr creates a new instance of SignValidationErr from an error.
+// NewSignValidationErr creates a new instance of SignValidationErr from an error,
+// classified as AUT_SIGNATURE_INVALID (the generic bucket). Use
+// NewCodedSignValidationErr when the caller knows a more specific AUT_* cause.
 func NewSignValidationErr(e error) *SignValidationErr {
-	return &SignValidationErr{e}
+	return &SignValidationErr{Code: defaultSignValidationCode, error: e}
+}
+
+// NewCodedSignValidationErr creates a SignValidationErr classified with an
+// explicit AUT_* code, for callers that already know the specific cause.
+func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
+	return &SignValidationErr{Code: code, error: e}
+}
+
+// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
+// plugin-defined sentinel error) in addition to matching *SignValidationErr itself.
+func (e *SignValidationErr) Unwrap() error {
+	return e.error
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
 func (e *SignValidationErr) BecknError() *Error {
+	code := e.Code
+	if code == "" {
+		code = defaultSignValidationCode
+	}
 	return &Error{
-		Code:    http.StatusText(http.StatusUnauthorized),
+		Code:    code,
 		Message: "Signature Validation Error: " + e.Error(),
 	}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -10,6 +10,12 @@ type Error struct {
 	Code    string        `json:"code"`
 	Message string        `json:"message"`
 	Details *ErrorDetails `json:"details,omitempty"`
+	// cause is the underlying error this Error was derived from, if any. It is
+	// unexported (never appears on the wire) and exists purely so
+	// errors.Is/errors.As can keep reaching the original cause through Unwrap,
+	// instead of a caller having to thread a separate cause value alongside
+	// the *Error return.
+	cause error
 }
 
 // NewCodedError constructs an Error carrying an explicit ErrorCode value and
@@ -19,12 +25,45 @@ type Error struct {
 //
 // The returned *Error is a plain value, not a step error: nackBecknError
 // (core/module/handler/responsestep.go) only recognizes SchemaValidationErr,
-// SignValidationErr, BadReqErr, NotFoundErr, and AckNoCallbackErr. Callers
-// must wrap the result in one of those types before returning it from a
-// Step — returning it bare falls through to a generic 500 Internal Server
-// Error instead of the intended NACK code.
+// SignValidationErr, BadReqErr, NotFoundErr, AckNoCallbackErr, and any type
+// implementing BecknErrorer. Callers must wrap the result in one of those
+// types (or implement BecknErrorer) before returning it from a Step —
+// returning it bare falls through to a generic 500 Internal Server Error
+// instead of the intended NACK code.
 func NewCodedError(code, message string) *Error {
 	return &Error{Code: code, Message: message}
+}
+
+// NewCodedErrorWithCause is like NewCodedError but also records the JSONPath
+// to the failing field (path, may be "") and the underlying cause, so callers
+// don't have to flatten both into the message string to preserve them —
+// Details.Path carries the path and Unwrap() keeps the cause reachable via
+// errors.Is/errors.As.
+func NewCodedErrorWithCause(code, message, path string, cause error) *Error {
+	e := &Error{Code: code, Message: message, cause: cause}
+	if path != "" {
+		e.Details = &ErrorDetails{Path: path}
+	}
+	return e
+}
+
+// Unwrap exposes the wrapped cause (if any) so errors.Is/errors.As can reach
+// it in addition to matching *Error itself.
+func (e *Error) Unwrap() error {
+	return e.cause
+}
+
+// BecknErrorer is implemented by any error type that can produce its own
+// *Error NACK representation. nackBecknError (core/module/handler/responsestep.go)
+// dispatches on a fixed list of concrete types first (SchemaValidationErr,
+// SignValidationErr, BadReqErr, NotFoundErr, AckNoCallbackErr) for their
+// type-specific HTTP status codes, then falls back to this interface for any
+// other type — so a new error type can be wired into NACK dispatch by
+// implementing BecknError() *Error alone, without core importing the
+// plugin package that defines it.
+type BecknErrorer interface {
+	error
+	BecknError() *Error
 }
 
 // ErrorDetails carries optional structured context for an Error: a JSONPath to

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -8,14 +8,29 @@ import (
 
 // Error represents a standard error response.
 type Error struct {
-	Code    string `json:"code"`
-	Paths   string `json:"paths,omitempty"`
-	Message string `json:"message"`
+	Code    string        `json:"code"`
+	Message string        `json:"message"`
+	Details *ErrorDetails `json:"details,omitempty"`
+}
+
+// ErrorDetails carries optional structured context for an Error: a JSONPath to
+// the failing field, and/or a chained root-cause Error from a downstream layer.
+type ErrorDetails struct {
+	Path  string `json:"path,omitempty"`
+	Cause *Error `json:"cause,omitempty"`
+}
+
+// path returns the details path, or "" if Details is unset.
+func (e *Error) path() string {
+	if e.Details == nil {
+		return ""
+	}
+	return e.Details.Path
 }
 
 // This implements the error interface for the Error struct.
 func (e *Error) Error() string {
-	return fmt.Sprintf("Error: Code=%s, Path=%s, Message=%s", e.Code, e.Paths, e.Message)
+	return fmt.Sprintf("Error: Code=%s, Path=%s, Message=%s", e.Code, e.path(), e.Message)
 }
 
 // SchemaValidationErr occurs when schema validation errors are encountered.
@@ -27,7 +42,7 @@ type SchemaValidationErr struct {
 func (e *SchemaValidationErr) Error() string {
 	var errorMessages []string
 	for _, err := range e.Errors {
-		errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", err.Paths, err.Message))
+		errorMessages = append(errorMessages, fmt.Sprintf("%s: %s", err.path(), err.Message))
 	}
 	return strings.Join(errorMessages, "; ")
 }
@@ -41,19 +56,32 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 	}
 
-	// Collect all error paths and messages
+	// Collect all error paths, one entry per cause (an entry with no path
+	// contributes an empty string), so Details.Path preserves per-cause
+	// structure when split on ";" — path segments don't contain literal
+	// semicolons in practice. Message is a separate, human-readable
+	// concatenation only; it may itself contain either delimiter, so it
+	// is not safe to split back into per-cause text.
 	var paths []string
 	var messages []string
+	hasPath := false
 	for _, err := range e.Errors {
-		if err.Paths != "" {
-			paths = append(paths, err.Paths)
+		p := err.path()
+		if p != "" {
+			hasPath = true
 		}
+		paths = append(paths, p)
 		messages = append(messages, err.Message)
+	}
+
+	var details *ErrorDetails
+	if hasPath {
+		details = &ErrorDetails{Path: strings.Join(paths, ";")}
 	}
 
 	return &Error{
 		Code:    http.StatusText(http.StatusBadRequest),
-		Paths:   strings.Join(paths, ";"),
+		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -13,6 +13,21 @@ type Error struct {
 	Details *ErrorDetails `json:"details,omitempty"`
 }
 
+// NewCodedError constructs an Error carrying an explicit ErrorCode value and
+// message, for callers that already know a specific code to report (e.g. a
+// plugin classifying one of its own failure modes onto the Beckn v2.0.0
+// ErrorCode taxonomy).
+//
+// The returned *Error is a plain value, not a step error: nackBecknError
+// (core/module/handler/responsestep.go) only recognizes SchemaValidationErr,
+// SignValidationErr, BadReqErr, NotFoundErr, and AckNoCallbackErr. Callers
+// must wrap the result in one of those types before returning it from a
+// Step — returning it bare falls through to a generic 500 Internal Server
+// Error instead of the intended NACK code.
+func NewCodedError(code, message string) *Error {
+	return &Error{Code: code, Message: message}
+}
+
 // ErrorDetails carries optional structured context for an Error: a JSONPath to
 // the failing field, and/or a chained root-cause Error from a downstream layer.
 type ErrorDetails struct {
@@ -65,6 +80,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	var paths []string
 	var messages []string
 	hasPath := false
+	code := ""
 	for _, err := range e.Errors {
 		p := err.path()
 		if p != "" {
@@ -72,6 +88,16 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 		paths = append(paths, p)
 		messages = append(messages, err.Message)
+		// First non-empty per-cause code wins. The other causes' text is
+		// still fully present in Message/Details.Path — only their
+		// individual Code is not separately represented on the wire, since
+		// a single Error can only carry one code.
+		if code == "" && err.Code != "" {
+			code = err.Code
+		}
+	}
+	if code == "" {
+		code = http.StatusText(http.StatusBadRequest)
 	}
 
 	var details *ErrorDetails
@@ -80,7 +106,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    http.StatusText(http.StatusBadRequest),
+		Code:    code,
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -62,11 +61,17 @@ func (e *SchemaValidationErr) Error() string {
 	return strings.Join(errorMessages, "; ")
 }
 
+// defaultSchemaValidationCode is used when a SchemaValidationErr (or one of
+// its underlying Errors) carries no more specific classification — the
+// closest generic bucket in the SCH_* taxonomy. Shared by both schemavalidator
+// (legacy, retiring) and schemav2validator, since both construct this type.
+const defaultSchemaValidationCode = "SCH_INVALID_FORMAT"
+
 // BecknError converts the SchemaValidationErr to an instance of Error.
 func (e *SchemaValidationErr) BecknError() *Error {
 	if len(e.Errors) == 0 {
 		return &Error{
-			Code:    http.StatusText(http.StatusBadRequest),
+			Code:    defaultSchemaValidationCode,
 			Message: "Schema validation error.",
 		}
 	}
@@ -95,7 +100,7 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    FirstNonEmptyCode(e.Errors, http.StatusText(http.StatusBadRequest)),
+		Code:    FirstNonEmptyCode(e.Errors, defaultSchemaValidationCode),
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
@@ -193,11 +198,17 @@ type BadReqErr struct {
 	codedErr
 }
 
+// defaultBadReqCode is used when a BadReqErr carries no more specific
+// classification — the closest generic bucket in the SCH_* taxonomy. Reused
+// across many callers rather than a dedicated bucket, since this fallback is
+// rarely hit once a caller adopts NewCodedBadReqErr.
+const defaultBadReqCode = "SCH_INVALID_FORMAT"
+
 // NewBadReqErr creates a new instance of BadReqErr from an error. Code is left
-// unset, so BecknError() falls back to the legacy "Bad Request" string — the
-// many existing callers of this constructor across the codebase keep that
-// behavior unchanged. Use NewCodedBadReqErr when the caller knows a more
-// specific taxonomy code.
+// unset, so BecknError() falls back to defaultBadReqCode — the many existing
+// callers of this constructor across the codebase keep that behavior
+// unchanged. Use NewCodedBadReqErr when the caller knows a more specific
+// taxonomy code.
 func NewBadReqErr(err error) *BadReqErr {
 	return &BadReqErr{codedErr{error: err}}
 }
@@ -212,25 +223,37 @@ func NewCodedBadReqErr(code string, err error) *BadReqErr {
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
 	return &Error{
-		Code:    e.resolveCode(http.StatusText(http.StatusBadRequest)),
+		Code:    e.resolveCode(defaultBadReqCode),
 		Message: "BAD Request: " + e.Error(),
 	}
 }
 
+// defaultNotFoundCode is used when a NotFoundErr carries no more specific
+// classification — the closest generic bucket in the NET_* taxonomy.
+const defaultNotFoundCode = "NET_ENTITY_NOT_FOUND"
+
 // NotFoundErr occurs when a requested endpoint is not found.
 type NotFoundErr struct {
-	error
+	codedErr
 }
 
-// NewNotFoundErr creates a new instance of NotFoundErr from an error.
+// NewNotFoundErr creates a new instance of NotFoundErr from an error. Code is
+// left unset, so BecknError() falls back to defaultNotFoundCode. Use
+// NewCodedNotFoundErr when the caller knows a more specific taxonomy code.
 func NewNotFoundErr(err error) *NotFoundErr {
-	return &NotFoundErr{err}
+	return &NotFoundErr{codedErr{error: err}}
+}
+
+// NewCodedNotFoundErr creates a NotFoundErr classified with an explicit
+// taxonomy code, for callers that already know the specific cause.
+func NewCodedNotFoundErr(code string, err error) *NotFoundErr {
+	return &NotFoundErr{codedErr{Code: code, error: err}}
 }
 
 // BecknError converts the NotFoundErr to an instance of Error.
 func (e *NotFoundErr) BecknError() *Error {
 	return &Error{
-		Code:    http.StatusText(http.StatusNotFound),
+		Code:    e.resolveCode(defaultNotFoundCode),
 		Message: "Endpoint not found: " + e.Error(),
 	}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -80,7 +80,6 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	var paths []string
 	var messages []string
 	hasPath := false
-	code := ""
 	for _, err := range e.Errors {
 		p := err.path()
 		if p != "" {
@@ -88,16 +87,6 @@ func (e *SchemaValidationErr) BecknError() *Error {
 		}
 		paths = append(paths, p)
 		messages = append(messages, err.Message)
-		// First non-empty per-cause code wins. The other causes' text is
-		// still fully present in Message/Details.Path — only their
-		// individual Code is not separately represented on the wire, since
-		// a single Error can only carry one code.
-		if code == "" && err.Code != "" {
-			code = err.Code
-		}
-	}
-	if code == "" {
-		code = http.StatusText(http.StatusBadRequest)
 	}
 
 	var details *ErrorDetails
@@ -106,10 +95,54 @@ func (e *SchemaValidationErr) BecknError() *Error {
 	}
 
 	return &Error{
-		Code:    code,
+		Code:    FirstNonEmptyCode(e.Errors, http.StatusText(http.StatusBadRequest)),
 		Details: details,
 		Message: strings.Join(messages, "; "),
 	}
+}
+
+// FirstNonEmptyCode returns the first non-empty Code among errs, in order, or
+// defaultCode if none is set. Used when multiple causes must be reduced to
+// one representative Code for the wire — the other causes' text is still
+// carried in full elsewhere (e.g. a joined Message), only their Code is
+// dropped, since a single Error can only carry one code.
+func FirstNonEmptyCode(errs []Error, defaultCode string) string {
+	for _, e := range errs {
+		if e.Code != "" {
+			return e.Code
+		}
+	}
+	return defaultCode
+}
+
+// codedErr is the common shape shared by wrapper error types that carry one
+// opaque cause plus an optional explicit taxonomy code, falling back to a
+// type-specific default when Code is empty. Embed it in a named type (e.g.
+// SignValidationErr, BadReqErr) to get Code storage and Unwrap() without
+// duplicating them — the embedding type still defines its own constructors
+// and BecknError(), since message-prefix formatting and the default code
+// genuinely differ per type.
+type codedErr struct {
+	// Code is the taxonomy value for this failure's specific cause, or ""
+	// if unclassified — the embedding type's BecknError() should apply its
+	// own default via resolveCode in that case.
+	Code string
+	error
+}
+
+// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
+// plugin-defined sentinel error) in addition to matching the embedding type.
+func (e *codedErr) Unwrap() error {
+	return e.error
+}
+
+// resolveCode returns Code if non-empty, else defaultCode. Called by each
+// embedding type's BecknError() to apply its own default fallback.
+func (e *codedErr) resolveCode(defaultCode string) string {
+	if e.Code != "" {
+		return e.Code
+	}
+	return defaultCode
 }
 
 // defaultSignValidationCode is used when a SignValidationErr carries no more
@@ -118,56 +151,57 @@ const defaultSignValidationCode = "AUT_SIGNATURE_INVALID"
 
 // SignValidationErr occurs when signature validation fails.
 type SignValidationErr struct {
-	// Code is the AUT_* taxonomy value for this failure's specific cause.
-	Code string
-	error
+	codedErr
 }
 
-// NewSignValidationErr creates a new instance of SignValidationErr from an error,
-// classified as AUT_SIGNATURE_INVALID (the generic bucket). Use
-// NewCodedSignValidationErr when the caller knows a more specific AUT_* cause.
+// NewSignValidationErr creates a new instance of SignValidationErr from an
+// error. Code is left unset, so BecknError() falls back to the generic
+// AUT_SIGNATURE_INVALID bucket — mirrors NewBadReqErr's lazy-default
+// convention. Use NewCodedSignValidationErr when the caller knows a more
+// specific AUT_* cause.
 func NewSignValidationErr(e error) *SignValidationErr {
-	return &SignValidationErr{Code: defaultSignValidationCode, error: e}
+	return &SignValidationErr{codedErr{error: e}}
 }
 
 // NewCodedSignValidationErr creates a SignValidationErr classified with an
 // explicit AUT_* code, for callers that already know the specific cause.
 func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
-	return &SignValidationErr{Code: code, error: e}
-}
-
-// Unwrap exposes the wrapped cause so errors.Is/errors.As can reach it (e.g. a
-// plugin-defined sentinel error) in addition to matching *SignValidationErr itself.
-func (e *SignValidationErr) Unwrap() error {
-	return e.error
+	return &SignValidationErr{codedErr{Code: code, error: e}}
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
 func (e *SignValidationErr) BecknError() *Error {
-	code := e.Code
-	if code == "" {
-		code = defaultSignValidationCode
-	}
 	return &Error{
-		Code:    code,
+		Code:    e.resolveCode(defaultSignValidationCode),
 		Message: "Signature Validation Error: " + e.Error(),
 	}
 }
 
 // BadReqErr occurs when a bad request is encountered.
 type BadReqErr struct {
-	error
+	codedErr
 }
 
-// NewBadReqErr creates a new instance of BadReqErr from an error.
+// NewBadReqErr creates a new instance of BadReqErr from an error. Code is left
+// unset, so BecknError() falls back to the legacy "Bad Request" string — the
+// many existing callers of this constructor across the codebase keep that
+// behavior unchanged. Use NewCodedBadReqErr when the caller knows a more
+// specific taxonomy code.
 func NewBadReqErr(err error) *BadReqErr {
-	return &BadReqErr{err}
+	return &BadReqErr{codedErr{error: err}}
+}
+
+// NewCodedBadReqErr creates a BadReqErr classified with an explicit taxonomy
+// code, for callers that already know the specific cause (e.g. a policy
+// checker classifying a denial onto the Beckn v2.0.0 POL_* codes).
+func NewCodedBadReqErr(code string, err error) *BadReqErr {
+	return &BadReqErr{codedErr{Code: code, error: err}}
 }
 
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
 	return &Error{
-		Code:    http.StatusText(http.StatusBadRequest),
+		Code:    e.resolveCode(http.StatusText(http.StatusBadRequest)),
 		Message: "BAD Request: " + e.Error(),
 	}
 }

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -170,6 +170,17 @@ func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
 }
 
 // BecknError converts the SignValidationErr to an instance of Error.
+//
+// The "Signature Validation Error: " message prefix was accurate for this
+// type's original sole caller (signvalidator.go, exclusively real signature
+// failures). vcvalidator (see #870/#884) also constructs SignValidationErr
+// for non-signature causes — expiry, revocation, DID-resolution failures,
+// issuer mismatch — via NewCodedSignValidationErr, so the human-readable
+// message can now read e.g. "Signature Validation Error: CREDENTIAL_EXPIRED:
+// ...". The structured Code field is correct either way; only this message
+// text is misleading for those causes. Deliberately left as-is: fixing it is
+// a cross-cutting change affecting every caller of this type, deferred
+// rather than folded into #884's scope.
 func (e *SignValidationErr) BecknError() *Error {
 	return &Error{
 		Code:    e.resolveCode(defaultSignValidationCode),

--- a/pkg/model/error.go
+++ b/pkg/model/error.go
@@ -180,13 +180,28 @@ func (e *codedErr) Unwrap() error {
 	return e.error
 }
 
-// resolveCode returns Code if non-empty, else defaultCode. Called by each
-// embedding type's BecknError() to apply its own default fallback.
+// resolveCode returns Code if non-empty, else defaultCode. Called by
+// becknError to apply the embedding type's own default fallback.
 func (e *codedErr) resolveCode(defaultCode string) string {
 	if e.Code != "" {
 		return e.Code
 	}
 	return defaultCode
+}
+
+// becknError builds the *Error NACK payload shared by every codedErr embedder:
+// resolveCode's Code/default fallback, plus prefix prepended to the wrapped
+// error's text. New plugin-specific error types that only need "a code with
+// a default, plus a fixed message prefix" (the common case) should embed
+// codedErr and implement BecknError() as a one-line call to this — see
+// BadReqErr/SignValidationErr/NotFoundErr below. Only reach for a fully
+// custom BecknError() (like SchemaValidationErr's multi-cause aggregation or
+// AckNoCallbackErr's pass-through) when the shape genuinely doesn't fit.
+func (e *codedErr) becknError(prefix, defaultCode string) *Error {
+	return &Error{
+		Code:    e.resolveCode(defaultCode),
+		Message: prefix + e.Error(),
+	}
 }
 
 // defaultSignValidationCode is used when a SignValidationErr carries no more
@@ -226,10 +241,7 @@ func NewCodedSignValidationErr(code string, e error) *SignValidationErr {
 // a cross-cutting change affecting every caller of this type, deferred
 // rather than folded into #884's scope.
 func (e *SignValidationErr) BecknError() *Error {
-	return &Error{
-		Code:    e.resolveCode(defaultSignValidationCode),
-		Message: "Signature Validation Error: " + e.Error(),
-	}
+	return e.becknError("Signature Validation Error: ", defaultSignValidationCode)
 }
 
 // BadReqErr occurs when a bad request is encountered.
@@ -261,10 +273,7 @@ func NewCodedBadReqErr(code string, err error) *BadReqErr {
 
 // BecknError converts the BadReqErr to an instance of Error.
 func (e *BadReqErr) BecknError() *Error {
-	return &Error{
-		Code:    e.resolveCode(defaultBadReqCode),
-		Message: "BAD Request: " + e.Error(),
-	}
+	return e.becknError("BAD Request: ", defaultBadReqCode)
 }
 
 // defaultNotFoundCode is used when a NotFoundErr carries no more specific
@@ -291,10 +300,7 @@ func NewCodedNotFoundErr(code string, err error) *NotFoundErr {
 
 // BecknError converts the NotFoundErr to an instance of Error.
 func (e *NotFoundErr) BecknError() *Error {
-	return &Error{
-		Code:    e.resolveCode(defaultNotFoundCode),
-		Message: "Endpoint not found: " + e.Error(),
-	}
+	return e.becknError("Endpoint not found: ", defaultNotFoundCode)
 }
 
 // AckNoCallbackErr is returned by a step when the receiver has authenticated and

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -18,7 +17,7 @@ func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
 func NewNotFoundErrf(format string, a ...any) *NotFoundErr {
-	return &NotFoundErr{fmt.Errorf(format, a...)}
+	return &NotFoundErr{codedErr{error: fmt.Errorf(format, a...)}}
 }
 
 // NewBadReqErrf creates a new BadReqErr with a formatted error message.
@@ -81,7 +80,7 @@ func TestSchemaValidationErr_BecknError(t *testing.T) {
 	}
 
 	beErr := schemaErr.BecknError()
-	expected := "Bad Request"
+	expected := "SCH_INVALID_FORMAT"
 	if beErr.Code != expected {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Code, expected)
@@ -155,12 +154,12 @@ func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
 			want: "SCH_INVALID_ENUM",
 		},
 		{
-			name: "no entry has a code falls back to the legacy default",
+			name: "no entry has a code falls back to the default",
 			errs: []Error{
 				{Message: "m1"},
 				{Message: "m2"},
 			},
-			want: "Bad Request",
+			want: "SCH_INVALID_FORMAT",
 		},
 	}
 
@@ -272,7 +271,7 @@ func TestResolveCode(t *testing.T) {
 		want        string
 	}{
 		{"explicit code wins", "AUT_KEY_EXPIRED_OR_REVOKED", "AUT_SIGNATURE_INVALID", "AUT_KEY_EXPIRED_OR_REVOKED"},
-		{"empty code falls back to default", "", "Bad Request", "Bad Request"},
+		{"empty code falls back to default", "", "AUT_SIGNATURE_INVALID", "AUT_SIGNATURE_INVALID"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,8 +311,8 @@ func TestBadReqErr_BecknError(t *testing.T) {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
 	}
-	if beErr.Code != "Bad Request" {
-		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default unchanged for NewBadReqErr callers", beErr.Code)
+	if beErr.Code != "SCH_INVALID_FORMAT" {
+		t.Errorf("beErr.Code = %s, want the SCH_INVALID_FORMAT default unchanged for NewBadReqErr callers", beErr.Code)
 	}
 }
 
@@ -334,8 +333,8 @@ func TestBadReqErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
 	badReqErr := &BadReqErr{codedErr{error: errors.New("invalid input")}}
 	beErr := badReqErr.BecknError()
 
-	if beErr.Code != "Bad Request" {
-		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default when Code is unset", beErr.Code)
+	if beErr.Code != "SCH_INVALID_FORMAT" {
+		t.Errorf("beErr.Code = %s, want the SCH_INVALID_FORMAT default when Code is unset", beErr.Code)
 	}
 }
 
@@ -376,6 +375,31 @@ func TestNotFoundErr_BecknError(t *testing.T) {
 	if beErr.Message != expectedMsg {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
+	}
+	if beErr.Code != "NET_ENTITY_NOT_FOUND" {
+		t.Errorf("beErr.Code = %s, want NET_ENTITY_NOT_FOUND (default classification)", beErr.Code)
+	}
+}
+
+func TestNewCodedNotFoundErr_BecknError(t *testing.T) {
+	notFoundErr := NewCodedNotFoundErr("NET_ENTITY_NOT_FOUND", errors.New("subscriber not registered"))
+	beErr := notFoundErr.BecknError()
+
+	if beErr.Code != "NET_ENTITY_NOT_FOUND" {
+		t.Errorf("beErr.Code = %s, want NET_ENTITY_NOT_FOUND", beErr.Code)
+	}
+	expectedMsg := "Endpoint not found: subscriber not registered"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestNotFoundErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	notFoundErr := NewCodedNotFoundErr("NET_ENTITY_NOT_FOUND", sentinel)
+
+	if !errors.Is(notFoundErr, sentinel) {
+		t.Errorf("errors.Is(notFoundErr, sentinel) = false, want true via Unwrap()")
 	}
 }
 
@@ -421,7 +445,7 @@ func TestSchemaValidationErr_BecknError_NoErrors(t *testing.T) {
 	beErr := schemaValidationErr.BecknError()
 
 	expectedMsg := "Schema validation error."
-	expectedCode := http.StatusText(http.StatusBadRequest)
+	expectedCode := "SCH_INVALID_FORMAT"
 
 	if beErr.Message != expectedMsg {
 		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -29,8 +29,8 @@ func NewBadReqErrf(format string, a ...any) *BadReqErr {
 func TestError_Error(t *testing.T) {
 	err := &Error{
 		Code:    "404",
-		Paths:   "/api/v1/user",
 		Message: "User not found",
+		Details: &ErrorDetails{Path: "/api/v1/user"},
 	}
 
 	expected := "Error: Code=404, Path=/api/v1/user, Message=User not found"
@@ -46,8 +46,8 @@ func TestError_Error(t *testing.T) {
 func TestSchemaValidationErr_Error(t *testing.T) {
 	schemaErr := &SchemaValidationErr{
 		Errors: []Error{
-			{Paths: "/user", Message: "Field required"},
-			{Paths: "/email", Message: "Invalid format"},
+			{Details: &ErrorDetails{Path: "/user"}, Message: "Field required"},
+			{Details: &ErrorDetails{Path: "/email"}, Message: "Invalid format"},
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestSchemaValidationErr_Error(t *testing.T) {
 func TestSchemaValidationErr_BecknError(t *testing.T) {
 	schemaErr := &SchemaValidationErr{
 		Errors: []Error{
-			{Paths: "/user", Message: "Field required"},
+			{Details: &ErrorDetails{Path: "/user"}, Message: "Field required"},
 		},
 	}
 
@@ -72,6 +72,50 @@ func TestSchemaValidationErr_BecknError(t *testing.T) {
 	if beErr.Code != expected {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Code, expected)
+	}
+	if beErr.Details == nil || beErr.Details.Path != "/user" {
+		t.Errorf("beErr.Details = %+v, want Path=/user", beErr.Details)
+	}
+}
+
+func TestSchemaValidationErr_BecknError_NoPaths(t *testing.T) {
+	schemaErr := &SchemaValidationErr{
+		Errors: []Error{
+			{Message: "generic error one"},
+			{Message: "generic error two"},
+		},
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Details != nil {
+		t.Errorf("beErr.Details = %+v, want nil when no entry has a path", beErr.Details)
+	}
+	expectedMsg := "generic error one; generic error two"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestSchemaValidationErr_BecknError_MixedPaths(t *testing.T) {
+	schemaErr := &SchemaValidationErr{
+		Errors: []Error{
+			{Details: &ErrorDetails{Path: "/a"}, Message: "m1"},
+			{Message: "m2"},
+			{Details: &ErrorDetails{Path: "/c"}, Message: "m3"},
+		},
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Details == nil {
+		t.Fatal("beErr.Details = nil, want non-nil since at least one entry has a path")
+	}
+	expectedPath := "/a;;/c"
+	if beErr.Details.Path != expectedPath {
+		t.Errorf("beErr.Details.Path = %s, want %s (positionally aligned with Message)", beErr.Details.Path, expectedPath)
+	}
+	expectedMsg := "m1; m2; m3"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
 	}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -26,6 +26,19 @@ func NewBadReqErrf(format string, a ...any) *BadReqErr {
 	return &BadReqErr{fmt.Errorf(format, a...)}
 }
 
+func TestNewCodedError(t *testing.T) {
+	err := NewCodedError("SCH_INVALID_ENUM", "value must be one of the allowed options")
+	if err.Code != "SCH_INVALID_ENUM" {
+		t.Errorf("Code = %s, want SCH_INVALID_ENUM", err.Code)
+	}
+	if err.Message != "value must be one of the allowed options" {
+		t.Errorf("Message = %s, want %s", err.Message, "value must be one of the allowed options")
+	}
+	if err.Details != nil {
+		t.Errorf("Details = %+v, want nil", err.Details)
+	}
+}
+
 func TestError_Error(t *testing.T) {
 	err := &Error{
 		Code:    "404",
@@ -116,6 +129,49 @@ func TestSchemaValidationErr_BecknError_MixedPaths(t *testing.T) {
 	expectedMsg := "m1; m2; m3"
 	if beErr.Message != expectedMsg {
 		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []Error
+		want string
+	}{
+		{
+			name: "first entry's code wins over a later different code",
+			errs: []Error{
+				{Code: "SCH_REQUIRED_FIELD_MISSING", Message: "m1"},
+				{Code: "SCH_INVALID_ENUM", Message: "m2"},
+			},
+			want: "SCH_REQUIRED_FIELD_MISSING",
+		},
+		{
+			name: "leading entries with no code are skipped",
+			errs: []Error{
+				{Message: "m1"},
+				{Code: "SCH_INVALID_ENUM", Message: "m2"},
+			},
+			want: "SCH_INVALID_ENUM",
+		},
+		{
+			name: "no entry has a code falls back to the legacy default",
+			errs: []Error{
+				{Message: "m1"},
+				{Message: "m2"},
+			},
+			want: "Bad Request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaErr := &SchemaValidationErr{Errors: tt.errs}
+			beErr := schemaErr.BecknError()
+			if beErr.Code != tt.want {
+				t.Errorf("Code = %s, want %s", beErr.Code, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -13,7 +13,7 @@ import (
 
 // NewSignValidationErrf creates a new SignValidationErr with a formatted error message.
 func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
-	return &SignValidationErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}
+	return &SignValidationErr{codedErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}}
 }
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
@@ -23,7 +23,7 @@ func NewNotFoundErrf(format string, a ...any) *NotFoundErr {
 
 // NewBadReqErrf creates a new BadReqErr with a formatted error message.
 func NewBadReqErrf(format string, a ...any) *BadReqErr {
-	return &BadReqErr{fmt.Errorf(format, a...)}
+	return &BadReqErr{codedErr{error: fmt.Errorf(format, a...)}}
 }
 
 func TestNewCodedError(t *testing.T) {
@@ -175,6 +175,41 @@ func TestSchemaValidationErr_BecknError_CodeFromFirstNonEmpty(t *testing.T) {
 	}
 }
 
+func TestFirstNonEmptyCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		errs        []Error
+		defaultCode string
+		want        string
+	}{
+		{
+			name:        "first non-empty code wins",
+			errs:        []Error{{Message: "m1"}, {Code: "POL_KYC_REQUIRED", Message: "m2"}, {Code: "POL_GEO_RESTRICTED", Message: "m3"}},
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_KYC_REQUIRED",
+		},
+		{
+			name:        "no entry has a code falls back to default",
+			errs:        []Error{{Message: "m1"}, {Message: "m2"}},
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_GENERIC_ERROR",
+		},
+		{
+			name:        "empty slice falls back to default",
+			errs:        nil,
+			defaultCode: "POL_GENERIC_ERROR",
+			want:        "POL_GENERIC_ERROR",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FirstNonEmptyCode(tt.errs, tt.defaultCode); got != tt.want {
+				t.Errorf("FirstNonEmptyCode() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSignValidationErr_BecknError(t *testing.T) {
 	signErr := NewSignValidationErr(errors.New("signature failed"))
 	beErr := signErr.BecknError()
@@ -203,7 +238,7 @@ func TestNewCodedSignValidationErr_BecknError(t *testing.T) {
 }
 
 func TestSignValidationErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
-	signErr := &SignValidationErr{error: errors.New("signature failed")}
+	signErr := &SignValidationErr{codedErr{error: errors.New("signature failed")}}
 	beErr := signErr.BecknError()
 
 	if beErr.Code != "AUT_SIGNATURE_INVALID" {
@@ -226,6 +261,26 @@ func TestSignValidationErr_Unwrap(t *testing.T) {
 	}
 	if target.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
 		t.Errorf("target.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", target.Code)
+	}
+}
+
+func TestResolveCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		defaultCode string
+		want        string
+	}{
+		{"explicit code wins", "AUT_KEY_EXPIRED_OR_REVOKED", "AUT_SIGNATURE_INVALID", "AUT_KEY_EXPIRED_OR_REVOKED"},
+		{"empty code falls back to default", "", "Bad Request", "Bad Request"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &codedErr{Code: tt.code}
+			if got := e.resolveCode(tt.defaultCode); got != tt.want {
+				t.Errorf("resolveCode(%q, %q) = %s, want %s", tt.code, tt.defaultCode, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -256,6 +311,40 @@ func TestBadReqErr_BecknError(t *testing.T) {
 	if beErr.Message != expectedMsg {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
+	}
+	if beErr.Code != "Bad Request" {
+		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default unchanged for NewBadReqErr callers", beErr.Code)
+	}
+}
+
+func TestNewCodedBadReqErr_BecknError(t *testing.T) {
+	badReqErr := NewCodedBadReqErr("POL_GEO_RESTRICTED", errors.New("delivery not offered in this region"))
+	beErr := badReqErr.BecknError()
+
+	if beErr.Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("beErr.Code = %s, want POL_GEO_RESTRICTED", beErr.Code)
+	}
+	expectedMsg := "BAD Request: delivery not offered in this region"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestBadReqErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
+	badReqErr := &BadReqErr{codedErr{error: errors.New("invalid input")}}
+	beErr := badReqErr.BecknError()
+
+	if beErr.Code != "Bad Request" {
+		t.Errorf("beErr.Code = %s, want the legacy \"Bad Request\" default when Code is unset", beErr.Code)
+	}
+}
+
+func TestBadReqErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	badReqErr := NewCodedBadReqErr("POL_GENERIC_ERROR", sentinel)
+
+	if !errors.Is(badReqErr, sentinel) {
+		t.Errorf("errors.Is(badReqErr, sentinel) = false, want true via Unwrap()")
 	}
 }
 

--- a/pkg/model/error_test.go
+++ b/pkg/model/error_test.go
@@ -13,7 +13,7 @@ import (
 
 // NewSignValidationErrf creates a new SignValidationErr with a formatted error message.
 func NewSignValidationErrf(format string, a ...any) *SignValidationErr {
-	return &SignValidationErr{fmt.Errorf(format, a...)}
+	return &SignValidationErr{Code: defaultSignValidationCode, error: fmt.Errorf(format, a...)}
 }
 
 // NewNotFoundErrf creates a new NotFoundErr with a formatted error message.
@@ -184,7 +184,49 @@ func TestSignValidationErr_BecknError(t *testing.T) {
 		t.Errorf("err.Error() = %s, want %s",
 			beErr.Message, expectedMsg)
 	}
+	if beErr.Code != "AUT_SIGNATURE_INVALID" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_INVALID (default classification)", beErr.Code)
+	}
+}
 
+func TestNewCodedSignValidationErr_BecknError(t *testing.T) {
+	signErr := NewCodedSignValidationErr("AUT_SIGNATURE_MISSING", errors.New("signature missing in header"))
+	beErr := signErr.BecknError()
+
+	if beErr.Code != "AUT_SIGNATURE_MISSING" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_MISSING", beErr.Code)
+	}
+	expectedMsg := "Signature Validation Error: signature missing in header"
+	if beErr.Message != expectedMsg {
+		t.Errorf("beErr.Message = %s, want %s", beErr.Message, expectedMsg)
+	}
+}
+
+func TestSignValidationErr_BecknError_EmptyCodeFallsBackToDefault(t *testing.T) {
+	signErr := &SignValidationErr{error: errors.New("signature failed")}
+	beErr := signErr.BecknError()
+
+	if beErr.Code != "AUT_SIGNATURE_INVALID" {
+		t.Errorf("beErr.Code = %s, want AUT_SIGNATURE_INVALID when Code is unset", beErr.Code)
+	}
+}
+
+func TestSignValidationErr_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel cause")
+	signErr := NewCodedSignValidationErr("AUT_SUBSCRIBER_NOT_FOUND", sentinel)
+
+	if !errors.Is(signErr, sentinel) {
+		t.Errorf("errors.Is(signErr, sentinel) = false, want true via Unwrap()")
+	}
+
+	var target *SignValidationErr
+	wrapped := fmt.Errorf("wrapped: %w", signErr)
+	if !errors.As(wrapped, &target) {
+		t.Fatalf("errors.As(wrapped, &target) = false, want true")
+	}
+	if target.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("target.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", target.Code)
+	}
 }
 
 func TestNewSignValidationErrf(t *testing.T) {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -3,7 +3,6 @@ package model
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -214,34 +213,29 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // an object) so callers can reuse the same Code/Message regardless of how
 // each formats its own response (e.g. wrapping in NewCodedBadReqErr, or
 // writing a bare JSON body directly). req and reqContext are nil on failure.
-// cause is the underlying json.Unmarshal error for the SCH_INVALID_JSON case
-// (nil otherwise, since the missing-context case has no wrapped cause of its
-// own) — callers that want errors.Is/errors.As to keep reaching it (e.g. via
-// fmt.Errorf("...: %w", cause)) can use it directly instead of losing that
-// chain through becknErr's already-flattened Message string.
-func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error, cause error) {
+// becknErr wraps the underlying json.Unmarshal error for the SCH_INVALID_JSON
+// case (via Error.Unwrap; nil for the missing-context case, which has no
+// cause of its own) — callers that want errors.Is/errors.As to keep reaching
+// it can call errors.As/errors.Is on becknErr directly.
+func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error) {
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, nil, NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err)), err
+		return nil, nil, NewCodedErrorWithCause("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err), "", err)
 	}
 	reqContext, ok := req["context"].(map[string]interface{})
 	if !ok {
-		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid"), nil
+		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid")
 	}
-	return req, reqContext, nil, nil
+	return req, reqContext, nil
 }
 
-// WrapExtractContextErr converts an ExtractContext failure (becknErr, cause)
-// into a *BadReqErr carrying becknErr's Code, for callers that need an error
-// value rather than the bare *Error ExtractContext returns. When cause is
-// non-nil (the SCH_INVALID_JSON case), it's wrapped with prefix via %w so
-// errors.Is/errors.As still reach it; the SCH_REQUIRED_FIELD_MISSING case has
-// no cause of its own, so becknErr.Message is used directly. Only call this
-// when becknErr is non-nil.
-func WrapExtractContextErr(prefix string, becknErr *Error, cause error) *BadReqErr {
-	if cause != nil {
-		return NewCodedBadReqErr(becknErr.Code, fmt.Errorf("%s: %w", prefix, cause))
-	}
-	return NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
+// WrapExtractContextErr converts an ExtractContext failure into a *BadReqErr
+// carrying becknErr's Code, for callers that need an error value rather than
+// the bare *Error ExtractContext returns. becknErr is wrapped with prefix via
+// %w, so errors.Is/errors.As still reach any cause set on it (via
+// Error.Unwrap) as well as becknErr itself. Only call this when becknErr is
+// non-nil.
+func WrapExtractContextErr(prefix string, becknErr *Error) *BadReqErr {
+	return NewCodedBadReqErr(becknErr.Code, fmt.Errorf("%s: %w", prefix, becknErr))
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -33,6 +33,26 @@ type Subscription struct {
 	NetworkMemberships []string  `json:"network_memberships,omitempty"`
 }
 
+// nonUsableKeySubscriptionStatuses are the Subscription.Status values that mean a
+// matched subscriber's key is no longer usable for signature verification.
+// INITIATED and UNDER_SUBSCRIPTION are intentionally absent — this function
+// distinguishes revocation/expiry from good standing only; it does not gate on
+// subscription completeness. A subscriber that has registered a key but not yet
+// finished onboarding is still treated as usable here. If pre-subscription
+// participants should be rejected too, that is a separate authorization
+// decision for a caller (or a future ticket) to make, not part of this check.
+var nonUsableKeySubscriptionStatuses = map[string]bool{
+	"EXPIRED":      true,
+	"UNSUBSCRIBED": true,
+	"INVALID_SSL":  true,
+}
+
+// IsKeyStatusUsable reports whether a subscriber's registry Status still
+// permits its key to be used for signature verification.
+func IsKeyStatusUsable(status string) bool {
+	return !nonUsableKeySubscriptionStatuses[status]
+}
+
 // RegistryMetadata represents metadata configured on a registry itself rather than on a specific record.
 type RegistryMetadata struct {
 	NamespaceIdentifier string
@@ -45,8 +65,8 @@ type RegistryMetadata struct {
 // node-level manifest metadata (from the registry meta block) in a single response,
 // since both come from the same DeDi endpoint call.
 type SubscriberRecord struct {
-	Subscription        // identity, URL, signing/encryption keys — from data["details"]
-	Meta map[string]string // node manifest metadata — from data["meta"]; may be empty
+	Subscription                   // identity, URL, signing/encryption keys — from data["details"]
+	Meta         map[string]string // node manifest metadata — from data["meta"]; may be empty
 }
 
 // Authorization-related constants for headers.

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -227,6 +228,20 @@ func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[str
 		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid"), nil
 	}
 	return req, reqContext, nil, nil
+}
+
+// WrapExtractContextErr converts an ExtractContext failure (becknErr, cause)
+// into a *BadReqErr carrying becknErr's Code, for callers that need an error
+// value rather than the bare *Error ExtractContext returns. When cause is
+// non-nil (the SCH_INVALID_JSON case), it's wrapped with prefix via %w so
+// errors.Is/errors.As still reach it; the SCH_REQUIRED_FIELD_MISSING case has
+// no cause of its own, so becknErr.Message is used directly. Only call this
+// when becknErr is non-nil.
+func WrapExtractContextErr(prefix string, becknErr *Error, cause error) *BadReqErr {
+	if cause != nil {
+		return NewCodedBadReqErr(becknErr.Code, fmt.Errorf("%s: %w", prefix, cause))
+	}
+	return NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -203,6 +204,29 @@ func (r *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	*r = role
 	return nil
+}
+
+// ExtractContext decodes body as JSON and returns both the full decoded body
+// and its "context" field as a map[string]interface{}, classifying the
+// failure onto the Beckn v2.0.0 ErrorCode taxonomy (SCH_INVALID_JSON if body
+// isn't valid JSON, SCH_REQUIRED_FIELD_MISSING if "context" is missing or not
+// an object) so callers can reuse the same Code/Message regardless of how
+// each formats its own response (e.g. wrapping in NewCodedBadReqErr, or
+// writing a bare JSON body directly). req and reqContext are nil on failure.
+// cause is the underlying json.Unmarshal error for the SCH_INVALID_JSON case
+// (nil otherwise, since the missing-context case has no wrapped cause of its
+// own) — callers that want errors.Is/errors.As to keep reaching it (e.g. via
+// fmt.Errorf("...: %w", cause)) can use it directly instead of losing that
+// chain through becknErr's already-flattened Message string.
+func ExtractContext(body []byte) (req map[string]interface{}, reqContext map[string]interface{}, becknErr *Error, cause error) {
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, nil, NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to decode request body: %v", err)), err
+	}
+	reqContext, ok := req["context"].(map[string]interface{})
+	if !ok {
+		return nil, nil, NewCodedError("SCH_REQUIRED_FIELD_MISSING", "context field not found or invalid"), nil
+	}
+	return req, reqContext, nil, nil
 }
 
 // ResolveNetworkID returns context.network_id from a parsed Beckn context map,

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -215,3 +215,60 @@ func TestResolveNetworkID(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractContext(t *testing.T) {
+	t.Run("malformed json", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte("{"))
+		if becknErr == nil {
+			t.Fatal("expected an error for malformed JSON, got nil")
+		}
+		if becknErr.Code != "SCH_INVALID_JSON" {
+			t.Errorf("Code = %s, want SCH_INVALID_JSON", becknErr.Code)
+		}
+		if cause == nil {
+			t.Error("expected a non-nil cause for a JSON decode failure, so callers can still errors.Is/errors.As through it")
+		}
+	})
+
+	t.Run("missing context", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
+		if becknErr == nil {
+			t.Fatal("expected an error for missing context, got nil")
+		}
+		if becknErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", becknErr.Code)
+		}
+		if becknErr.Message != "context field not found or invalid" {
+			t.Errorf("Message = %q, want %q", becknErr.Message, "context field not found or invalid")
+		}
+		if cause != nil {
+			t.Errorf("expected a nil cause for a missing-context failure (no wrapped error of its own), got %v", cause)
+		}
+	})
+
+	t.Run("context is not an object", func(t *testing.T) {
+		_, _, becknErr, _ := ExtractContext([]byte(`{"context":"not-a-map"}`))
+		if becknErr == nil {
+			t.Fatal("expected an error for non-object context, got nil")
+		}
+		if becknErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", becknErr.Code)
+		}
+	})
+
+	t.Run("valid body returns both the full body and its context", func(t *testing.T) {
+		req, reqContext, becknErr, cause := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
+		if becknErr != nil {
+			t.Fatalf("unexpected error: %+v", becknErr)
+		}
+		if cause != nil {
+			t.Errorf("expected a nil cause on success, got %v", cause)
+		}
+		if req["message"] == nil {
+			t.Errorf("expected req to include the full decoded body, got %+v", req)
+		}
+		if reqContext["bap_id"] != "bap-123" {
+			t.Errorf("reqContext[\"bap_id\"] = %v, want bap-123", reqContext["bap_id"])
+		}
+	})
+}

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -2,6 +2,29 @@ package model
 
 import "testing"
 
+func TestIsKeyStatusUsable(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{status: "SUBSCRIBED", want: true},
+		{status: "INITIATED", want: true},
+		{status: "UNDER_SUBSCRIPTION", want: true},
+		{status: "", want: true},
+		{status: "EXPIRED", want: false},
+		{status: "UNSUBSCRIBED", want: false},
+		{status: "INVALID_SSL", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := IsKeyStatusUsable(tt.status); got != tt.want {
+				t.Errorf("IsKeyStatusUsable(%q) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveCallerID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,6 +1,11 @@
 package model
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestIsKeyStatusUsable(t *testing.T) {
 	tests := []struct {
@@ -269,6 +274,36 @@ func TestExtractContext(t *testing.T) {
 		}
 		if reqContext["bap_id"] != "bap-123" {
 			t.Errorf("reqContext[\"bap_id\"] = %v, want bap-123", reqContext["bap_id"])
+		}
+	})
+}
+
+func TestWrapExtractContextErr(t *testing.T) {
+	t.Run("with cause, wraps prefix and preserves errors.As reachability", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte("{"))
+		err := WrapExtractContextErr("error parsing request body", becknErr, cause)
+
+		if err.Code != "SCH_INVALID_JSON" {
+			t.Errorf("Code = %s, want SCH_INVALID_JSON", err.Code)
+		}
+		if !strings.Contains(err.Error(), "error parsing request body") {
+			t.Errorf("Error() = %q, want it to contain the given prefix", err.Error())
+		}
+		var syntaxErr *json.SyntaxError
+		if !errors.As(err, &syntaxErr) {
+			t.Error("expected errors.As to reach the underlying *json.SyntaxError")
+		}
+	})
+
+	t.Run("without cause, uses becknErr.Message directly", func(t *testing.T) {
+		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
+		err := WrapExtractContextErr("unused prefix", becknErr, cause)
+
+		if err.Code != "SCH_REQUIRED_FIELD_MISSING" {
+			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", err.Code)
+		}
+		if !strings.Contains(err.Error(), "context field not found or invalid") {
+			t.Errorf("Error() = %q, want it to contain becknErr.Message", err.Error())
 		}
 	})
 }

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -223,20 +223,21 @@ func TestResolveNetworkID(t *testing.T) {
 
 func TestExtractContext(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
-		_, _, becknErr, cause := ExtractContext([]byte("{"))
+		_, _, becknErr := ExtractContext([]byte("{"))
 		if becknErr == nil {
 			t.Fatal("expected an error for malformed JSON, got nil")
 		}
 		if becknErr.Code != "SCH_INVALID_JSON" {
 			t.Errorf("Code = %s, want SCH_INVALID_JSON", becknErr.Code)
 		}
-		if cause == nil {
-			t.Error("expected a non-nil cause for a JSON decode failure, so callers can still errors.Is/errors.As through it")
+		var syntaxErr *json.SyntaxError
+		if !errors.As(becknErr, &syntaxErr) {
+			t.Error("expected errors.As on becknErr to reach the underlying *json.SyntaxError via Unwrap")
 		}
 	})
 
 	t.Run("missing context", func(t *testing.T) {
-		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
+		_, _, becknErr := ExtractContext([]byte(`{"message":{}}`))
 		if becknErr == nil {
 			t.Fatal("expected an error for missing context, got nil")
 		}
@@ -246,13 +247,13 @@ func TestExtractContext(t *testing.T) {
 		if becknErr.Message != "context field not found or invalid" {
 			t.Errorf("Message = %q, want %q", becknErr.Message, "context field not found or invalid")
 		}
-		if cause != nil {
-			t.Errorf("expected a nil cause for a missing-context failure (no wrapped error of its own), got %v", cause)
+		if becknErr.Unwrap() != nil {
+			t.Errorf("expected a nil Unwrap() for a missing-context failure (no wrapped error of its own), got %v", becknErr.Unwrap())
 		}
 	})
 
 	t.Run("context is not an object", func(t *testing.T) {
-		_, _, becknErr, _ := ExtractContext([]byte(`{"context":"not-a-map"}`))
+		_, _, becknErr := ExtractContext([]byte(`{"context":"not-a-map"}`))
 		if becknErr == nil {
 			t.Fatal("expected an error for non-object context, got nil")
 		}
@@ -262,12 +263,9 @@ func TestExtractContext(t *testing.T) {
 	})
 
 	t.Run("valid body returns both the full body and its context", func(t *testing.T) {
-		req, reqContext, becknErr, cause := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
+		req, reqContext, becknErr := ExtractContext([]byte(`{"context":{"bap_id":"bap-123"},"message":{"key":"value"}}`))
 		if becknErr != nil {
 			t.Fatalf("unexpected error: %+v", becknErr)
-		}
-		if cause != nil {
-			t.Errorf("expected a nil cause on success, got %v", cause)
 		}
 		if req["message"] == nil {
 			t.Errorf("expected req to include the full decoded body, got %+v", req)
@@ -280,8 +278,8 @@ func TestExtractContext(t *testing.T) {
 
 func TestWrapExtractContextErr(t *testing.T) {
 	t.Run("with cause, wraps prefix and preserves errors.As reachability", func(t *testing.T) {
-		_, _, becknErr, cause := ExtractContext([]byte("{"))
-		err := WrapExtractContextErr("error parsing request body", becknErr, cause)
+		_, _, becknErr := ExtractContext([]byte("{"))
+		err := WrapExtractContextErr("error parsing request body", becknErr)
 
 		if err.Code != "SCH_INVALID_JSON" {
 			t.Errorf("Code = %s, want SCH_INVALID_JSON", err.Code)
@@ -296,8 +294,8 @@ func TestWrapExtractContextErr(t *testing.T) {
 	})
 
 	t.Run("without cause, uses becknErr.Message directly", func(t *testing.T) {
-		_, _, becknErr, cause := ExtractContext([]byte(`{"message":{}}`))
-		err := WrapExtractContextErr("unused prefix", becknErr, cause)
+		_, _, becknErr := ExtractContext([]byte(`{"message":{}}`))
+		err := WrapExtractContextErr("unused prefix", becknErr)
 
 		if err.Code != "SCH_REQUIRED_FIELD_MISSING" {
 			t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", err.Code)

--- a/pkg/plugin/implementation/decrypter/decrypter.go
+++ b/pkg/plugin/implementation/decrypter/decrypter.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/ecdh"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/zenazn/pkcs7pad"
@@ -26,18 +27,18 @@ func New(ctx context.Context) (*decrypter, func() error, error) {
 func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Decode the Base64 encoded encrypted data.
 	messageByte, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("failed to decode encrypted data: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to decode encrypted data: %w", err))
 	}
 
 	aesCipher, err := createAESCipher(privateKeyBytes, publicKeyBytes)
@@ -47,7 +48,7 @@ func (d *decrypter) Decrypt(ctx context.Context, encryptedData, privateKeyBase64
 
 	blocksize := aesCipher.BlockSize()
 	if len(messageByte)%blocksize != 0 {
-		return "", fmt.Errorf("ciphertext is not a multiple of the blocksize")
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", errors.New("ciphertext is not a multiple of the blocksize"))
 	}
 
 	for i := 0; i < len(messageByte); i += aesCipher.BlockSize() {
@@ -67,11 +68,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create private key: %w", err)
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create public key: %w", err)
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/decrypter/decrypter_test.go
+++ b/pkg/plugin/implementation/decrypter/decrypter_test.go
@@ -6,10 +6,13 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/zenazn/pkcs7pad"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Helper function to generate valid test keys.
@@ -131,6 +134,8 @@ func TestDecrypterFailure(t *testing.T) {
 		privateKey    string
 		publicKey     string
 		expectedErr   string
+		// wantCode is checked via requireBadReqCode when non-empty.
+		wantCode string
 	}{
 		{
 			name:          "Invalid private key format",
@@ -138,6 +143,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "invalid-base64!@#$",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid public key format",
@@ -145,6 +151,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "invalid-base64!@#$",
 			expectedErr:   "invalid public key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid encrypted data format",
@@ -152,6 +159,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to decode encrypted data",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Empty private key",
@@ -159,6 +167,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    "",
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "invalid private key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Empty public key",
@@ -166,6 +175,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     "",
 			expectedErr:   "invalid public key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid base64 data",
@@ -173,6 +183,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to decode encrypted data",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid private key size",
@@ -180,6 +191,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    base64.StdEncoding.EncodeToString([]byte("short")),
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "failed to create private key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid public key size",
@@ -187,6 +199,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     base64.StdEncoding.EncodeToString([]byte("short")),
 			expectedErr:   "failed to create public key",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 		{
 			name:          "Invalid block size",
@@ -194,6 +207,7 @@ func TestDecrypterFailure(t *testing.T) {
 			privateKey:    receiverPrivateKeyB64,
 			publicKey:     senderPublicKeyB64,
 			expectedErr:   "ciphertext is not a multiple of the blocksize",
+			wantCode:      "AUT_SIGNATURE_INVALID",
 		},
 	}
 
@@ -214,7 +228,29 @@ func TestDecrypterFailure(t *testing.T) {
 					t.Errorf("Expected error containing %q, got %q", tt.expectedErr, err.Error())
 				}
 			}
+			if tt.wantCode != "" {
+				requireBadReqCode(t, err, tt.wantCode)
+			}
 		})
+	}
+}
+
+// requireBadReqCode asserts err unwraps (via errors.As, matching how
+// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
+// wantCode. createAESCipher's callers re-wrap its errors in an outer
+// fmt.Errorf, so a raw type assertion would miss a coded error returned from
+// there even though production code (nackBecknError) finds it fine via
+// errors.As — mirrors encrypter_test.go's helper of the same name, which
+// needed this for the identical reason.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	var badReqErr *model.BadReqErr
+	if !errors.As(err, &badReqErr) {
+		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/decrypter/decrypter_test.go
+++ b/pkg/plugin/implementation/decrypter/decrypter_test.go
@@ -6,13 +6,12 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/zenazn/pkcs7pad"
 
-	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/testutil"
 )
 
 // Helper function to generate valid test keys.
@@ -134,7 +133,7 @@ func TestDecrypterFailure(t *testing.T) {
 		privateKey    string
 		publicKey     string
 		expectedErr   string
-		// wantCode is checked via requireBadReqCode when non-empty.
+		// wantCode is checked via testutil.RequireBadReqCode when non-empty.
 		wantCode string
 	}{
 		{
@@ -229,28 +228,9 @@ func TestDecrypterFailure(t *testing.T) {
 				}
 			}
 			if tt.wantCode != "" {
-				requireBadReqCode(t, err, tt.wantCode)
+				testutil.RequireBadReqCode(t, err, tt.wantCode)
 			}
 		})
-	}
-}
-
-// requireBadReqCode asserts err unwraps (via errors.As, matching how
-// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
-// wantCode. createAESCipher's callers re-wrap its errors in an outer
-// fmt.Errorf, so a raw type assertion would miss a coded error returned from
-// there even though production code (nackBecknError) finds it fine via
-// errors.As — mirrors encrypter_test.go's helper of the same name, which
-// needed this for the identical reason.
-func requireBadReqCode(t *testing.T, err error, wantCode string) {
-	t.Helper()
-
-	var badReqErr *model.BadReqErr
-	if !errors.As(err, &badReqErr) {
-		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
-	}
-	if code := badReqErr.BecknError().Code; code != wantCode {
-		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/encrypter/encrypter.go
+++ b/pkg/plugin/implementation/encrypter/encrypter.go
@@ -24,12 +24,12 @@ func New(ctx context.Context) (*encrypter, func() error, error) {
 func (e *encrypter) Encrypt(ctx context.Context, data string, privateKeyBase64, publicKeyBase64 string) (string, error) {
 	privateKeyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid private key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid private key: %w", err))
 	}
 
 	publicKeyBytes, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return "", model.NewBadReqErr(fmt.Errorf("invalid public key: %w", err))
+		return "", model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("invalid public key: %w", err))
 	}
 
 	// Convert the input string to a byte slice.
@@ -51,11 +51,11 @@ func createAESCipher(privateKey, publicKey []byte) (cipher.Block, error) {
 	x25519Curve := ecdh.X25519()
 	x25519PrivateKey, err := x25519Curve.NewPrivateKey(privateKey)
 	if err != nil {
-		return nil, model.NewBadReqErr(fmt.Errorf("failed to create private key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create private key: %w", err))
 	}
 	x25519PublicKey, err := x25519Curve.NewPublicKey(publicKey)
 	if err != nil {
-		return nil, model.NewBadReqErr(fmt.Errorf("failed to create public key: %w", err))
+		return nil, model.NewCodedBadReqErr("AUT_SIGNATURE_INVALID", fmt.Errorf("failed to create public key: %w", err))
 	}
 	sharedSecret, err := x25519PrivateKey.ECDH(x25519PublicKey)
 	if err != nil {

--- a/pkg/plugin/implementation/encrypter/encrypter_test.go
+++ b/pkg/plugin/implementation/encrypter/encrypter_test.go
@@ -5,11 +5,10 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"strings"
 	"testing"
 
-	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/testutil"
 )
 
 // Helper function to generate a test X25519 key pair.
@@ -164,26 +163,8 @@ func TestEncryptFailure(t *testing.T) {
 			// undecodable signature/key material: verification-relevant key
 			// material is inherently an AUT_* concern even when the proximate
 			// cause is bad encoding, not a request-schema problem.
-			requireBadReqCode(t, err, "AUT_SIGNATURE_INVALID")
+			testutil.RequireBadReqCode(t, err, "AUT_SIGNATURE_INVALID")
 		})
-	}
-}
-
-// requireBadReqCode asserts err unwraps (via errors.As, matching how
-// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
-// wantCode. createAESCipher's callers re-wrap its errors in an outer
-// fmt.Errorf, so a raw type assertion would miss the coded error even though
-// production code (core/module/handler/responsestep.go's nackBecknError)
-// finds it fine via errors.As.
-func requireBadReqCode(t *testing.T, err error, wantCode string) {
-	t.Helper()
-
-	var badReqErr *model.BadReqErr
-	if !errors.As(err, &badReqErr) {
-		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
-	}
-	if code := badReqErr.BecknError().Code; code != wantCode {
-		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/encrypter/encrypter_test.go
+++ b/pkg/plugin/implementation/encrypter/encrypter_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Helper function to generate a test X25519 key pair.
@@ -156,7 +159,31 @@ func TestEncryptFailure(t *testing.T) {
 			if err != nil && !strings.Contains(err.Error(), tt.errorContains) {
 				t.Errorf("Encrypt() error = %v, want error containing %q", err, tt.errorContains)
 			}
+			// All malformed-key-material failures above are classified as
+			// AUT_SIGNATURE_INVALID, matching signvalidator.go's precedent for
+			// undecodable signature/key material: verification-relevant key
+			// material is inherently an AUT_* concern even when the proximate
+			// cause is bad encoding, not a request-schema problem.
+			requireBadReqCode(t, err, "AUT_SIGNATURE_INVALID")
 		})
+	}
+}
+
+// requireBadReqCode asserts err unwraps (via errors.As, matching how
+// nackBecknError itself classifies errors) to a *model.BadReqErr carrying
+// wantCode. createAESCipher's callers re-wrap its errors in an outer
+// fmt.Errorf, so a raw type assertion would miss the coded error even though
+// production code (core/module/handler/responsestep.go's nackBecknError)
+// finds it fine via errors.As.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	var badReqErr *model.BadReqErr
+	if !errors.As(err, &badReqErr) {
+		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -50,6 +50,19 @@ var (
 
 	// ErrNilRegistryLookup indicates that the registry lookup implementation is nil.
 	ErrNilRegistryLookup = errors.New("registry lookup implementation cannot be nil")
+
+	// ErrKeyExpiredOrRevoked indicates that the matched subscriber's key exists but
+	// is no longer usable (registry status EXPIRED, UNSUBSCRIBED, or INVALID_SSL).
+	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
+)
+
+// AUT_* codes reachable from LookupNPKeys.
+const (
+	// codeSubscriberNotFound is used when the registry lookup returns zero results.
+	codeSubscriberNotFound = "AUT_SUBSCRIBER_NOT_FOUND"
+	// codeKeyExpiredOrRevoked is used when a matched subscriber's key is no
+	// longer usable per model.IsKeyStatusUsable.
+	codeKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
 )
 
 // ValidateCfg validates the Vault configuration and sets default KV version if missing.
@@ -275,6 +288,12 @@ func (km *KeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyset, erro
 }
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
+//
+// A zero-result lookup and a matched-but-unusable-status subscriber are both
+// AUT_* authentication failures, so both are returned already classified as
+// *model.SignValidationErr — the caller (signvalidator's validateSignStep)
+// propagates this as-is; it does not need to know keymanager's own sentinel
+// errors to build the correct NACK code.
 func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
 	subscribers, err := km.Registry.Lookup(ctx, &model.Subscription{
 		Subscriber: model.Subscriber{
@@ -286,7 +305,10 @@ func (km *KeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID st
 		return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 	}
 	if len(subscribers) == 0 {
-		return "", "", ErrSubscriberNotFound
+		return "", "", model.NewCodedSignValidationErr(codeSubscriberNotFound, ErrSubscriberNotFound)
+	}
+	if !model.IsKeyStatusUsable(subscribers[0].Status) {
+		return "", "", model.NewCodedSignValidationErr(codeKeyExpiredOrRevoked, ErrKeyExpiredOrRevoked)
 	}
 	return subscribers[0].SigningPublicKey, subscribers[0].EncrPublicKey, nil
 }

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -50,7 +50,6 @@ func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]m
 	}, nil
 }
 
-
 func TestValidateCfgSuccess(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -971,9 +970,9 @@ func TestLookupNPKeysSuccess(t *testing.T) {
 						Subscriber: model.Subscriber{
 							SubscriberID: sub.SubscriberID,
 						},
-						KeyID:           sub.KeyID,
+						KeyID:            sub.KeyID,
 						SigningPublicKey: "mock-signing-public-key",
-						EncrPublicKey:   "mock-encryption-public-key",
+						EncrPublicKey:    "mock-encryption-public-key",
 					},
 				}, nil
 			},
@@ -1009,6 +1008,8 @@ func TestLookupNPKeysFailure(t *testing.T) {
 		name               string
 		registryLookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
 		expectedError      string
+		wantCode           string
+		wantSentinel       error
 	}{
 		{
 			name: "registry failure",
@@ -1023,6 +1024,35 @@ func TestLookupNPKeysFailure(t *testing.T) {
 				return nil, nil
 			},
 			expectedError: "no subscriber found with given credentials",
+			wantCode:      "AUT_SUBSCRIBER_NOT_FOUND",
+			wantSentinel:  ErrSubscriberNotFound,
+		},
+		{
+			name: "subscriber found but key EXPIRED",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "EXPIRED"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
+		},
+		{
+			name: "subscriber found but UNSUBSCRIBED",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "UNSUBSCRIBED"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
+		},
+		{
+			name: "subscriber found but INVALID_SSL",
+			registryLookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return []model.Subscription{{Status: "INVALID_SSL"}}, nil
+			},
+			expectedError: "subscriber key is expired or revoked",
+			wantCode:      "AUT_KEY_EXPIRED_OR_REVOKED",
+			wantSentinel:  ErrKeyExpiredOrRevoked,
 		},
 	}
 
@@ -1039,6 +1069,18 @@ func TestLookupNPKeysFailure(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.expectedError) {
 				t.Errorf("expected error to contain %v, got %v", tt.expectedError, err.Error())
+			}
+			if tt.wantCode != "" {
+				var signErr *model.SignValidationErr
+				if !errors.As(err, &signErr) {
+					t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+				}
+				if signErr.Code != tt.wantCode {
+					t.Errorf("signErr.Code = %s, want %s", signErr.Code, tt.wantCode)
+				}
+				if !errors.Is(err, tt.wantSentinel) {
+					t.Errorf("expected errors.Is(err, %v) = true", tt.wantSentinel)
+				}
 			}
 		})
 	}

--- a/pkg/plugin/implementation/opapolicychecker/README.md
+++ b/pkg/plugin/implementation/opapolicychecker/README.md
@@ -194,11 +194,15 @@ networkPolicies:
 |---|---|
 | `{"valid": true, "violations": []}` | Allowed — recommended structured format |
 | `{"valid": false, "violations": ["msg1", "msg2"]}` | Rejected — violation messages returned to caller |
+| `{"valid": false, "violations": [{"code": "POL_...", "message": "..."}]}` | Rejected — each violation may optionally carry a Beckn v2.0.0 `POL_*` error code alongside its message, instead of a plain string. Coded and plain-string entries can be mixed in the same list; codes not provided fall back to `POL_GENERIC_ERROR` |
 | `set()` / `[]string` | Each string is a violation message |
+| `set()` of `{"code": "POL_...", "message": "..."}` objects | Same coded-violation shape as the structured format above — also supported directly under the simpler `set()`/direct-query style |
 | `bool` `true` | Allowed |
 | `bool` `false` | Rejected |
 | `string` (non-empty) | Rejected — the string is the violation message |
 | Empty / undefined | **Rejected** — fail-closed; indicates a misconfigured query path |
+
+A violation's `code`, when provided, should be one of the `POL_*` values in the Beckn v2.0.0 `ErrorCode` taxonomy (e.g. `POL_GEO_RESTRICTED`, `POL_KYC_REQUIRED`, `POL_ELIGIBILITY_NOT_MET`) — see `pkg/plugin/implementation/opapolicychecker/evaluator.go`'s `parseViolationItem` for the exact parsing rules.
 
 ---
 

--- a/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/benchmark_test.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // generateDummyRules creates a .rego policy file with N rules.
@@ -116,7 +118,7 @@ func BenchmarkEvaluate_MostlyInactive(b *testing.B) {
 			if err != nil {
 				b.Fatalf("correctness check failed: %v", err)
 			}
-			if len(violations) != 1 || violations[0] != "real_violation" {
+			if len(violations) != 1 || violations[0].Message != "real_violation" {
 				b.Fatalf("expected [real_violation], got %v", violations)
 			}
 
@@ -238,7 +240,7 @@ func TestBenchmarkReport(t *testing.T) {
 
 		ctx := context.Background()
 		durations := make([]time.Duration, iterations)
-		var lastViolations []string
+		var lastViolations []model.Error
 
 		for i := 0; i < iterations; i++ {
 			start := time.Now()
@@ -274,7 +276,7 @@ func TestBenchmarkReport(t *testing.T) {
 
 		ctx := context.Background()
 		durations := make([]time.Duration, iterations)
-		var lastViolations []string
+		var lastViolations []model.Error
 
 		for i := 0; i < iterations; i++ {
 			start := time.Now()

--- a/pkg/plugin/implementation/opapolicychecker/enforcer.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer.go
@@ -642,8 +642,14 @@ func (e *PolicyEnforcer) selectedPolicy(networkID string) *loadedPolicy {
 }
 
 // CheckPolicy evaluates the message body against loaded OPA policies.
-// Returns a BadReqErr (causing NACK) if violations are found.
-// Returns an error on evaluation failure (fail closed).
+// Returns a BadReqErr (causing NACK) for every failure mode — an
+// uninitialized evaluator, an evaluation failure, or actual violations —
+// each classified with a POL_* code. Violations use the first non-empty
+// per-violation code (falling back to POL_GENERIC_ERROR when the policy only
+// emits plain violation strings — see evaluator.go's parseViolationItem for
+// the structured/coded shape a Rego policy can opt into); the other two
+// failure modes always use POL_GENERIC_ERROR, since they're evaluation-layer
+// failures rather than a specific policy decision.
 func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	if !e.config.Enabled {
 		log.Debug(ctx, "OPAPolicyChecker: plugin disabled, skipping")
@@ -666,7 +672,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	// Disabled policies intentionally do not initialize an evaluator in loadPolicy.
 	ev := policy.evaluator
 	if ev == nil {
-		return model.NewBadReqErr(fmt.Errorf("policy evaluator is not initialized"))
+		return model.NewCodedBadReqErr("POL_GENERIC_ERROR", fmt.Errorf("policy evaluator is not initialized"))
 	}
 
 	if e.config.DebugLogging {
@@ -678,7 +684,7 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 	violations, err := ev.Evaluate(ctx, ctx.Body)
 	if err != nil {
 		log.Errorf(ctx, err, "OPAPolicyChecker: policy evaluation failed for networkID=%q%s: %v", reqCtx.NetworkID, requestLogCtx, err)
-		return model.NewBadReqErr(fmt.Errorf("policy evaluation error: %w", err))
+		return model.NewCodedBadReqErr("POL_GENERIC_ERROR", fmt.Errorf("policy evaluation error: %w", err))
 	}
 
 	if len(violations) == 0 {
@@ -688,9 +694,19 @@ func (e *PolicyEnforcer) CheckPolicy(ctx *model.StepContext) error {
 		return nil
 	}
 
-	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violations, "; "))
+	msg := fmt.Sprintf("policy violation(s): %s", strings.Join(violationMessages(violations), "; "))
 	log.Warnf(ctx, "OPAPolicyChecker: networkID=%q%s %s", reqCtx.NetworkID, requestLogCtx, msg)
-	return model.NewBadReqErr(fmt.Errorf("%s", msg))
+	code := model.FirstNonEmptyCode(violations, "POL_GENERIC_ERROR")
+	return model.NewCodedBadReqErr(code, fmt.Errorf("%s", msg))
+}
+
+// violationMessages extracts each violation's human-readable message, in order.
+func violationMessages(violations []model.Error) []string {
+	messages := make([]string, len(violations))
+	for i, v := range violations {
+		messages[i] = v.Message
+	}
+	return messages
 }
 
 func (e *PolicyEnforcer) Close() {

--- a/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
+++ b/pkg/plugin/implementation/opapolicychecker/enforcer_test.go
@@ -252,8 +252,241 @@ violations contains msg if {
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
 	}
-	if violations[0] != "value is negative" {
-		t.Errorf("unexpected violation: %q", violations[0])
+	if violations[0].Message != "value is negative" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
+	}
+}
+
+// TestEvaluator_BareSetResult_WithCodedViolations is a regression test for a
+// fail-open bug found in self-review: extractViolations' []interface{} case
+// (the bare-set query style used above in TestEvaluator_WithViolation, and
+// documented in README.md as a supported format) only accepted plain string
+// items, silently dropping a coded violation object entirely — meaning a
+// policy that denied via a coded violation under this query style would be
+// treated as compliant (violations == nil), and CheckPolicy would incorrectly
+// allow the request. This confirms the fix: coded violations now survive the
+// same code path as the structured {"valid",...} format.
+func TestEvaluator_BareSetResult_WithCodedViolations(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violations", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"context": {"action": "confirm"}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v — a coded violation under the bare-set query style must not be silently dropped", len(violations), violations)
+	}
+	if violations[0].Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("violations[0].Code = %q, want POL_GEO_RESTRICTED", violations[0].Code)
+	}
+	if violations[0].Message != "delivery not offered in this region" {
+		t.Errorf("violations[0].Message = %q, want %q", violations[0].Message, "delivery not offered in this region")
+	}
+}
+
+// TestEnforcer_BareSetResult_NonCompliant_PropagatesCode is the CheckPolicy
+// end-to-end counterpart: confirms a coded violation under the bare-set query
+// style correctly denies the request (not silently allows it) and the code
+// reaches the final NACK.
+func TestEnforcer_BareSetResult_NonCompliant_PropagatesCode(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a coded violation under the bare-set query style must not be silently allowed")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GEO_RESTRICTED" {
+		t.Errorf("BecknError().Code = %s, want POL_GEO_RESTRICTED", code)
+	}
+}
+
+// TestEvaluator_BareSetResult_UnparseableItem_FallsBackToGenericViolation is a
+// regression test for a fail-open bug found in self-review: once
+// parseViolationItem started dropping empty-string items (to correctly reject
+// malformed coded objects), a bare-set violation whose only item was an empty
+// string would parse to zero violations with no fallback — unlike the
+// structured {"valid",...} format, which falls back to a generic violation
+// when valid=false but the violations list is empty. This confirms the fix:
+// a non-empty set that yields zero parseable items still produces one
+// generic violation.
+func TestEvaluator_BareSetResult_UnparseableItem_FallsBackToGenericViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains msg if {
+    input.context.action == "confirm"
+    msg := ""
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violations", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"context": {"action": "confirm"}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 fallback violation, got %d: %v — a non-empty violations set must not be silently dropped just because its item didn't parse", len(violations), violations)
+	}
+	if violations[0].Message == "" {
+		t.Errorf("expected a non-empty fallback message, got empty")
+	}
+}
+
+// TestEnforcer_BareSetResult_UnparseableItem_StillDenies is the CheckPolicy
+// end-to-end counterpart: confirms a bare-set violation with an unparseable
+// item still denies the request (not silently allows it).
+func TestEnforcer_BareSetResult_UnparseableItem_StillDenies(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains msg if {
+    input.context.action == "confirm"
+    msg := ""
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a non-empty violations set must not be silently allowed just because its item didn't parse")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
+	}
+}
+
+// TestEvaluator_BareStringResult_WithViolation and
+// TestEvaluator_BareStringResult_EmptyStringIsCompliant cover extractViolations'
+// top-level `case string:` branch (a bare single-string Rego result, not a
+// set) — the branch commit 0c496d6 routed through parseViolationItem but that
+// left it with 0% test coverage, flagged in self-review.
+func TestEvaluator_BareStringResult_WithViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+deny_reason := "order value exceeds limit" if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.deny_reason", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Message != "order value exceeds limit" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
+	}
+}
+
+func TestEvaluator_BareStringResult_EmptyStringIsCompliant(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+deny_reason := "" if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.deny_reason", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected 0 violations for empty string result, got %v", violations)
+	}
+}
+
+// TestEvaluator_UnsupportedResultType_FallsBackToGenericViolation is a
+// regression test for a fail-open bug found in self-review: extractViolations'
+// type switch had no default case, so a query result of any type other than
+// the four documented shapes (bool, string, []interface{}, map[string]interface{})
+// — e.g. a bare number from a policy authoring mistake — matched nothing and
+// was silently dropped with zero violations. This confirms the fix: an
+// unrecognized result type now falls back to one generic violation instead of
+// being silently treated as compliant.
+func TestEvaluator_UnsupportedResultType_FallsBackToGenericViolation(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violation_count := 1 if {
+    input.value > 1000
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.policy.violation_count", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"value": 2000}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 || violations[0].Message != genericDenialMessage {
+		t.Errorf("expected 1 generic denial violation for an unsupported result type, got %v — a policy result of an unrecognized type must not be silently allowed", violations)
 	}
 }
 
@@ -457,7 +690,7 @@ violations contains "from_file" if { input.bad }
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "from_file" {
+	if len(violations) != 1 || violations[0].Message != "from_file" {
 		t.Errorf("expected [from_file], got %v", violations)
 	}
 }
@@ -497,7 +730,7 @@ violations contains "order too large" if { is_high_value }
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "order too large" {
+	if len(violations) != 1 || violations[0].Message != "order too large" {
 		t.Errorf("expected [order too large], got %v", violations)
 	}
 
@@ -672,8 +905,148 @@ violations contains "blocked" if { input.context.action == "confirm" }
 	}
 
 	// Should be a BadReqErr
-	if _, ok := err.(*model.BadReqErr); !ok {
-		t.Errorf("expected *model.BadReqErr, got %T: %v", err, err)
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+
+	// The Rego policy above only emits a plain violation string, so the
+	// aggregate code falls back to the generic bucket.
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR for an unclassified plain-string violation", code)
+	}
+}
+
+// TestEnforcer_NonCompliant_PropagatesCode confirms a Rego policy emitting a
+// coded violation ({"code": "POL_...", "message": "..."}) has that code
+// survive all the way to CheckPolicy's returned NACK — not just extracted by
+// the Evaluator in isolation.
+func TestEnforcer_NonCompliant_PropagatesCode(t *testing.T) {
+	policy := `
+package policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+  input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.result\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error for non-compliant message, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	beErr := badReqErr.BecknError()
+	if beErr.Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("BecknError().Code = %s, want POL_GEO_RESTRICTED", beErr.Code)
+	}
+	if !strings.Contains(beErr.Message, "delivery not offered in this region") {
+		t.Errorf("BecknError().Message = %q, want it to contain the violation text", beErr.Message)
+	}
+}
+
+// TestEnforcer_EvaluationError_UsesGenericCode confirms a failure to evaluate
+// the policy at all (as opposed to a clean deny decision) is classified as
+// POL_GENERIC_ERROR — it's an evaluation failure, not a policy denial, so no
+// more specific POL_* code applies.
+func TestEnforcer_EvaluationError_UsesGenericCode(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+violations contains "blocked" if { input.context.action == "confirm" }
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.violations\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	// Malformed JSON body reaches ev.Evaluate (parseRequestContext degrades
+	// gracefully on invalid JSON, so CheckPolicy still selects this policy).
+	ctx := makeStepCtx("confirm", `not valid json`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error for malformed body, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR for an evaluation failure", code)
+	}
+}
+
+// TestEnforcer_UninitializedEvaluator_UsesGenericCode covers the defensive
+// "evaluator is not initialized" branch directly — an enabled policy whose
+// evaluator is nil should not normally occur via the real loading path
+// (loadPolicy only skips evaluator init for disabled policies), so this
+// constructs the PolicyEnforcer's internal state directly rather than trying
+// to race the real startup path. Confirms this branch is now classified with
+// POL_GENERIC_ERROR, consistent with the other two CheckPolicy failure modes.
+func TestEnforcer_UninitializedEvaluator_UsesGenericCode(t *testing.T) {
+	enforcer := &PolicyEnforcer{
+		config: &Config{Enabled: true},
+		defaultPolicy: &loadedPolicy{
+			config:    &PolicyConfig{Enabled: true},
+			evaluator: nil,
+		},
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err := enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error when evaluator is nil, got nil")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
+	}
+}
+
+func TestViolationMessages(t *testing.T) {
+	violations := []model.Error{
+		{Code: "POL_KYC_REQUIRED", Message: "m1"},
+		{Message: "m2"},
+	}
+	got := violationMessages(violations)
+	want := []string{"m1", "m2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("violationMessages() = %v, want %v", got, want)
 	}
 }
 
@@ -1017,8 +1390,8 @@ violations contains msg if {
 	if len(violations) != 1 {
 		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
 	}
-	if violations[0] != "item item1: quantity must be > 0" {
-		t.Errorf("unexpected violation: %q", violations[0])
+	if violations[0].Message != "item item1: quantity must be > 0" {
+		t.Errorf("unexpected violation: %q", violations[0].Message)
 	}
 
 	// Compliant input
@@ -1037,6 +1410,98 @@ violations contains msg if {
 	}
 	if len(violations) != 0 {
 		t.Errorf("expected 0 violations for compliant input, got %v", violations)
+	}
+}
+
+// TestEvaluator_StructuredResult_WithCodedViolations exercises the additive
+// violation shape: a Rego policy MAY emit {"code": "POL_...", "message": "..."}
+// objects instead of plain strings, and extractStructuredViolations preserves
+// the Code. Existing policies that only emit plain strings are unaffected —
+// verified by the "message" fallback and mixed-shape cases below.
+func TestEvaluator_StructuredResult_WithCodedViolations(t *testing.T) {
+	policy := `
+package retail.policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains {"code": "POL_GEO_RESTRICTED", "message": "delivery not offered in this region"} if {
+  input.message.fulfillment.region == "restricted-zone"
+}
+`
+	dir := writePolicyDir(t, "policy.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.retail.policy.result", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"message": {"fulfillment": {"region": "restricted-zone"}}}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Code != "POL_GEO_RESTRICTED" {
+		t.Errorf("violations[0].Code = %q, want POL_GEO_RESTRICTED", violations[0].Code)
+	}
+	if violations[0].Message != "delivery not offered in this region" {
+		t.Errorf("violations[0].Message = %q, want %q", violations[0].Message, "delivery not offered in this region")
+	}
+}
+
+// TestEvaluator_StructuredResult_MixedCodedAndPlainViolations confirms a
+// policy can mix legacy plain-string violations with coded ones in the same
+// result — the plain one gets no Code (left for the caller's generic
+// fallback), the coded one keeps its classification.
+func TestEvaluator_StructuredResult_MixedCodedAndPlainViolations(t *testing.T) {
+	policy := `
+package retail.policy
+
+import rego.v1
+
+default result := {
+  "valid": true,
+  "violations": []
+}
+
+result := {
+  "valid": count(violations) == 0,
+  "violations": violations
+}
+
+violations contains "unclassified legacy violation" if {
+  input.trigger == "legacy"
+}
+
+violations contains {"code": "POL_KYC_REQUIRED", "message": "KYC verification required"} if {
+  input.trigger == "coded"
+}
+`
+	dir := writePolicyDir(t, "policy.rego", policy)
+	eval, err := NewEvaluator([]string{dir}, "data.retail.policy.result", nil, false, 0, nil)
+	if err != nil {
+		t.Fatalf("NewEvaluator failed: %v", err)
+	}
+
+	violations, err := eval.Evaluate(context.Background(), []byte(`{"trigger": "coded"}`))
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Code != "POL_KYC_REQUIRED" || violations[0].Message != "KYC verification required" {
+		t.Errorf("unexpected violation: %+v", violations[0])
 	}
 }
 
@@ -1062,8 +1527,218 @@ result := {
 	if err != nil {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
-	if len(violations) != 1 || violations[0] != "policy denied the request" {
+	if len(violations) != 1 || violations[0].Message != "policy denied the request" {
 		t.Errorf("expected ['policy denied the request'], got %v", violations)
+	}
+}
+
+// TestExtractStructuredViolations_ObjectItemEdgeCases unit-tests the
+// object-shaped violation item parsing directly, without needing a real Rego
+// policy — covering the code-only fallback and empty-item-skip branches that
+// the Rego-driven tests above don't exercise.
+func TestExtractStructuredViolations_ObjectItemEdgeCases(t *testing.T) {
+	m := map[string]interface{}{
+		"valid": false,
+		"violations": []interface{}{
+			"plain string violation",
+			map[string]interface{}{"code": "POL_CONSENT_REQUIRED", "message": "consent required"},
+			map[string]interface{}{"code": "POL_SANCTIONED_PARTY"}, // no message: falls back to code
+			map[string]interface{}{},                               // neither code nor message: skipped
+		},
+	}
+
+	got := extractStructuredViolations(context.Background(), m)
+	want := []model.Error{
+		{Message: "plain string violation"},
+		{Code: "POL_CONSENT_REQUIRED", Message: "consent required"},
+		{Code: "POL_SANCTIONED_PARTY", Message: "POL_SANCTIONED_PARTY"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d violations, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("violations[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestExtractStructuredViolations_MalformedShape_FallsBackToGenericViolation is
+// a regression test for a fail-open bug found in self-review: a map with only
+// one of "valid"/"violations", or either key present with the wrong JSON type,
+// was silently returned as nil — discarding any populated violations the map
+// carried and letting a request the policy clearly denied through as
+// compliant. This confirms the fix: any map that looks like an attempted
+// structured result but doesn't fully match the expected shape now falls back
+// to a generic denial instead of nil.
+func TestExtractStructuredViolations_MalformedShape_FallsBackToGenericViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+	}{
+		{
+			name: "violations present without valid",
+			m: map[string]interface{}{
+				"violations": []interface{}{
+					map[string]interface{}{"code": "POL_KYC_REQUIRED", "message": "kyc required"},
+				},
+			},
+		},
+		{
+			name: "valid present without violations",
+			m: map[string]interface{}{
+				"valid": false,
+			},
+		},
+		{
+			name: "valid has wrong type",
+			m: map[string]interface{}{
+				"valid":      "false",
+				"violations": []interface{}{"some violation"},
+			},
+		},
+		{
+			name: "violations has wrong type",
+			m: map[string]interface{}{
+				"valid":      false,
+				"violations": "some violation",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStructuredViolations(context.Background(), tt.m)
+			if len(got) != 1 || got[0].Message != genericDenialMessage {
+				t.Errorf("extractStructuredViolations(%+v) = %v, want a single generic denial violation — a malformed structured result must not be silently treated as compliant", tt.m, got)
+			}
+		})
+	}
+}
+
+// TestExtractStructuredViolations_NeitherKeyPresent_ReturnsNil confirms the
+// boundary the fix above must not cross: a map with neither "valid" nor
+// "violations" isn't an attempt at this format at all (some other, unrelated
+// map result at this query path) and should still be ignored, not treated as
+// a denial.
+func TestExtractStructuredViolations_NeitherKeyPresent_ReturnsNil(t *testing.T) {
+	got := extractStructuredViolations(context.Background(), map[string]interface{}{"foo": "bar"})
+	if got != nil {
+		t.Errorf("expected nil for a map with neither valid nor violations key, got %v", got)
+	}
+}
+
+// TestEnforcer_StructuredResult_MissingValidKey_StillDenies is the CheckPolicy
+// end-to-end counterpart: confirms a structured result missing "valid" (e.g.
+// an incomplete migration to the structured shape) still denies the request
+// and the violation's code survives to the final NACK, rather than being
+// silently allowed.
+func TestEnforcer_StructuredResult_MissingValidKey_StillDenies(t *testing.T) {
+	policy := `
+package policy
+import rego.v1
+result := {"violations": [{"code": "POL_KYC_REQUIRED", "message": "kyc required"}]} if {
+    input.context.action == "confirm"
+}
+`
+	dir := writePolicyDir(t, "test.rego", policy)
+
+	configPath := writeDefaultOnlyNetworkPolicyConfig(t, "type: dir\nlocation: "+dir+"\nquery: data.policy.result\n")
+	enforcer, err := New(context.Background(), map[string]string{
+		"networkPolicyConfig": configPath,
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	ctx := makeStepCtx("confirm", `{"context": {"action": "confirm"}}`)
+	err = enforcer.CheckPolicy(ctx)
+	if err == nil {
+		t.Fatal("expected error (request must be denied), got nil — a structured result missing the \"valid\" key must not be silently allowed")
+	}
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "POL_GENERIC_ERROR" {
+		t.Errorf("BecknError().Code = %s, want POL_GENERIC_ERROR", code)
+	}
+}
+
+func TestParseViolationItem(t *testing.T) {
+	tests := []struct {
+		name   string
+		item   interface{}
+		wantOK bool
+		want   model.Error
+	}{
+		{
+			name:   "plain string",
+			item:   "some violation",
+			wantOK: true,
+			want:   model.Error{Message: "some violation"},
+		},
+		{
+			name:   "empty string is dropped",
+			item:   "",
+			wantOK: false,
+		},
+		{
+			name:   "coded object",
+			item:   map[string]interface{}{"code": "POL_KYC_REQUIRED", "message": "KYC required"},
+			wantOK: true,
+			want:   model.Error{Code: "POL_KYC_REQUIRED", Message: "KYC required"},
+		},
+		{
+			name:   "code only falls back to code as message",
+			item:   map[string]interface{}{"code": "POL_SANCTIONED_PARTY"},
+			wantOK: true,
+			want:   model.Error{Code: "POL_SANCTIONED_PARTY", Message: "POL_SANCTIONED_PARTY"},
+		},
+		{
+			name:   "empty object is dropped",
+			item:   map[string]interface{}{},
+			wantOK: false,
+		},
+		{
+			name:   "non-string message is ignored, code alone survives",
+			item:   map[string]interface{}{"code": "POL_GEO_RESTRICTED", "message": 12345},
+			wantOK: true,
+			want:   model.Error{Code: "POL_GEO_RESTRICTED", Message: "POL_GEO_RESTRICTED"},
+		},
+		{
+			name:   "non-string code is ignored, message alone survives",
+			item:   map[string]interface{}{"code": 12345, "message": "some message"},
+			wantOK: true,
+			want:   model.Error{Message: "some message"},
+		},
+		{
+			name:   "both non-string is dropped",
+			item:   map[string]interface{}{"code": 12345, "message": true},
+			wantOK: false,
+		},
+		{
+			name:   "unsupported type (number) is dropped",
+			item:   42,
+			wantOK: false,
+		},
+		{
+			name:   "unsupported type (nested list) is dropped",
+			item:   []interface{}{"nested"},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseViolationItem(context.Background(), tt.item)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got=%+v)", ok, tt.wantOK, got)
+			}
+			if ok && got != tt.want {
+				t.Errorf("got = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/plugin/implementation/opapolicychecker/evaluator.go
+++ b/pkg/plugin/implementation/opapolicychecker/evaluator.go
@@ -25,6 +25,8 @@ import (
 	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/security/artifactverifier"
 )
 
@@ -402,8 +404,11 @@ func fetchPolicy(rawURL string, fetchTimeout time.Duration) (string, string, err
 }
 
 // Evaluate runs the compiled policy against a JSON message body.
-// Returns a list of violation strings (empty = compliant).
-func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]string, error) {
+// Returns a list of violations (empty = compliant). Each violation's Code is
+// set only when the Rego result explicitly provided one (see
+// extractStructuredViolations) — otherwise it's left empty for the caller to
+// fall back to a generic classification.
+func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]model.Error, error) {
 	var input interface{}
 	if err := json.Unmarshal(body, &input); err != nil {
 		return nil, fmt.Errorf("failed to parse message body as JSON: %w", err)
@@ -417,49 +422,75 @@ func (e *Evaluator) Evaluate(ctx context.Context, body []byte) ([]string, error)
 	// Fail-closed for bundles: if the query returned no result, the policy_query_path
 	// is likely misconfigured or the rule doesn't exist in the bundle.
 	if e.failOnUndefined && len(rs) == 0 {
-		return []string{fmt.Sprintf("policy query %q returned no result (undefined)", e.query)}, nil
+		return []model.Error{{Message: fmt.Sprintf("policy query %q returned no result (undefined)", e.query)}}, nil
 	}
 
-	return extractViolations(rs)
+	return extractViolations(ctx, rs)
 }
+
+// genericDenialMessage is used whenever a policy result clearly signals a
+// denial (a non-empty deny-shaped value, or a malformed attempt at one) but
+// its content can't be parsed into a more specific violation.
+const genericDenialMessage = "policy denied the request"
 
 // extractViolations pulls violations from the OPA result set.
 // Supported query output formats:
-//   - map with {"valid": bool, "violations": []string}: structured policy_query_path result
-//   - []string / set of strings: each string is a violation message
-//   - bool: false = denied ("policy denied the request"), true = allowed
-//   - string: non-empty = violation message
-//   - empty/undefined: allowed (no violations)
-func extractViolations(rs rego.ResultSet) ([]string, error) {
+//   - map with {"valid": bool, "violations": [...]}: structured policy_query_path
+//     result. Each violation entry may be a plain string (legacy, no code) or an
+//     object {"code": "POL_...", "message": "..."} (Code is preserved). A map
+//     that doesn't fully match this shape (a missing or wrong-typed key) still
+//     produces one generic violation rather than being silently ignored.
+//   - []interface{} / set: each item may be a plain string (legacy, no code) or
+//     an object {"code": "POL_...", "message": "..."} (Code is preserved) — the
+//     same two shapes accepted by the structured format above. A non-empty set
+//     that yields zero parseable items still produces one generic violation,
+//     mirroring the structured format's invalid-with-no-violations fallback.
+//   - bool: false = denied ("policy denied the request"), true = allowed.
+//   - string: non-empty = violation message, no code.
+//   - empty/undefined: allowed (no violations).
+//   - any other type (e.g. a bare number, or an explicit Rego null): not a
+//     recognized decision shape, so treated the same as a malformed result —
+//     one generic violation, rather than being silently ignored.
+func extractViolations(ctx context.Context, rs rego.ResultSet) ([]model.Error, error) {
 	if len(rs) == 0 {
 		return nil, nil
 	}
 
-	var violations []string
+	var violations []model.Error
 	for _, result := range rs {
 		for _, expr := range result.Expressions {
 			switch v := expr.Value.(type) {
 			case bool:
 				// allow/deny pattern: false = denied
 				if !v {
-					violations = append(violations, "policy denied the request")
+					violations = append(violations, model.Error{Message: genericDenialMessage})
 				}
 			case string:
 				// single violation string
-				if v != "" {
-					violations = append(violations, v)
+				if e, ok := parseViolationItem(ctx, v); ok {
+					violations = append(violations, e)
 				}
 			case []interface{}:
 				// Result is a list (from set)
+				lenBefore := len(violations)
 				for _, item := range v {
-					if s, ok := item.(string); ok {
-						violations = append(violations, s)
+					if e, ok := parseViolationItem(ctx, item); ok {
+						violations = append(violations, e)
 					}
 				}
+				// A non-empty set is itself a deny signal — don't let every item
+				// failing to parse (e.g. an empty string, or a malformed/unsupported
+				// item) silently flip the result to compliant.
+				if len(v) > 0 && len(violations) == lenBefore {
+					violations = append(violations, model.Error{Message: genericDenialMessage})
+				}
 			case map[string]interface{}:
-				if vs := extractStructuredViolations(v); vs != nil {
+				if vs := extractStructuredViolations(ctx, v); vs != nil {
 					violations = append(violations, vs...)
 				}
+			default:
+				log.Debugf(ctx, "OPAPolicyChecker: policy result has unsupported type %T (%+v); treating as a denial", v, v)
+				violations = append(violations, model.Error{Message: genericDenialMessage})
 			}
 		}
 	}
@@ -467,42 +498,86 @@ func extractViolations(rs rego.ResultSet) ([]string, error) {
 	return violations, nil
 }
 
+// parseViolationItem converts one item from a Rego violations list/set into a
+// model.Error. Supported shapes: a plain string (legacy, Code left empty), or
+// an object {"code": "POL_...", "message": "..."} (Code preserved). Returns
+// ok=false for anything else (wrong types, or both code and message empty),
+// logging a debug line so a malformed Rego policy's output isn't silently
+// invisible.
+func parseViolationItem(ctx context.Context, item interface{}) (model.Error, bool) {
+	switch v := item.(type) {
+	case string:
+		if v == "" {
+			return model.Error{}, false
+		}
+		return model.Error{Message: v}, true
+	case map[string]interface{}:
+		message, msgIsString := v["message"].(string)
+		code, codeIsString := v["code"].(string)
+		if rawMsg := v["message"]; rawMsg != nil && !msgIsString {
+			log.Debugf(ctx, "OPAPolicyChecker: violation item has a non-string \"message\" (%T); ignoring", rawMsg)
+		}
+		if rawCode := v["code"]; rawCode != nil && !codeIsString {
+			log.Debugf(ctx, "OPAPolicyChecker: violation item has a non-string \"code\" (%T); ignoring", rawCode)
+		}
+		if message == "" && code == "" {
+			log.Debugf(ctx, "OPAPolicyChecker: dropping violation item with no usable code or message: %+v", v)
+			return model.Error{}, false
+		}
+		if message == "" {
+			message = code
+		}
+		return model.Error{Code: code, Message: message}, true
+	default:
+		log.Debugf(ctx, "OPAPolicyChecker: dropping violation item of unsupported type %T", item)
+		return model.Error{}, false
+	}
+}
+
 // extractStructuredViolations handles the policy_query_path result format:
-// {"valid": bool, "violations": []string}
-// Returns the violation strings if the map matches this format, or nil if it doesn't.
-func extractStructuredViolations(m map[string]interface{}) []string {
+// {"valid": bool, "violations": [...]}. Each item in "violations" is parsed by
+// parseViolationItem — either a plain string (legacy — Code left empty) or an
+// object {"code": "POL_...", "message": "..."} (Code preserved for the
+// caller's classification). Returns the parsed violations if the map matches
+// this format; nil if the map has neither key (not an attempt at this format
+// at all — some other, unrelated map result); or one generic denial if the
+// map has only one of the two keys, or either key has the wrong type (a
+// malformed attempt at this format must not be silently treated as
+// compliant).
+func extractStructuredViolations(ctx context.Context, m map[string]interface{}) []model.Error {
 	validRaw, hasValid := m["valid"]
 	violationsRaw, hasViolations := m["violations"]
 
-	if !hasValid || !hasViolations {
+	if !hasValid && !hasViolations {
 		return nil
 	}
 
-	valid, ok := validRaw.(bool)
-	if !ok {
-		return nil
-	}
+	valid, validOK := validRaw.(bool)
+	violationsList, violationsOK := violationsRaw.([]interface{})
 
-	violationsList, ok := violationsRaw.([]interface{})
-	if !ok {
-		return nil
+	// A missing key always type-asserts to !OK too, so checking just the OK
+	// results (rather than also hasValid/hasViolations) already covers both
+	// "key absent" and "key present with the wrong type".
+	if !validOK || !violationsOK {
+		log.Debugf(ctx, "OPAPolicyChecker: malformed structured policy result (expected {\"valid\": bool, \"violations\": [...]}), got %+v; treating as a denial", m)
+		return []model.Error{{Message: genericDenialMessage}}
 	}
 
 	// If valid is true and violations is empty, no violations
 	if valid && len(violationsList) == 0 {
-		return []string{}
+		return []model.Error{}
 	}
 
-	var violations []string
+	var violations []model.Error
 	for _, item := range violationsList {
-		if s, ok := item.(string); ok {
-			violations = append(violations, s)
+		if e, ok := parseViolationItem(ctx, item); ok {
+			violations = append(violations, e)
 		}
 	}
 
 	// If valid is false but violations is empty, report a generic violation
 	if !valid && len(violations) == 0 {
-		violations = append(violations, "policy denied the request")
+		violations = append(violations, model.Error{Message: genericDenialMessage})
 	}
 
 	return violations

--- a/pkg/plugin/implementation/publisher/publisher.go
+++ b/pkg/plugin/implementation/publisher/publisher.go
@@ -118,7 +118,7 @@ func (p *Publisher) Publish(ctx context.Context, routingKey string, msg []byte) 
 
 	if err != nil {
 		log.Errorf(ctx, err, "Publish failed for Exchange: %s, RoutingKey: %s", p.Config.Exchange, routingKey)
-		return model.NewBadReqErr(fmt.Errorf("publish message failed: %w", err))
+		return model.NewCodedBadReqErr("NET_DOWNSTREAM_UNAVAILABLE", fmt.Errorf("publish message failed: %w", err))
 	}
 
 	log.Infof(ctx, "Message published successfully to Exchange: %s, RoutingKey: %s", p.Config.Exchange, routingKey)

--- a/pkg/plugin/implementation/publisher/publisher_test.go
+++ b/pkg/plugin/implementation/publisher/publisher_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/rabbitmq/amqp091-go"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 func TestGetConnURLSuccess(t *testing.T) {
@@ -232,6 +234,16 @@ func TestPublishFailure(t *testing.T) {
 	err := p.Publish(context.Background(), "", []byte(`{"test": true}`))
 	if err == nil {
 		t.Error("expected error from failed publish, got nil")
+	}
+
+	// A RabbitMQ publish failure is a downstream-infrastructure problem, not
+	// a caller bad-request — classified as NET_DOWNSTREAM_UNAVAILABLE.
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != "NET_DOWNSTREAM_UNAVAILABLE" {
+		t.Errorf("BecknError().Code = %s, want NET_DOWNSTREAM_UNAVAILABLE", code)
 	}
 }
 

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -110,9 +110,9 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 // ErrorCode taxonomy at the point each cause is known, rather than being
 // wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
-	req, reqContext, becknErr, cause := model.ExtractContext(body)
+	req, reqContext, becknErr := model.ExtractContext(body)
 	if becknErr != nil {
-		return nil, model.WrapExtractContextErr("failed to decode request body", becknErr, cause)
+		return nil, model.WrapExtractContextErr("failed to decode request body", becknErr)
 	}
 
 	action, ok := reqContext["action"].(string)

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -112,13 +112,7 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 func parseRequestBody(body []byte) (*parsedRequest, error) {
 	req, reqContext, becknErr, cause := model.ExtractContext(body)
 	if becknErr != nil {
-		if cause != nil {
-			// Preserve the underlying decode error in the wrap chain so
-			// errors.Is/errors.As can still reach it, same as before ExtractContext
-			// was extracted.
-			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("failed to decode request body: %w", cause))
-		}
-		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
+		return nil, model.WrapExtractContextErr("failed to decode request body", becknErr, cause)
 	}
 
 	action, ok := reqContext["action"].(string)

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -110,14 +110,15 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 // ErrorCode taxonomy at the point each cause is known, rather than being
 // wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
-	var req map[string]interface{}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, model.NewCodedBadReqErr("SCH_INVALID_JSON", fmt.Errorf("failed to decode request body: %w", err))
-	}
-
-	reqContext, ok := req["context"].(map[string]interface{})
-	if !ok {
-		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("context field not found or invalid"))
+	req, reqContext, becknErr, cause := model.ExtractContext(body)
+	if becknErr != nil {
+		if cause != nil {
+			// Preserve the underlying decode error in the wrap chain so
+			// errors.Is/errors.As can still reach it, same as before ExtractContext
+			// was extracted.
+			return nil, model.NewCodedBadReqErr(becknErr.Code, fmt.Errorf("failed to decode request body: %w", cause))
+		}
+		return nil, model.NewCodedBadReqErr(becknErr.Code, errors.New(becknErr.Message))
 	}
 
 	action, ok := reqContext["action"].(string)

--- a/pkg/plugin/implementation/reqmapper/reqmapper.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper.go
@@ -93,7 +93,7 @@ func (s *reqMapperStep) Run(ctx *model.StepContext) error {
 func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte, error) {
 	parsed, err := parseRequestBody(body)
 	if err != nil {
-		return nil, model.NewBadReqErr(err)
+		return nil, err
 	}
 
 	mappedBody, err := s.engine.Transform(ctx, parsed.action, parsed.req, s.role)
@@ -105,20 +105,24 @@ func (s *reqMapperStep) transformBody(ctx context.Context, body []byte) ([]byte,
 	return mappedBody, nil
 }
 
+// parseRequestBody parses the incoming request body and extracts the fields
+// the mapping engine needs. Failures are classified onto the Beckn v2.0.0
+// ErrorCode taxonomy at the point each cause is known, rather than being
+// wrapped in a single generic code by the caller.
 func parseRequestBody(body []byte) (*parsedRequest, error) {
 	var req map[string]interface{}
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, fmt.Errorf("failed to decode request body: %w", err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_JSON", fmt.Errorf("failed to decode request body: %w", err))
 	}
 
 	reqContext, ok := req["context"].(map[string]interface{})
 	if !ok {
-		return nil, errors.New("context field not found or invalid")
+		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("context field not found or invalid"))
 	}
 
 	action, ok := reqContext["action"].(string)
 	if !ok || action == "" {
-		return nil, errors.New("action field not found or invalid")
+		return nil, model.NewCodedBadReqErr("SCH_REQUIRED_FIELD_MISSING", errors.New("action field not found or invalid"))
 	}
 
 	return &parsedRequest{

--- a/pkg/plugin/implementation/reqmapper/reqmapper_test.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper_test.go
@@ -189,29 +189,48 @@ func TestReqMapperStepRun_EmptyBody(t *testing.T) {
 		Body:    nil,
 	}
 
-	require.Error(t, step.Run(ctx))
+	err = step.Run(ctx)
+	require.Error(t, err)
+	requireBadReqCode(t, err, "SCH_INVALID_JSON")
 }
 
 func TestParseRequestBody(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		_, err := parseRequestBody([]byte("{"))
 		require.Error(t, err)
+		requireBadReqCode(t, err, "SCH_INVALID_JSON")
 	})
 
 	t.Run("missing context", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"message":{}}`))
 		require.EqualError(t, err, "context field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("missing action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("empty action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{"action":""},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
+		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
+}
+
+// requireBadReqCode confirms err is a *model.BadReqErr classified with wantCode.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
+	}
 }
 
 func TestMappingEngineTransform(t *testing.T) {

--- a/pkg/plugin/implementation/reqmapper/reqmapper_test.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper_test.go
@@ -199,11 +199,20 @@ func TestParseRequestBody(t *testing.T) {
 		_, err := parseRequestBody([]byte("{"))
 		require.Error(t, err)
 		requireBadReqCode(t, err, "SCH_INVALID_JSON")
+
+		// Regression test: the decode failure must still unwrap to the
+		// underlying json error via errors.As, matching the wrapping this
+		// function did before model.ExtractContext was extracted (self-review
+		// of #882 found this had silently regressed, then fixed it).
+		var syntaxErr *json.SyntaxError
+		require.ErrorAs(t, err, &syntaxErr, "expected errors.As to still reach the underlying *json.SyntaxError")
 	})
 
 	t.Run("missing context", func(t *testing.T) {
+		// The exact message text for this classification is model.ExtractContext's
+		// concern and is already verified directly in pkg/model/model_test.go;
+		// this only needs to confirm parseRequestBody forwards the Code correctly.
 		_, err := parseRequestBody([]byte(`{"message":{}}`))
-		require.EqualError(t, err, "context field not found or invalid")
 		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 

--- a/pkg/plugin/implementation/reqmapper/reqmapper_test.go
+++ b/pkg/plugin/implementation/reqmapper/reqmapper_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/testutil"
 	"github.com/jsonata-go/jsonata"
 	"github.com/stretchr/testify/require"
 )
@@ -191,14 +192,14 @@ func TestReqMapperStepRun_EmptyBody(t *testing.T) {
 
 	err = step.Run(ctx)
 	require.Error(t, err)
-	requireBadReqCode(t, err, "SCH_INVALID_JSON")
+	testutil.RequireBadReqCode(t, err, "SCH_INVALID_JSON")
 }
 
 func TestParseRequestBody(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		_, err := parseRequestBody([]byte("{"))
 		require.Error(t, err)
-		requireBadReqCode(t, err, "SCH_INVALID_JSON")
+		testutil.RequireBadReqCode(t, err, "SCH_INVALID_JSON")
 
 		// Regression test: the decode failure must still unwrap to the
 		// underlying json error via errors.As, matching the wrapping this
@@ -213,33 +214,20 @@ func TestParseRequestBody(t *testing.T) {
 		// concern and is already verified directly in pkg/model/model_test.go;
 		// this only needs to confirm parseRequestBody forwards the Code correctly.
 		_, err := parseRequestBody([]byte(`{"message":{}}`))
-		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
+		testutil.RequireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("missing action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
-		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
+		testutil.RequireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
 
 	t.Run("empty action", func(t *testing.T) {
 		_, err := parseRequestBody([]byte(`{"context":{"action":""},"message":{}}`))
 		require.EqualError(t, err, "action field not found or invalid")
-		requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
+		testutil.RequireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 	})
-}
-
-// requireBadReqCode confirms err is a *model.BadReqErr classified with wantCode.
-func requireBadReqCode(t *testing.T, err error, wantCode string) {
-	t.Helper()
-
-	badReqErr, ok := err.(*model.BadReqErr)
-	if !ok {
-		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
-	}
-	if code := badReqErr.BecknError().Code; code != wantCode {
-		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
-	}
 }
 
 func TestMappingEngineTransform(t *testing.T) {

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -21,7 +20,24 @@ type Config struct {
 	ParentID    string
 }
 
-const contextKey = "context"
+// writeCodedError writes a Beckn v2.0.0 ErrorCode-aligned JSON error body.
+// reqpreprocessor runs as HTTP middleware ahead of the standard step/NACK
+// pipeline (see core/module/handler/stdHandler.go's step loop), so this is a
+// correctly-coded but unsigned JSON body, not the full Beckn NACK envelope
+// nack() produces elsewhere — wiring this plugin into that pipeline (with the
+// signing/telemetry implications that carries) is tracked separately in #868.
+func writeCodedError(ctx context.Context, w http.ResponseWriter, status int, code, message string) {
+	// model.NewCodedError's result is a two-string-field struct that cannot
+	// realistically fail to marshal — matching nack()'s own established
+	// convention (core/module/handler/responsestep.go) of not guarding this.
+	data, _ := json.Marshal(model.NewCodedError(code, message))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, werr := w.Write(data); werr != nil {
+		log.Debugf(ctx, "failed to write coded error response: %v", werr)
+		http.Error(w, message, http.StatusInternalServerError)
+	}
+}
 
 // snakeToCamel converts a snake_case string to camelCase.
 // For example: "transaction_id" -> "transactionId".
@@ -47,12 +63,12 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				http.Error(w, "Failed to read request body", http.StatusBadRequest)
+				writeCodedError(ctx, w, http.StatusBadRequest, "SCH_INVALID_JSON", "Failed to read request body")
 				return
 			}
-			ctx := r.Context()
 
 			// Bodyless requests (GET/DELETE) carry no JSON body and no context
 			// fields — skip body extraction and pass through directly.
@@ -70,16 +86,11 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 				return
 			}
 
-			var req map[string]interface{}
-			if err := json.Unmarshal(body, &req); err != nil {
-				http.Error(w, "Failed to decode request body", http.StatusBadRequest)
-				return
-			}
-
-			// Extract context from request.
-			reqContext, ok := req["context"].(map[string]interface{})
-			if !ok {
-				http.Error(w, fmt.Sprintf("%s field not found or invalid.", contextKey), http.StatusBadRequest)
+			// Decode the body and extract its context field using the same
+			// classification reqmapper (#867) relies on for the identical check.
+			_, reqContext, becknErr, _ := model.ExtractContext(body)
+			if becknErr != nil {
+				writeCodedError(ctx, w, http.StatusBadRequest, becknErr.Code, becknErr.Message)
 				return
 			}
 

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -88,7 +88,7 @@ func NewPreProcessor(cfg *Config) (func(http.Handler) http.Handler, error) {
 
 			// Decode the body and extract its context field using the same
 			// classification reqmapper (#867) relies on for the identical check.
-			_, reqContext, becknErr, _ := model.ExtractContext(body)
+			_, reqContext, becknErr := model.ExtractContext(body)
 			if becknErr != nil {
 				writeCodedError(ctx, w, http.StatusBadRequest, becknErr.Code, becknErr.Message)
 				return

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -2,7 +2,9 @@ package reqpreprocessor
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -130,6 +132,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 		expectedCode int
 		expectErr    bool
 		errMsg       string
+		wantBeckn    string // expected model.Error.Code in the response body, if expectedCode is a per-request failure
 	}{
 		{
 			name: "Missing context",
@@ -142,6 +145,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "context field not found or invalid",
+			wantBeckn:    "SCH_REQUIRED_FIELD_MISSING",
 		},
 		{
 			name: "Invalid context type",
@@ -154,6 +158,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "context field not found or invalid",
+			wantBeckn:    "SCH_REQUIRED_FIELD_MISSING",
 		},
 		{
 			name:         "Nil config",
@@ -199,6 +204,7 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectErr:    false,
 			errMsg:       "failed to decode request body",
+			wantBeckn:    "SCH_INVALID_JSON",
 		},
 	}
 
@@ -231,7 +237,91 @@ func TestNewPreProcessorErrorCases(t *testing.T) {
 			if rec.Code != tt.expectedCode {
 				t.Errorf("Expected status code %d, but got %d", tt.expectedCode, rec.Code)
 			}
+
+			if tt.wantBeckn != "" {
+				requireCodedErrorBody(t, rec, tt.wantBeckn)
+			}
 		})
+	}
+}
+
+// requireCodedErrorBody confirms rec's body is a JSON model.Error with the
+// given Code, and that Content-Type reflects that.
+func requireCodedErrorBody(t *testing.T, rec *httptest.ResponseRecorder, wantCode string) {
+	t.Helper()
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got model.Error
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response body is not valid JSON model.Error: %v (body: %s)", err, rec.Body.String())
+	}
+	if got.Code != wantCode {
+		t.Errorf("response body Code = %s, want %s", got.Code, wantCode)
+	}
+}
+
+// errReader is an io.Reader that always fails, used to exercise the
+// io.ReadAll(r.Body) failure path in NewPreProcessor's middleware.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("simulated read failure")
+}
+
+func TestNewPreProcessor_BodyReadFailure(t *testing.T) {
+	cfg := &Config{Role: "bap"}
+	middleware, err := NewPreProcessor(cfg)
+	if err != nil {
+		t.Fatalf("NewPreProcessor() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/test", errReader{})
+	rec := httptest.NewRecorder()
+
+	middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler must not be called when the body can't be read")
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	requireCodedErrorBody(t, rec, "SCH_INVALID_JSON")
+}
+
+// failOnceWriteRecorder wraps httptest.ResponseRecorder but fails the first
+// Write, then passes subsequent writes through — used to exercise
+// writeCodedError's write-failure fallback path and observe its effect.
+type failOnceWriteRecorder struct {
+	*httptest.ResponseRecorder
+	failed bool
+}
+
+func (r *failOnceWriteRecorder) Write(b []byte) (int, error) {
+	if !r.failed {
+		r.failed = true
+		return 0, errors.New("simulated write failure")
+	}
+	return r.ResponseRecorder.Write(b)
+}
+
+func TestWriteCodedError_WriteFailureFallsBackToHTTPError(t *testing.T) {
+	rec := &failOnceWriteRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+	writeCodedError(context.Background(), rec, http.StatusBadRequest, "SCH_INVALID_JSON", "failed to decode")
+
+	// The initial WriteHeader(400) already committed the status line before the
+	// write failed; a superfluous second WriteHeader call from http.Error's
+	// fallback is a no-op (matches real net/http.ResponseWriter semantics, same
+	// as nack()'s established pattern), so the status stays 400 — but the
+	// fallback's plain-text body still lands via the second (successful) write.
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, "failed to decode") {
+		t.Errorf("body = %q, want it to contain the fallback http.Error message", got)
 	}
 }
 

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -235,9 +235,9 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	// classification reqmapper (#867) and reqpreprocessor (#868) rely on for
 	// the identical check, instead of router's own separate typed-struct and
 	// map decodes of the same body.
-	_, reqContext, becknErr, cause := model.ExtractContext(body)
+	_, reqContext, becknErr := model.ExtractContext(body)
 	if becknErr != nil {
-		return nil, model.WrapExtractContextErr("error parsing request body", becknErr, cause)
+		return nil, model.WrapExtractContextErr("error parsing request body", becknErr)
 	}
 
 	// Checks legacy snake_case (bpp_uri, bap_uri), then camelCase (bppUri,

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -232,35 +231,24 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 		return r.routeBodyless(endpoint, rawQuery)
 	}
 
-	// Parse domain and version via typed struct.
-	var requestBody struct {
-		Context struct {
-			Domain  string `json:"domain"`
-			Version string `json:"version"`
-		} `json:"context"`
-	}
-	if err := json.Unmarshal(body, &requestBody); err != nil {
-		return nil, fmt.Errorf("error parsing request body: %w", err)
+	// Decode the body and extract its context field using the same
+	// classification reqmapper (#867) and reqpreprocessor (#868) rely on for
+	// the identical check, instead of router's own separate typed-struct and
+	// map decodes of the same body.
+	_, reqContext, becknErr, cause := model.ExtractContext(body)
+	if becknErr != nil {
+		return nil, model.WrapExtractContextErr("error parsing request body", becknErr, cause)
 	}
 
-	// Parse context as a map solely to resolve URI fields. Checks legacy
-	// snake_case (bpp_uri, bap_uri), then camelCase (bppUri, bapUri), then
-	// the new Beckn spec v2 names (receiverUri, senderUri).
-	var uriBody struct {
-		Context map[string]interface{} `json:"context"`
-	}
-	if err := json.Unmarshal(body, &uriBody); err != nil {
-		return nil, fmt.Errorf("error parsing request body: %w", err)
-	}
-	if uriBody.Context == nil {
-		return nil, fmt.Errorf("context field not found or invalid in request body")
-	}
-	bppURI := getContextString(uriBody.Context, "bpp_uri", "bppUri", "receiverUri")
-	bapURI := getContextString(uriBody.Context, "bap_uri", "bapUri", "senderUri")
+	// Checks legacy snake_case (bpp_uri, bap_uri), then camelCase (bppUri,
+	// bapUri), then the new Beckn spec v2 names (receiverUri, senderUri).
+	bppURI := getContextString(reqContext, "bpp_uri", "bppUri", "receiverUri")
+	bapURI := getContextString(reqContext, "bap_uri", "bapUri", "senderUri")
+	version := getContextString(reqContext, "version")
 
 	// For v2.x.x, ignore domain and use wildcard; for v1.x.x, use actual domain
-	domain := requestBody.Context.Domain
-	if isV2Version(requestBody.Context.Version) {
+	domain := getContextString(reqContext, "domain")
+	if isV2Version(version) {
 		domain = "*"
 	}
 
@@ -268,26 +256,26 @@ func (r *Router) Route(ctx context.Context, reqURL *url.URL, body []byte) (*mode
 	domainRules, ok := r.rules[domain]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("no routing rules found for version %s", requestBody.Context.Version)
+			return nil, fmt.Errorf("no routing rules found for version %s", version)
 		}
-		return nil, fmt.Errorf("no routing rules found for domain %s", requestBody.Context.Domain)
+		return nil, fmt.Errorf("no routing rules found for domain %s", domain)
 	}
 
-	versionRules, ok := domainRules[requestBody.Context.Version]
+	versionRules, ok := domainRules[version]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("no routing rules found for version %s", requestBody.Context.Version)
+			return nil, fmt.Errorf("no routing rules found for version %s", version)
 		}
-		return nil, fmt.Errorf("no routing rules found for domain %s version %s", requestBody.Context.Domain, requestBody.Context.Version)
+		return nil, fmt.Errorf("no routing rules found for domain %s version %s", domain, version)
 	}
 
 	route, ok := versionRules[endpoint]
 	if !ok {
 		if domain == "*" {
-			return nil, fmt.Errorf("endpoint '%s' is not supported for version %s in routing config", endpoint, requestBody.Context.Version)
+			return nil, fmt.Errorf("endpoint '%s' is not supported for version %s in routing config", endpoint, version)
 		}
 		return nil, fmt.Errorf("endpoint '%s' is not supported for domain %s and version %s in routing config",
-			endpoint, requestBody.Context.Domain, requestBody.Context.Version)
+			endpoint, domain, version)
 	}
 	// Handle BPP/BAP routing with request URIs.
 	// Both legacy ("bpp"/"bap") and new spec v2 ("receiver"/"sender") values are accepted.
@@ -381,7 +369,8 @@ func handleProtocolMapping(route *model.Route, npURI, endpoint, rawQuery string)
 	}
 	targetURL, err := url.Parse(target)
 	if err != nil {
-		return nil, fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err)
+		return nil, model.NewCodedBadReqErr("SCH_INVALID_FORMAT",
+			fmt.Errorf("invalid %s URI - %s in request body for %s: %w", role, target, endpoint, err))
 	}
 	targetURL.Path = joinPath(targetURL, endpoint)
 	if rawQuery != "" {

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/testutil"
 )
 
 //go:embed testData/*
@@ -533,7 +534,7 @@ func TestRouteFailure(t *testing.T) {
 		endpointAction string
 		body           string
 		wantErr        string
-		// wantCode is checked via requireBadReqCode when non-empty. Failure
+		// wantCode is checked via testutil.RequireBadReqCode when non-empty. Failure
 		// modes that remain unclassified (plain fmt.Errorf, no model.Error)
 		// leave this blank — see #869's scope note on why domain/version/
 		// endpoint config-lookup misses and missing-URI-with-no-fallback are
@@ -596,23 +597,9 @@ func TestRouteFailure(t *testing.T) {
 				t.Errorf("Route(%q, %q) = %v, want error containing %q", tt.endpointAction, tt.body, err, tt.wantErr)
 			}
 			if tt.wantCode != "" {
-				requireBadReqCode(t, err, tt.wantCode)
+				testutil.RequireBadReqCode(t, err, tt.wantCode)
 			}
 		})
-	}
-}
-
-// requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode,
-// mirroring reqmapper_test.go's helper of the same name for the same check.
-func requireBadReqCode(t *testing.T, err error, wantCode string) {
-	t.Helper()
-
-	badReqErr, ok := err.(*model.BadReqErr)
-	if !ok {
-		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
-	}
-	if code := badReqErr.BecknError().Code; code != wantCode {
-		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 
@@ -905,7 +892,7 @@ func TestRouteNilContext(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "context field not found or invalid") {
 		t.Errorf("Route() with missing context = %v, want error containing 'context field not found or invalid'", err)
 	}
-	requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
+	testutil.RequireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 }
 
 // TestV1DomainRequired tests that domain is required for v1 configs

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -533,6 +533,12 @@ func TestRouteFailure(t *testing.T) {
 		endpointAction string
 		body           string
 		wantErr        string
+		// wantCode is checked via requireBadReqCode when non-empty. Failure
+		// modes that remain unclassified (plain fmt.Errorf, no model.Error)
+		// leave this blank — see #869's scope note on why domain/version/
+		// endpoint config-lookup misses and missing-URI-with-no-fallback are
+		// deliberately left out of this ticket's SCH_* realignment.
+		wantCode string
 	}{
 		{
 			name:           "Unsupported endpoint",
@@ -568,6 +574,15 @@ func TestRouteFailure(t *testing.T) {
 			endpointAction: "select",
 			body:           `{"context": {"domain": "ONDC:TRV10", "version": "1.1.0", "bpp_uri": "htp:// invalid-url"}}`,
 			wantErr:        `invalid BPP URI - htp:// invalid-url in request body for select: parse "htp:// invalid-url": invalid character " " in host name`,
+			wantCode:       "SCH_INVALID_FORMAT",
+		},
+		{
+			name:           "Malformed JSON body",
+			configFile:     "bap_caller.yaml",
+			endpointAction: "select",
+			body:           `{"context": {`,
+			wantErr:        "error parsing request body",
+			wantCode:       "SCH_INVALID_JSON",
 		},
 	}
 
@@ -580,7 +595,24 @@ func TestRouteFailure(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Errorf("Route(%q, %q) = %v, want error containing %q", tt.endpointAction, tt.body, err, tt.wantErr)
 			}
+			if tt.wantCode != "" {
+				requireBadReqCode(t, err, tt.wantCode)
+			}
 		})
+	}
+}
+
+// requireBadReqCode asserts err is a *model.BadReqErr carrying wantCode,
+// mirroring reqmapper_test.go's helper of the same name for the same check.
+func requireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	badReqErr, ok := err.(*model.BadReqErr)
+	if !ok {
+		t.Fatalf("expected *model.BadReqErr, got %T: %v", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
 	}
 }
 
@@ -873,6 +905,7 @@ func TestRouteNilContext(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "context field not found or invalid") {
 		t.Errorf("Route() with missing context = %v, want error containing 'context field not found or invalid'", err)
 	}
+	requireBadReqCode(t, err, "SCH_REQUIRED_FIELD_MISSING")
 }
 
 // TestV1DomainRequired tests that domain is required for v1 configs

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -193,20 +193,30 @@ func (v *schemav2Validator) validateExtendedSchemas(ctx context.Context, body in
 			var schemaErrors []model.Error
 			v.extractSchemaErrors(err, &schemaErrors)
 
-			// Prefix all paths with object path
-			for i := range schemaErrors {
-				if schemaErrors[i].Paths != "" {
-					schemaErrors[i].Paths = obj.Path + "." + schemaErrors[i].Paths
-				} else {
-					schemaErrors[i].Paths = obj.Path
-				}
-			}
+			prefixSchemaErrorPaths(schemaErrors, obj.Path)
 
 			return &model.SchemaValidationErr{Errors: schemaErrors}
 		}
 	}
 
 	return nil
+}
+
+// prefixSchemaErrorPaths prefixes objPath onto each error's Details.Path,
+// updating it in place when Details already exists so any other field (e.g.
+// a chained Cause) set upstream is preserved rather than discarded.
+func prefixSchemaErrorPaths(schemaErrors []model.Error, objPath string) {
+	for i := range schemaErrors {
+		prefixed := objPath
+		if schemaErrors[i].Details != nil && schemaErrors[i].Details.Path != "" {
+			prefixed = objPath + "." + schemaErrors[i].Details.Path
+		}
+		if schemaErrors[i].Details != nil {
+			schemaErrors[i].Details.Path = prefixed
+		} else {
+			schemaErrors[i].Details = &model.ErrorDetails{Path: prefixed}
+		}
+	}
 }
 
 // newSchemaCache creates a new schema cache.

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -529,11 +529,11 @@ func (c *schemaCache) validateReferencedObject(
 			u, err := url.Parse(obj.Context)
 			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 				log.Warnf(ctx, "Invalid or disallowed scheme in @context: %s", obj.Context)
-				return fmt.Errorf("invalid scheme in @context: %s", obj.Context)
+				return model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", fmt.Sprintf("invalid scheme in @context: %s", obj.Context))
 			}
 			if !isAllowedDomain(u, allowedDomains) {
 				log.Warnf(ctx, "Domain not in whitelist: %s", obj.Context)
-				return fmt.Errorf("domain not allowed: %s", obj.Context)
+				return model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", fmt.Sprintf("domain not allowed: %s", obj.Context))
 			}
 		}
 		schemaPath := transformContextToSchemaURL(obj.Context)
@@ -541,7 +541,7 @@ func (c *schemaCache) validateReferencedObject(
 		var err error
 		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
 		if err != nil {
-			return fmt.Errorf("at %s: %w", obj.Path, err)
+			return model.NewCodedError("SCH_SCHEMA_ADAPTATION_FAILED", err.Error())
 		}
 	}
 
@@ -549,7 +549,7 @@ func (c *schemaCache) validateReferencedObject(
 	schema, err := findSchemaByType(ctx, doc, obj.Type)
 	if err != nil {
 		log.Errorf(ctx, err, "Schema not found for @type: %s at path: %s", obj.Type, obj.Path)
-		return fmt.Errorf("at %s: %w", obj.Path, err)
+		return model.NewCodedError("SCH_INVALID_ENTITY_TYPE", err.Error())
 	}
 
 	// Strip JSON-LD metadata before validation

--- a/pkg/plugin/implementation/schemav2validator/extended_schema.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema.go
@@ -541,7 +541,7 @@ func (c *schemaCache) validateReferencedObject(
 		var err error
 		doc, err = c.loadSchemaFromPath(ctx, schemaPath, ttl, timeout, false)
 		if err != nil {
-			return model.NewCodedError("SCH_SCHEMA_ADAPTATION_FAILED", err.Error())
+			return model.NewCodedErrorWithCause("SCH_SCHEMA_ADAPTATION_FAILED", err.Error(), obj.Path, err)
 		}
 	}
 
@@ -549,7 +549,7 @@ func (c *schemaCache) validateReferencedObject(
 	schema, err := findSchemaByType(ctx, doc, obj.Type)
 	if err != nil {
 		log.Errorf(ctx, err, "Schema not found for @type: %s at path: %s", obj.Type, obj.Path)
-		return model.NewCodedError("SCH_INVALID_ENTITY_TYPE", err.Error())
+		return model.NewCodedErrorWithCause("SCH_INVALID_ENTITY_TYPE", err.Error(), obj.Path, err)
 	}
 
 	// Strip JSON-LD metadata before validation

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -730,6 +730,12 @@ components:
 	if !ok || becknErr.Code != "SCH_INVALID_ENTITY_TYPE" {
 		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_ENTITY_TYPE", err, err)
 	}
+	if becknErr.Details == nil || becknErr.Details.Path != obj.Path {
+		t.Errorf("Details.Path = %+v, want %q", becknErr.Details, obj.Path)
+	}
+	if becknErr.Unwrap() == nil {
+		t.Error("expected Unwrap() to reach the underlying findSchemaByType error, got nil")
+	}
 }
 
 func TestValidateReferencedObject_SchemaLoadFailure(t *testing.T) {
@@ -749,6 +755,12 @@ func TestValidateReferencedObject_SchemaLoadFailure(t *testing.T) {
 	becknErr, ok := err.(*model.Error)
 	if !ok || becknErr.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
 		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_SCHEMA_ADAPTATION_FAILED", err, err)
+	}
+	if becknErr.Details == nil || becknErr.Details.Path != obj.Path {
+		t.Errorf("Details.Path = %+v, want %q", becknErr.Details, obj.Path)
+	}
+	if becknErr.Unwrap() == nil {
+		t.Error("expected Unwrap() to reach the underlying loadSchemaFromPath error, got nil")
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -7,10 +7,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 )
@@ -812,6 +814,86 @@ func TestValidateExtendedSchemas_MissingMessage(t *testing.T) {
 	err := v.validateExtendedSchemas(ctx, body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'message' field")
+}
+
+func TestPrefixSchemaErrorPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		schemaErrors []model.Error
+		objPath      string
+		want         []model.Error
+	}{
+		{
+			name:         "no existing details gets object path",
+			schemaErrors: []model.Error{{Message: "m1"}},
+			objPath:      "message.order",
+			want: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "message.order"}},
+			},
+		},
+		{
+			name: "existing path is prefixed with object path",
+			schemaErrors: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "items[0].id"}},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{Message: "m1", Details: &model.ErrorDetails{Path: "message.order.items[0].id"}},
+			},
+		},
+		{
+			name: "existing cause is preserved after prefixing",
+			schemaErrors: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "items[0].id",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "message.order.items[0].id",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+		},
+		{
+			name: "existing details with no path yet gets object path, cause still preserved",
+			schemaErrors: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+			objPath: "message.order",
+			want: []model.Error{
+				{
+					Message: "m1",
+					Details: &model.ErrorDetails{
+						Path:  "message.order",
+						Cause: &model.Error{Code: "NET_DOWNSTREAM_UNAVAILABLE", Message: "registry lookup failed"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefixSchemaErrorPaths(tt.schemaErrors, tt.objPath)
+			if !reflect.DeepEqual(tt.schemaErrors, tt.want) {
+				t.Errorf("prefixSchemaErrorPaths() = %+v, want %+v", tt.schemaErrors, tt.want)
+			}
+		})
+	}
 }
 
 func TestIsSchemaVersionSegment(t *testing.T) {

--- a/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
+++ b/pkg/plugin/implementation/schemav2validator/extended_schema_test.go
@@ -2,6 +2,7 @@ package schemav2validator
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -661,24 +662,94 @@ components:
 	
 	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
 	assert.Error(t, err)
+
+	schemaErrors := []model.Error{}
+	(&schemav2Validator{}).extractSchemaErrors(err, &schemaErrors)
+	if len(schemaErrors) == 0 || schemaErrors[0].Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("Code = %+v, want SCH_REQUIRED_FIELD_MISSING", schemaErrors)
+	}
 }
 
 func TestValidateReferencedObject_DomainNotAllowed(t *testing.T) {
 	cache := newSchemaCache(10)
 	ctx := context.Background()
-	
+
 	obj := referencedObject{
 		Path:    "message.test",
 		Context: "https://malicious.com/schema.yaml",
 		Type:    "TestType",
 		Data:    map[string]interface{}{},
 	}
-	
+
 	allowedDomains := []string{"trusted.com"}
-	
+
 	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "domain not allowed")
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_INVALID_JSONLD_CONTEXT" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_JSONLD_CONTEXT", err, err)
+	}
+}
+
+func TestValidateReferencedObject_EntityTypeNotFound(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	tmpFile, err := os.CreateTemp("", "test-schema-*.yaml")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	schemaContent := `openapi: 3.1.0
+info:
+  title: Test Schema
+  version: 1.0.0
+components:
+  schemas:
+    TestType:
+      type: object`
+
+	tmpFile.Write([]byte(schemaContent))
+	tmpFile.Close()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: tmpFile.Name(),
+		Type:    "NonExistentType",
+		Data: map[string]interface{}{
+			"@context": tmpFile.Name(),
+			"@type":    "NonExistentType",
+		},
+	}
+
+	err = cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
+	assert.Error(t, err)
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_INVALID_ENTITY_TYPE" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_ENTITY_TYPE", err, err)
+	}
+}
+
+func TestValidateReferencedObject_SchemaLoadFailure(t *testing.T) {
+	cache := newSchemaCache(10)
+	ctx := context.Background()
+
+	obj := referencedObject{
+		Path:    "message.test",
+		Context: "/nonexistent/schema.yaml",
+		Type:    "TestType",
+		Data:    map[string]interface{}{},
+	}
+
+	err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, nil, false)
+	assert.Error(t, err)
+
+	becknErr, ok := err.(*model.Error)
+	if !ok || becknErr.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
+		t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_SCHEMA_ADAPTATION_FAILED", err, err)
+	}
 }
 
 func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testing.T) {
@@ -718,6 +789,11 @@ func TestValidateReferencedObject_NonHttpSchemeRejectedWhenAllowlistSet(t *testi
 			err := cache.validateReferencedObject(ctx, obj, 1*time.Hour, 30*time.Second, allowedDomains, false)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid scheme in @context")
+
+			becknErr, ok := err.(*model.Error)
+			if !ok || becknErr.Code != "SCH_INVALID_JSONLD_CONTEXT" {
+				t.Errorf("err = %+v (%T), want *model.Error with Code=SCH_INVALID_JSONLD_CONTEXT", err, err)
+			}
 		})
 	}
 }
@@ -814,6 +890,50 @@ func TestValidateExtendedSchemas_MissingMessage(t *testing.T) {
 	err := v.validateExtendedSchemas(ctx, body)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing 'message' field")
+}
+
+// TestValidateExtendedSchemas_DomainNotAllowed_PropagatesCode drives a real
+// domain-object validation failure through the full production path
+// (validateExtendedSchemas -> validateReferencedObject -> extractSchemaErrors'
+// *model.Error passthrough branch -> prefixSchemaErrorPaths), confirming the
+// classified code and path both survive end-to-end — not just at the unit
+// level of validateReferencedObject or extractSchemaErrors individually.
+func TestValidateExtendedSchemas_DomainNotAllowed_PropagatesCode(t *testing.T) {
+	v := &schemav2Validator{
+		config: &Config{
+			EnableExtendedSchema: true,
+			ExtendedSchemaConfig: ExtendedSchemaConfig{
+				AllowedDomains: []string{"trusted.com"},
+			},
+		},
+		schemaCache: newSchemaCache(10),
+	}
+
+	ctx := context.Background()
+	body := map[string]interface{}{
+		"message": map[string]interface{}{
+			"order": map[string]interface{}{
+				"@context": "https://malicious.com/schema.yaml",
+				"@type":    "SomeType",
+			},
+		},
+	}
+
+	err := v.validateExtendedSchemas(ctx, body)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSONLD_CONTEXT" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSONLD_CONTEXT", schemaErr.Errors)
+	}
+	if schemaErr.Errors[0].Details == nil || schemaErr.Errors[0].Details.Path == "" {
+		t.Errorf("Details = %+v, want a non-empty Path from prefixSchemaErrorPaths", schemaErr.Errors[0].Details)
+	}
 }
 
 func TestPrefixSchemaErrorPaths(t *testing.T) {

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -560,10 +560,11 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			}
 		}
 
-		*schemaErrors = append(*schemaErrors, model.Error{
-			Paths:   path,
-			Message: message,
-		})
+		errItem := model.Error{Message: message}
+		if path != "" {
+			errItem.Details = &model.ErrorDetails{Path: path}
+		}
+		*schemaErrors = append(*schemaErrors, errItem)
 	} else if multiErr, ok := err.(openapi3.MultiError); ok {
 		// Nested MultiError
 		for _, e := range multiErr {
@@ -572,7 +573,6 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 	} else {
 		// Generic error
 		*schemaErrors = append(*schemaErrors, model.Error{
-			Paths:   "",
 			Message: err.Error(),
 		})
 	}

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator.go
@@ -161,7 +161,9 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 	var payloadData payload
 	err := json.Unmarshal(data, &payloadData)
 	if err != nil {
-		return model.NewBadReqErr(fmt.Errorf("failed to parse JSON payload: %v", err))
+		return &model.SchemaValidationErr{Errors: []model.Error{
+			*model.NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("failed to parse JSON payload: %v", err)),
+		}}
 	}
 
 	if payloadData.Context.Action == "" {
@@ -189,7 +191,9 @@ func (v *schemav2Validator) Validate(ctx context.Context, reqURL *url.URL, data 
 
 	var jsonData any
 	if err := json.Unmarshal(data, &jsonData); err != nil {
-		return model.NewBadReqErr(fmt.Errorf("invalid JSON: %v", err))
+		return &model.SchemaValidationErr{Errors: []model.Error{
+			*model.NewCodedError("SCH_INVALID_JSON", fmt.Sprintf("invalid JSON: %v", err)),
+		}}
 	}
 
 	opts := []openapi3.SchemaValidationOption{
@@ -528,9 +532,39 @@ func (v *schemav2Validator) formatValidationError(err error) error {
 	return &model.SchemaValidationErr{Errors: schemaErrors}
 }
 
+// schemaFieldCodes maps an openapi3.SchemaError's SchemaField (the JSON-schema
+// keyword that failed) to the corresponding Beckn v2.0.0 SCH_* code.
+var schemaFieldCodes = map[string]string{
+	"required": "SCH_REQUIRED_FIELD_MISSING",
+	// kin-openapi uses SchemaField "properties" specifically for the
+	// additionalProperties-disallowed case ("property %q is unsupported").
+	"properties": "SCH_FIELD_NOT_ALLOWED",
+	"enum":       "SCH_INVALID_ENUM",
+	// "const" is JSON Schema's own sugar for an enum with a single allowed
+	// value — there is no dedicated SCH_* code for it, so it shares enum's.
+	"const":  "SCH_INVALID_ENUM",
+	"format": "SCH_INVALID_FORMAT",
+	"type":   "SCH_TYPE_NOT_SUPPORTED",
+}
+
+// schemaFieldToCode looks up schemaFieldCodes. Composite keywords
+// (oneOf/anyOf/allOf) and any constraint without a dedicated code fall back
+// to SCH_SCHEMA_VALIDATION_FAILED, since kin-openapi doesn't attribute those
+// to one single underlying cause.
+func schemaFieldToCode(schemaField string) string {
+	if code, ok := schemaFieldCodes[schemaField]; ok {
+		return code
+	}
+	return "SCH_SCHEMA_VALIDATION_FAILED"
+}
+
 // extractSchemaErrors recursively extracts detailed error information from SchemaError.
 func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model.Error) {
-	if schemaErr, ok := err.(*openapi3.SchemaError); ok {
+	if becknErr, ok := err.(*model.Error); ok {
+		// Already a fully-classified error (e.g. from validateReferencedObject's
+		// domain/JSON-LD checks) — pass it through as-is.
+		*schemaErrors = append(*schemaErrors, *becknErr)
+	} else if schemaErr, ok := err.(*openapi3.SchemaError); ok {
 		// Extract path from current error and message from Origin if available
 		pathParts := schemaErr.JSONPointer()
 		path := strings.Join(pathParts, "/")
@@ -560,21 +594,19 @@ func (v *schemav2Validator) extractSchemaErrors(err error, schemaErrors *[]model
 			}
 		}
 
-		errItem := model.Error{Message: message}
+		errItem := model.NewCodedError(schemaFieldToCode(schemaErr.SchemaField), message)
 		if path != "" {
 			errItem.Details = &model.ErrorDetails{Path: path}
 		}
-		*schemaErrors = append(*schemaErrors, errItem)
+		*schemaErrors = append(*schemaErrors, *errItem)
 	} else if multiErr, ok := err.(openapi3.MultiError); ok {
 		// Nested MultiError
 		for _, e := range multiErr {
 			v.extractSchemaErrors(e, schemaErrors)
 		}
 	} else {
-		// Generic error
-		*schemaErrors = append(*schemaErrors, model.Error{
-			Message: err.Error(),
-		})
+		// Generic error — no schema keyword to classify against.
+		*schemaErrors = append(*schemaErrors, *model.NewCodedError("SCH_SCHEMA_VALIDATION_FAILED", err.Error()))
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -2,6 +2,7 @@ package schemav2validator
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,6 +10,8 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // testSpecBodyless mirrors the Beckn 2.0 /catalog/subscription path which
@@ -262,6 +265,45 @@ func TestValidate_NestedValidation(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestValidate_SchemaErrorDetails confirms extractSchemaErrors only attaches
+// Details when the underlying validation cause has a non-empty path — never
+// a non-nil Details with an empty Path (the fix for issue #862's finding #5).
+func TestValidate_SchemaErrorDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"select"},"message":{}}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) == 0 {
+		t.Fatal("expected at least one schema error")
+	}
+
+	hasDetails := false
+	for _, got := range schemaErr.Errors {
+		t.Logf("Details = %+v", got.Details)
+		if got.Details != nil && got.Details.Path == "" {
+			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
+		}
+		if got.Details != nil && got.Details.Path != "" {
+			hasDetails = true
+		}
+	}
+	if !hasDetails {
+		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
 	}
 }
 

--- a/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
+++ b/pkg/plugin/implementation/schemav2validator/schemav2validator_test.go
@@ -8,10 +8,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // testSpecBodyless mirrors the Beckn 2.0 /catalog/subscription path which
@@ -294,7 +296,7 @@ func TestValidate_SchemaErrorDetails(t *testing.T) {
 
 	hasDetails := false
 	for _, got := range schemaErr.Errors {
-		t.Logf("Details = %+v", got.Details)
+		t.Logf("Code = %s, Details = %+v", got.Code, got.Details)
 		if got.Details != nil && got.Details.Path == "" {
 			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
 		}
@@ -304,6 +306,235 @@ func TestValidate_SchemaErrorDetails(t *testing.T) {
 	}
 	if !hasDetails {
 		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
+	}
+
+	// "message.order" is required and missing — SchemaField "required" must
+	// map to SCH_REQUIRED_FIELD_MISSING.
+	if schemaErr.Errors[0].Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("Code = %s, want SCH_REQUIRED_FIELD_MISSING", schemaErr.Errors[0].Code)
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Code != "SCH_REQUIRED_FIELD_MISSING" {
+		t.Errorf("aggregate Code = %s, want SCH_REQUIRED_FIELD_MISSING (first non-empty per-cause code)", beErr.Code)
+	}
+}
+
+func TestSchemaFieldToCode(t *testing.T) {
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{"required", "SCH_REQUIRED_FIELD_MISSING"},
+		{"properties", "SCH_FIELD_NOT_ALLOWED"},
+		{"enum", "SCH_INVALID_ENUM"},
+		{"const", "SCH_INVALID_ENUM"},
+		{"format", "SCH_INVALID_FORMAT"},
+		{"type", "SCH_TYPE_NOT_SUPPORTED"},
+		{"allOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"oneOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"anyOf", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"pattern", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"", "SCH_SCHEMA_VALIDATION_FAILED"},
+		{"unknown-keyword", "SCH_SCHEMA_VALIDATION_FAILED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			if got := schemaFieldToCode(tt.field); got != tt.want {
+				t.Errorf("schemaFieldToCode(%q) = %s, want %s", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSON" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSON", schemaErr.Errors)
+	}
+
+	beErr := schemaErr.BecknError()
+	if beErr.Code != "SCH_INVALID_JSON" {
+		t.Errorf("aggregate Code = %s, want SCH_INVALID_JSON", beErr.Code)
+	}
+}
+
+// TestValidate_NumericOverflowFailsSecondUnmarshal exercises Validate()'s
+// second json.Unmarshal call (into `any`, for schema validation) failing
+// independently of the first (into the narrow `payload` struct, used only to
+// extract context.action). A numeric literal outside float64 range decodes
+// fine into `payload` — which ignores unrelated fields — but fails when
+// decoded into `any`, which must convert every value.
+func TestValidate_NumericOverflowFailsSecondUnmarshal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testSpec))
+	}))
+	defer server.Close()
+
+	validator, _, err := New(context.Background(), &Config{Type: "url", Location: server.URL, CacheTTL: 3600})
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = validator.Validate(context.Background(), nil, []byte(`{"context":{"action":"select"},"message":{"order":{}},"extra":1e400}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) != 1 || schemaErr.Errors[0].Code != "SCH_INVALID_JSON" {
+		t.Errorf("Errors = %+v, want one entry with Code=SCH_INVALID_JSON", schemaErr.Errors)
+	}
+}
+
+// TestExtractSchemaErrors_CompositeOriginFallsBackToGeneric exercises the
+// Origin != nil branch (oneOf/anyOf/allOf composite failures), previously
+// uncovered by any test. Since kin-openapi attributes the failure to the
+// composite keyword itself (not the nested cause), classification correctly
+// falls back to the generic SCH_SCHEMA_VALIDATION_FAILED rather than
+// guessing at whichever nested branch failed.
+func TestExtractSchemaErrors_CompositeOriginFallsBackToGeneric(t *testing.T) {
+	sub := openapi3.NewObjectSchema().WithProperty("name", openapi3.NewStringSchema())
+	sub.Required = []string{"name"}
+
+	parent := openapi3.NewObjectSchema()
+	parent.AllOf = openapi3.SchemaRefs{openapi3.NewSchemaRef("", sub)}
+
+	err := parent.VisitJSON(map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.SchemaField != "allOf" || schemaErr.Origin == nil {
+		t.Fatalf("expected SchemaField=allOf with a non-nil Origin, got SchemaField=%s, Origin=%v", schemaErr.SchemaField, schemaErr.Origin)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	got := schemaErrors[0]
+	t.Logf("extracted = %+v", got)
+	if got.Code != "SCH_SCHEMA_VALIDATION_FAILED" {
+		t.Errorf("Code = %s, want SCH_SCHEMA_VALIDATION_FAILED", got.Code)
+	}
+	if got.Message == "" {
+		t.Error("Message = \"\", want a non-empty message describing the nested cause")
+	}
+}
+
+// TestExtractSchemaErrors_CompositeOriginParsesNestedFieldPath exercises the
+// "Error at \"/path\": reason" string-parsing branch specifically — triggered
+// when the nested cause inside an allOf/oneOf failure occurred on a property
+// deep enough to have a tagged reversePath. Previously uncovered by any test.
+func TestExtractSchemaErrors_CompositeOriginParsesNestedFieldPath(t *testing.T) {
+	innerSub := openapi3.NewObjectSchema().WithProperty("name", openapi3.NewStringSchema())
+	innerSub.Required = []string{"name"}
+	sub := openapi3.NewObjectSchema().WithProperty("nested", innerSub)
+
+	parent := openapi3.NewObjectSchema()
+	parent.AllOf = openapi3.SchemaRefs{openapi3.NewSchemaRef("", sub)}
+
+	err := parent.VisitJSON(map[string]interface{}{"nested": map[string]interface{}{}})
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.Origin == nil || !strings.Contains(schemaErr.Origin.Error(), `Error at "`) {
+		t.Fatalf(`expected Origin.Error() to contain 'Error at "', got: %v`, schemaErr.Origin)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	got := schemaErrors[0]
+	t.Logf("extracted = %+v", got)
+	if got.Details == nil || got.Details.Path != "nested/name" {
+		t.Errorf("Details = %+v, want Path=nested/name", got.Details)
+	}
+	// kin-openapi's SchemaError.Error() appends a verbose schema/value dump
+	// after the reason — check the extracted reason is the prefix, not an
+	// exact match against that library-formatted tail.
+	if !strings.HasPrefix(got.Message, `property "name" is missing`) {
+		t.Errorf("Message = %q, want it to start with %q", got.Message, `property "name" is missing`)
+	}
+}
+
+// TestExtractSchemaErrors_ConstViolation confirms a JSON-schema "const"
+// violation — SchemaField "const", no dedicated SCH_* code in the taxonomy —
+// classifies as SCH_INVALID_ENUM, since const is enum-of-one.
+func TestExtractSchemaErrors_ConstViolation(t *testing.T) {
+	sub := openapi3.NewStringSchema()
+	sub.Const = "search"
+
+	err := sub.VisitJSON("select")
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	schemaErr, ok := err.(*openapi3.SchemaError)
+	if !ok {
+		t.Fatalf("expected *openapi3.SchemaError, got %T: %v", err, err)
+	}
+	if schemaErr.SchemaField != "const" {
+		t.Fatalf("expected SchemaField=const, got %s", schemaErr.SchemaField)
+	}
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(err, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	if got := schemaErrors[0].Code; got != "SCH_INVALID_ENUM" {
+		t.Errorf("Code = %s, want SCH_INVALID_ENUM", got)
+	}
+}
+
+// TestExtractSchemaErrors_BecknErrorPassthrough closes the coverage gap on
+// extractSchemaErrors' *model.Error passthrough branch (used to carry
+// validateReferencedObject's already-classified domain/JSON-LD/@type errors
+// into the aggregate SchemaValidationErr) — previously exercised by no test.
+func TestExtractSchemaErrors_BecknErrorPassthrough(t *testing.T) {
+	original := model.NewCodedError("SCH_INVALID_JSONLD_CONTEXT", "domain not allowed: malicious.com")
+
+	v := &schemav2Validator{}
+	var schemaErrors []model.Error
+	v.extractSchemaErrors(original, &schemaErrors)
+
+	if len(schemaErrors) != 1 {
+		t.Fatalf("expected exactly one extracted error, got %d: %+v", len(schemaErrors), schemaErrors)
+	}
+	if schemaErrors[0] != *original {
+		t.Errorf("extractSchemaErrors did not pass through *model.Error as-is: got %+v, want %+v", schemaErrors[0], *original)
 	}
 }
 

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator.go
@@ -104,10 +104,11 @@ func (v *schemaValidator) Validate(ctx context.Context, reqURL *url.URL, data []
 				message := cause.Error()                          // Validation error message
 
 				// Append the error to the schemaErrors array
-				schemaErrors = append(schemaErrors, model.Error{
-					Paths:   path,
-					Message: message,
-				})
+				errItem := model.Error{Message: message}
+				if path != "" {
+					errItem.Details = &model.ErrorDetails{Path: path}
+				}
+				schemaErrors = append(schemaErrors, errItem)
 			}
 			// Return the array of schema validation errors
 			return &model.SchemaValidationErr{Errors: schemaErrors}

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator_test.go
@@ -2,12 +2,14 @@ package schemavalidator
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -145,6 +147,49 @@ func TestValidator_Validate_Failure(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestValidator_Validate_SchemaErrorDetails confirms Validate() attaches
+// Details with the JSON-schema cause's path through the real code path
+// (extractSchemaErrors is inlined here, not a separately-testable helper).
+// Note: setupTestSchema's schema only requires "context" at the root, so a
+// root-level (empty-path) cause never occurs for THIS test's schema — that is
+// not a general property of Validate() itself. Validate() never independently
+// checks for a top-level "message" field before calling schema.Validate(), so
+// a real schema requiring ["context", "message"] at root (as this plugin's
+// own README documents) could still produce a root-level cause with no path.
+func TestValidator_Validate_SchemaErrorDetails(t *testing.T) {
+	schemaDir := setupTestSchema(t)
+	defer os.RemoveAll(schemaDir)
+
+	config := &Config{SchemaDir: schemaDir}
+	v, _, err := New(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Failed to create validator: %v", err)
+	}
+
+	err = v.Validate(context.Background(), &url.URL{Path: "endpoint"}, []byte(`{"context": {"domain": "example", "version": "1.0"}}`))
+
+	var schemaErr *model.SchemaValidationErr
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("expected *model.SchemaValidationErr, got %T: %v", err, err)
+	}
+	if len(schemaErr.Errors) == 0 {
+		t.Fatal("expected at least one schema error")
+	}
+
+	hasDetails := false
+	for _, got := range schemaErr.Errors {
+		if got.Details != nil && got.Details.Path == "" {
+			t.Errorf("Details = %+v, want either nil or a non-empty Path — never a non-nil Details with an empty Path", got.Details)
+		}
+		if got.Details != nil && got.Details.Path != "" {
+			hasDetails = true
+		}
+	}
+	if !hasDetails {
+		t.Error("expected at least one schema error with a non-nil Details and a non-empty Path, got none")
 	}
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/README.md
+++ b/pkg/plugin/implementation/schemaversionmediator/README.md
@@ -24,7 +24,7 @@
 
 On every inbound request, `Mediate` runs the following sequence:
 
-1. **Cold-start guard** — if the local node manifest was absent, unreachable, or had no `schemaObjects` at startup (or if `nodeId` was not set in config), every call is rejected immediately with `subscriberNotOnboarded`.
+1. **Cold-start guard** — if the local node manifest was absent, unreachable, or had no `schemaObjects` at startup (or if `nodeId` was not set in config), every call is rejected immediately with `SCH_SUBSCRIBER_NOT_FOUND`.
 2. **Identity extraction** — reads `networkId`/`network_id` from the payload `context` block; reads the counterparty subscriber ID from `ContextKeyRemoteID` (set by `reqpreprocessor`). If either is empty the payload passes through unchanged.
 3. **Target manifest selection** — direction-aware:
    - **Receiver handler** (`bapTxnReceiver`, `bppTxnReceiver`): uses the local node manifest loaded at startup. No network call at request time.
@@ -32,7 +32,7 @@ On every inbound request, `Mediate` runs the following sequence:
 4. **Compatibility check** — walks the payload for `@context`+`@type` pairs and compares them against the target manifest's `schemaObjects`. If all objects are at a supported version, the payload passes through unchanged.
 5. **Artifact fetch** — for each incompatible schema object, derives the artifact URL from the target manifest's `baseUrl`, canonical version, and the source version, then fetches it over HTTP.
 6. **Translation** — composes the fetched artifacts into a single JSONata expression (`$merge([$, patch1, patch2, ...])`) and executes it against the `message` subtree of the payload in one pass.
-7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `schemaTranslationDataLoss`.
+7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `SCH_ADAPTATION_FAILED`.
 8. **Patch** — replaces the `message` field in `ctx.Body` with the translated output.
 
 ---
@@ -78,11 +78,11 @@ plugins:
 **`action` values:**
 
 - `translate` — attempt translation for each incompatible schema object; apply `onFailure` if any artifact is unavailable.
-- `reject` — return `schemaIncompatible` immediately without attempting translation.
+- `reject` — return `SCH_ADAPTATION_FAILED` immediately without attempting translation.
 
 **`onFailure` values (only evaluated when `action=translate`):**
 
-- `reject` — return `schemaIncompatible` when an artifact cannot be fetched.
+- `reject` — return `SCH_ADAPTATION_FAILED` when an artifact cannot be fetched.
 - `passThrough` — forward the untranslated payload. Operator escape hatch for false-mismatch situations (e.g. stale local manifest during rollout). Not recommended for production.
 
 ---
@@ -134,7 +134,7 @@ At startup, `New` calls `ManifestLoader.GetBySubscriberID` using the `nodeId` co
 - The manifest document cannot be fetched or parsed
 - The manifest contains no `schemaObjects`
 
-While `notOnboarded` is set, every `Mediate` call returns `subscriberNotOnboarded` immediately. The adapter must be restarted after the local node manifest is published to DeDi and `nodeId` is correctly set in config.
+While `notOnboarded` is set, every `Mediate` call returns `SCH_SUBSCRIBER_NOT_FOUND` immediately. The adapter must be restarted after the local node manifest is published to DeDi and `nodeId` is correctly set in config.
 
 ---
 
@@ -214,13 +214,13 @@ The artifact at that URL must contain a JSONata expression that transforms a `v2
 
 ## Error Codes
 
-All errors returned by `Mediate` are of type `*MediationError`, which carries a camelCase `Code` field. The handler uses this to build a structured Beckn NACK response.
+All errors returned by `Mediate` are of type `*MediationError`, which carries a `Code` field aligned with the Beckn v2.0.0 `ErrorCode` taxonomy's `SCH_*` prefix. Note: `MediationError` is not yet wired into the handler's NACK-building dispatch (`nackBecknError`) — today these codes are not surfaced on the wire; a `MediationError` currently falls through to a generic internal-error NACK.
 
 | Code | Cause | Resolution |
 |---|---|---|
-| `subscriberNotOnboarded` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
-| `schemaIncompatible` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
-| `schemaTranslationDataLoss` | Translation dropped fields present in the source payload | Review translation artifact — it must not remove fields from the source |
+| `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
+| `SCH_ADAPTATION_FAILED` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
+| `SCH_ADAPTATION_FAILED` | Translation dropped fields present in the source payload (not yet implemented — no code path currently constructs this case) | Review translation artifact — it must not remove fields from the source |
 
 Plain (non-`MediationError`) errors may also be returned for malformed payloads (e.g. missing `message` field). The handler treats these as HTTP 400 Bad Request with a generic error body — distinct from the structured NACK produced by `MediationError`.
 
@@ -240,7 +240,7 @@ Artifacts are cached in memory with configurable positive and negative TTLs. The
 
 After translation, the plugin compares the flattened dot-notation key paths of the source `message` subtree against the translated output. Any key present in the source but absent in the output is considered a dropped field.
 
-**Current behaviour:** data loss always causes rejection with `schemaTranslationDataLoss`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
+**Current behaviour:** data loss always causes rejection with `SCH_ADAPTATION_FAILED`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
 
 **Array handling:** array elements are treated as opaque leaf values. Element-level drops within an array are not detected — only object key presence is compared.
 

--- a/pkg/plugin/implementation/schemaversionmediator/README.md
+++ b/pkg/plugin/implementation/schemaversionmediator/README.md
@@ -32,7 +32,7 @@ On every inbound request, `Mediate` runs the following sequence:
 4. **Compatibility check** — walks the payload for `@context`+`@type` pairs and compares them against the target manifest's `schemaObjects`. If all objects are at a supported version, the payload passes through unchanged.
 5. **Artifact fetch** — for each incompatible schema object, derives the artifact URL from the target manifest's `baseUrl`, canonical version, and the source version, then fetches it over HTTP.
 6. **Translation** — composes the fetched artifacts into a single JSONata expression (`$merge([$, patch1, patch2, ...])`) and executes it against the `message` subtree of the payload in one pass.
-7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `SCH_ADAPTATION_FAILED`.
+7. **Data-loss detection** — compares flattened key paths of the source and translated message. If any source keys are absent in the output, the request is rejected with `SCH_SCHEMA_ADAPTATION_FAILED`.
 8. **Patch** — replaces the `message` field in `ctx.Body` with the translated output.
 
 ---
@@ -78,11 +78,11 @@ plugins:
 **`action` values:**
 
 - `translate` — attempt translation for each incompatible schema object; apply `onFailure` if any artifact is unavailable.
-- `reject` — return `SCH_ADAPTATION_FAILED` immediately without attempting translation.
+- `reject` — return `SCH_SCHEMA_ADAPTATION_FAILED` immediately without attempting translation.
 
 **`onFailure` values (only evaluated when `action=translate`):**
 
-- `reject` — return `SCH_ADAPTATION_FAILED` when an artifact cannot be fetched.
+- `reject` — return `SCH_SCHEMA_ADAPTATION_FAILED` when an artifact cannot be fetched.
 - `passThrough` — forward the untranslated payload. Operator escape hatch for false-mismatch situations (e.g. stale local manifest during rollout). Not recommended for production.
 
 ---
@@ -214,13 +214,12 @@ The artifact at that URL must contain a JSONata expression that transforms a `v2
 
 ## Error Codes
 
-All errors returned by `Mediate` are of type `*MediationError`, which carries a `Code` field aligned with the Beckn v2.0.0 `ErrorCode` taxonomy's `SCH_*` prefix. Note: `MediationError` is not yet wired into the handler's NACK-building dispatch (`nackBecknError`) — today these codes are not surfaced on the wire; a `MediationError` currently falls through to a generic internal-error NACK.
+All errors returned by `Mediate` are of type `*MediationError`, which carries a `Code` field aligned with the Beckn v2.0.0 `ErrorCode` taxonomy's `SCH_*` prefix. `MediationError` implements `model.BecknErrorer`, so the handler's NACK-building dispatch (`nackBecknError`) recognizes it and surfaces its Code/Message as a proper NACK response, at HTTP 400 Bad Request.
 
 | Code | Cause | Resolution |
 |---|---|---|
 | `SCH_SUBSCRIBER_NOT_FOUND` | Local node manifest absent or has no `schemaObjects` at startup | Publish node manifest to DeDi and restart the adapter |
-| `SCH_ADAPTATION_FAILED` | Incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject` | Check counterparty manifest in DeDi; verify artifact URLs are reachable |
-| `SCH_ADAPTATION_FAILED` | Translation dropped fields present in the source payload (not yet implemented — no code path currently constructs this case) | Review translation artifact — it must not remove fields from the source |
+| `SCH_SCHEMA_ADAPTATION_FAILED` | Two causes share this code: (1) incompatible schema objects found and `action=reject`, or artifact fetch failed and `onFailure=reject`; (2) translation dropped fields present in the source payload (not yet implemented — no code path currently constructs this case) | Check counterparty manifest in DeDi and verify artifact URLs are reachable; for (2), review the translation artifact — it must not remove fields from the source |
 
 Plain (non-`MediationError`) errors may also be returned for malformed payloads (e.g. missing `message` field). The handler treats these as HTTP 400 Bad Request with a generic error body — distinct from the structured NACK produced by `MediationError`.
 
@@ -240,7 +239,7 @@ Artifacts are cached in memory with configurable positive and negative TTLs. The
 
 After translation, the plugin compares the flattened dot-notation key paths of the source `message` subtree against the translated output. Any key present in the source but absent in the output is considered a dropped field.
 
-**Current behaviour:** data loss always causes rejection with `SCH_ADAPTATION_FAILED`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
+**Current behaviour:** data loss always causes rejection with `SCH_SCHEMA_ADAPTATION_FAILED`, listing the dropped field paths. There is no configurable policy — this is intentional. A partially translated payload is as harmful as an incompatible one.
 
 **Array handling:** array elements are treated as opaque leaf values. Element-level drops within an array are not detected — only object key presence is compared.
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -480,7 +480,7 @@ func (m *mediator) Mediate(ctx *model.StepContext) error {
 
 	if m.policy.Action == PolicyActionReject {
 		return &MediationError{
-			Code:    "SCH_ADAPTATION_FAILED",
+			Code:    "SCH_SCHEMA_ADAPTATION_FAILED",
 			Message: fmt.Sprintf("payload contains %d incompatible schema object(s) and policy is reject", len(needs)),
 		}
 	}
@@ -586,7 +586,7 @@ func (m *mediator) applyOnFailure(cause error) error {
 		return nil
 	}
 	return &MediationError{
-		Code:    "SCH_ADAPTATION_FAILED",
+		Code:    "SCH_SCHEMA_ADAPTATION_FAILED",
 		Message: "schema version mediation failed; check adapter logs for details",
 		cause:   cause,
 	}
@@ -646,7 +646,7 @@ func patchMessageSubtree(body, translated []byte) ([]byte, error) {
 type MediationError struct {
 	Code          string
 	Message       string
-	DroppedFields []string // non-nil only for SCH_ADAPTATION_FAILED (data-loss variant)
+	DroppedFields []string // non-nil only for SCH_SCHEMA_ADAPTATION_FAILED (data-loss variant)
 	cause         error    // internal; use errors.Unwrap to access
 }
 
@@ -658,6 +658,14 @@ func (e *MediationError) Error() string {
 }
 
 func (e *MediationError) Unwrap() error { return e.cause }
+
+// BecknError converts the MediationError into the shared *model.Error NACK
+// payload, implementing model.BecknErrorer so nackBecknError
+// (core/module/handler/responsestep.go) surfaces this Code/Message on the
+// wire instead of falling through to a generic 500 Internal Server Error.
+func (e *MediationError) BecknError() *model.Error {
+	return &model.Error{Code: e.Code, Message: e.Error()}
+}
 
 // droppedFields returns the sorted set of dot-notation key paths that are
 // present in src but absent in dst. Both must be JSON object bytes.

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator.go
@@ -430,7 +430,7 @@ func (p *provider) New(ctx context.Context, loader definition.ManifestLoader, cf
 func (m *mediator) Mediate(ctx *model.StepContext) error {
 	if m.notOnboarded {
 		return &MediationError{
-			Code:    "subscriberNotOnboarded",
+			Code:    "SCH_SUBSCRIBER_NOT_FOUND",
 			Message: "Local node manifest is missing or has no schemaObjects. Publish your manifest to DeDi before going live.",
 		}
 	}
@@ -480,7 +480,7 @@ func (m *mediator) Mediate(ctx *model.StepContext) error {
 
 	if m.policy.Action == PolicyActionReject {
 		return &MediationError{
-			Code:    "schemaIncompatible",
+			Code:    "SCH_ADAPTATION_FAILED",
 			Message: fmt.Sprintf("payload contains %d incompatible schema object(s) and policy is reject", len(needs)),
 		}
 	}
@@ -586,7 +586,7 @@ func (m *mediator) applyOnFailure(cause error) error {
 		return nil
 	}
 	return &MediationError{
-		Code:    "schemaIncompatible",
+		Code:    "SCH_ADAPTATION_FAILED",
 		Message: "schema version mediation failed; check adapter logs for details",
 		cause:   cause,
 	}
@@ -646,7 +646,7 @@ func patchMessageSubtree(body, translated []byte) ([]byte, error) {
 type MediationError struct {
 	Code          string
 	Message       string
-	DroppedFields []string // non-nil only for schemaTranslationDataLoss
+	DroppedFields []string // non-nil only for SCH_ADAPTATION_FAILED (data-loss variant)
 	cause         error    // internal; use errors.Unwrap to access
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -1321,8 +1321,8 @@ func TestMediate_NotOnboarded(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "subscriberNotOnboarded" {
-		t.Errorf("expected subscriberNotOnboarded, got %q", me.Code)
+	if me.Code != "SCH_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("expected SCH_SUBSCRIBER_NOT_FOUND, got %q", me.Code)
 	}
 }
 
@@ -1350,8 +1350,8 @@ func TestMediate_CounterpartyManifestUnavailable_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1405,8 +1405,8 @@ func TestMediate_ActionReject_OnIncompatible(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1434,8 +1434,8 @@ func TestMediate_ArtifactNotFound_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "schemaIncompatible" {
-		t.Errorf("expected schemaIncompatible, got %q", me.Code)
+	if me.Code != "SCH_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 

--- a/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
+++ b/pkg/plugin/implementation/schemaversionmediator/schemaversionmediator_test.go
@@ -401,11 +401,11 @@ func TestIsVersionSegment(t *testing.T) {
 		{"retail", false},
 		{"", false},
 		{"v", false},
-		{"2", false},    // bare number with no dot must not match
-		{"v2", false},   // bare number with v prefix, no dot
-		{"v.", false},   // dot but no digits
-		{"v1.", false},  // trailing dot — digits only before dot
-		{"1.", false},   // trailing dot without v prefix
+		{"2", false},   // bare number with no dot must not match
+		{"v2", false},  // bare number with v prefix, no dot
+		{"v.", false},  // dot but no digits
+		{"v1.", false}, // trailing dot — digits only before dot
+		{"1.", false},  // trailing dot without v prefix
 		{"vX.Y", false},
 		{"order.jsonld", false},
 	}
@@ -1350,8 +1350,8 @@ func TestMediate_CounterpartyManifestUnavailable_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "SCH_ADAPTATION_FAILED" {
-		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
+	if me.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_SCHEMA_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1405,8 +1405,8 @@ func TestMediate_ActionReject_OnIncompatible(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "SCH_ADAPTATION_FAILED" {
-		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
+	if me.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_SCHEMA_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1434,8 +1434,8 @@ func TestMediate_ArtifactNotFound_Reject(t *testing.T) {
 	if !errors.As(err, &me) {
 		t.Fatalf("expected MediationError, got %T: %v", err, err)
 	}
-	if me.Code != "SCH_ADAPTATION_FAILED" {
-		t.Errorf("expected SCH_ADAPTATION_FAILED, got %q", me.Code)
+	if me.Code != "SCH_SCHEMA_ADAPTATION_FAILED" {
+		t.Errorf("expected SCH_SCHEMA_ADAPTATION_FAILED, got %q", me.Code)
 	}
 }
 
@@ -1728,7 +1728,7 @@ func TestMediate_TranslationApplied_MultipleObjectsDifferentPaths(t *testing.T) 
 	// Verifies each artifact is scoped to its own path and both are applied.
 	srv := artifactServer(t, map[string]string{
 		"/retail/v2.0/Offer_from_v1.0.jsonata":    `{"offerState": offerStatus}`,
-		"/retail/v2.0/Resource_from_v1.0.jsonata":  `{"resourceLabel": resourceName}`,
+		"/retail/v2.0/Resource_from_v1.0.jsonata": `{"resourceLabel": resourceName}`,
 	})
 	defer srv.Close()
 
@@ -1938,5 +1938,20 @@ func TestDroppedFields_NoneDropped_Nested(t *testing.T) {
 	}
 	if len(dropped) != 0 {
 		t.Errorf("expected no dropped fields, got %v", dropped)
+	}
+}
+
+func TestMediationError_BecknError(t *testing.T) {
+	var be model.BecknErrorer = &MediationError{
+		Code:    "SCH_SUBSCRIBER_NOT_FOUND",
+		Message: "no manifest published",
+	}
+
+	got := be.BecknError()
+	if got.Code != "SCH_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("Code = %s, want SCH_SUBSCRIBER_NOT_FOUND", got.Code)
+	}
+	if got.Message != be.Error() {
+		t.Errorf("Message = %q, want it to match Error(): %q", got.Message, be.Error())
 	}
 }

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -20,6 +20,21 @@ const (
 	maxClockSkewTolerance     = 10 * time.Second
 )
 
+// AUT_* codes reachable from this plugin's failure modes. AUT_RATE_LIMITED,
+// AUT_DOMAIN_NOT_ALLOWED, and AUT_REPLAY_DETECTED have no corresponding checks
+// in signvalidator today and are intentionally absent from this list.
+const (
+	// codeSignatureMissing covers an absent signature value in the Authorization header.
+	codeSignatureMissing = "AUT_SIGNATURE_MISSING"
+	// codeSignatureInvalid is the generic bucket for malformed headers, undecodable
+	// signature/key material, expired/not-yet-valid timestamp windows, and failed
+	// cryptographic verification — none of these have a more specific taxonomy value.
+	codeSignatureInvalid = "AUT_SIGNATURE_INVALID"
+	// codeUnauthorizedAction covers a cryptographically valid signature whose signer
+	// identity does not match the identity declared in the request context.
+	codeUnauthorizedAction = "AUT_UNAUTHORIZED_ACTION"
+)
+
 // Config struct for Verifier.
 type Config struct {
 	// ClockSkewTolerance is the maximum future drift allowed for the `created`
@@ -53,12 +68,16 @@ func New(ctx context.Context, config *Config) (*validator, func() error, error) 
 func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(header)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error parsing header: %w", err))
+		// parseAuthHeader always returns an already-classified *model.SignValidationErr;
+		// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As still
+		// finds that inner classification instead of shadowing it with a new, less
+		// specific wrapper.
+		return fmt.Errorf("error parsing header: %w", err)
 	}
 
 	signatureBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
-		return fmt.Errorf("error decoding signature: %w", err)
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding signature: %w", err))
 	}
 
 	if err := checkTimestampWindow("signature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
@@ -72,11 +91,11 @@ func (v *validator) Validate(ctx *model.StepContext, header string, publicKeyBas
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error decoding public key: %w", err))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding public key: %w", err))
 	}
 
 	if !ed25519.Verify(ed25519.PublicKey(decodedPublicKey), []byte(signingString), signatureBytes) {
-		return model.NewSignValidationErr(fmt.Errorf("signature verification failed"))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("signature verification failed"))
 	}
 
 	if checkIdentity {
@@ -105,24 +124,22 @@ func parseAuthHeader(header string) (int64, int64, string, string, error) {
 	}
 
 	if signatureMap["algorithm"] != "ed25519" {
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("unsupported algorithm %q: only ed25519 is permitted", signatureMap["algorithm"]))
 	}
 
 	createdTimestamp, err := strconv.ParseInt(signatureMap["created"], 10, 64)
 	if err != nil {
-		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", "", fmt.Errorf("invalid created timestamp: %w", err)
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("invalid created timestamp: %w", err))
 	}
 
 	expiredTimestamp, err := strconv.ParseInt(signatureMap["expires"], 10, 64)
 	if err != nil {
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("invalid expires timestamp: %w", err))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("invalid expires timestamp: %w", err))
 	}
 
 	signature := signatureMap["signature"]
 	if signature == "" {
-		// TODO: Return appropriate error code when Error Code Handling Module is ready
-		return 0, 0, "", "", model.NewSignValidationErr(fmt.Errorf("signature missing in header"))
+		return 0, 0, "", "", model.NewCodedSignValidationErr(codeSignatureMissing, fmt.Errorf("signature missing in header"))
 	}
 
 	var subscriberID string
@@ -141,12 +158,16 @@ func parseAuthHeader(header string) (int64, int64, string, string, error) {
 func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHeader, outboundAuthSignature, publicKeyBase64 string, checkIdentity bool) error {
 	createdTimestamp, expiredTimestamp, signature, subscriberID, err := parseAuthHeader(signatureHeader)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error parsing Signature header: %w", err))
+		// parseAuthHeader always returns an already-classified *model.SignValidationErr;
+		// wrap with plain fmt.Errorf (not model.NewSignValidationErr) so errors.As still
+		// finds that inner classification instead of shadowing it with a new, less
+		// specific wrapper.
+		return fmt.Errorf("error parsing Signature header: %w", err)
 	}
 
 	signatureBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
-		return fmt.Errorf("error decoding signature: %w", err)
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding signature: %w", err))
 	}
 
 	if err := checkTimestampWindow("AckSignature", createdTimestamp, expiredTimestamp, v.clockSkewTolerance); err != nil {
@@ -157,11 +178,11 @@ func (v *validator) ValidateAck(ctx *model.StepContext, body []byte, signatureHe
 
 	decodedPublicKey, err := base64.StdEncoding.DecodeString(publicKeyBase64)
 	if err != nil {
-		return model.NewSignValidationErr(fmt.Errorf("error decoding public key: %w", err))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("error decoding public key: %w", err))
 	}
 
 	if !ed25519.Verify(ed25519.PublicKey(decodedPublicKey), []byte(signingString), signatureBytes) {
-		return model.NewSignValidationErr(fmt.Errorf("AckSignature verification failed"))
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("AckSignature verification failed"))
 	}
 
 	if checkIdentity {
@@ -196,7 +217,7 @@ func checkSubscriberIdentity(ctx *model.StepContext, body []byte, signerID strin
 	}
 
 	if signerID != expected {
-		return model.NewSignValidationErr(fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
+		return model.NewCodedSignValidationErr(codeUnauthorizedAction, fmt.Errorf("subscriber identity mismatch: signing subscriber %q does not match declared context identity %q",
 			signerID, expected))
 	}
 	return nil
@@ -211,7 +232,7 @@ func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int6
 	// Accept created values up to clockSkewTolerance in the future.
 	deadline := now.Add(clockSkewTolerance)
 	if time.Unix(createdTimestamp, 0).UTC().After(deadline) {
-		return model.NewSignValidationErr(fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, overshoot=%ds",
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("%s not yet valid: created=%s, server_time=%s, tolerance=%ds, overshoot=%ds",
 			prefix,
 			time.Unix(createdTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),
@@ -221,7 +242,7 @@ func checkTimestampWindow(prefix string, createdTimestamp, expiredTimestamp int6
 	}
 	// expires: zero tolerance — reject without exception.
 	if now.Unix() > expiredTimestamp {
-		return model.NewSignValidationErr(fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
+		return model.NewCodedSignValidationErr(codeSignatureInvalid, fmt.Errorf("%s expired: expires=%s, server_time=%s, expired_by=%ds",
 			prefix,
 			time.Unix(expiredTimestamp, 0).UTC().Format(time.RFC3339),
 			now.Format(time.RFC3339),

--- a/pkg/plugin/implementation/signvalidator/signvalidator_test.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -214,18 +215,21 @@ func TestVerifyFailure(t *testing.T) {
 		header      string
 		pubKey      string
 		errContains string
+		wantCode    string
 	}{
 		{
-			name:   "Missing Authorization Header",
-			body:   []byte("Test Payload"),
-			header: "",
-			pubKey: publicKeyBase64,
+			name:     "Missing Authorization Header",
+			body:     []byte("Test Payload"),
+			header:   "",
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
-			name:   "Malformed Header",
-			body:   []byte("Test Payload"),
-			header: `InvalidSignature created="wrong"`,
-			pubKey: publicKeyBase64,
+			name:     "Malformed Header",
+			body:     []byte("Test Payload"),
+			header:   `InvalidSignature created="wrong"`,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Unsupported Algorithm",
@@ -233,7 +237,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="rsa", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="somesig=="`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Missing Algorithm",
@@ -241,7 +246,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="somesig=="`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Base64 Signature",
@@ -249,7 +255,8 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="!!INVALIDBASE64!!"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Expired Signature",
@@ -259,6 +266,7 @@ func TestVerifyFailure(t *testing.T) {
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix()-7200, time.Now().Unix()-3600) + `"`,
 			pubKey:      publicKeyBase64,
 			errContains: "expired_by=",
+			wantCode:    codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Public Key",
@@ -266,21 +274,24 @@ func TestVerifyFailure(t *testing.T) {
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) +
 				`", signature="` + signTestData(privateKeyBase64, []byte("Test Payload"), time.Now().Unix(), time.Now().Unix()+3600) + `"`,
-			pubKey: wrongPublicKeyBase64,
+			pubKey:   wrongPublicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Invalid Expires Timestamp",
 			body: []byte("Test Payload"),
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="invalid_timestamp"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureInvalid,
 		},
 		{
 			name: "Signature Missing in Headers",
 			body: []byte("Test Payload"),
 			header: `Signature algorithm="ed25519", created="` + strconv.FormatInt(time.Now().Unix(), 10) +
 				`", expires="` + strconv.FormatInt(time.Now().Unix()+3600, 10) + `"`,
-			pubKey: publicKeyBase64,
+			pubKey:   publicKeyBase64,
+			wantCode: codeSignatureMissing,
 		},
 	}
 
@@ -294,6 +305,13 @@ func TestVerifyFailure(t *testing.T) {
 			}
 			if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 				t.Fatalf("Expected error to contain %q, got: %v", tt.errContains, err)
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != tt.wantCode {
+				t.Errorf("signErr.Code = %s, want %s", signErr.Code, tt.wantCode)
 			}
 			if close != nil {
 				if err := close(); err != nil {
@@ -329,8 +347,16 @@ func TestValidate_SubIdentity_FromContext_Mismatch(t *testing.T) {
 
 	verifier, _, _ := New(context.Background(), &Config{})
 	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
-	if err := verifier.Validate(ctx, header, publicKey, true); err == nil {
+	err := verifier.Validate(ctx, header, publicKey, true)
+	if err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != codeUnauthorizedAction {
+		t.Errorf("signErr.Code = %s, want %s", signErr.Code, codeUnauthorizedAction)
 	}
 }
 
@@ -448,8 +474,16 @@ func TestValidateAck_SubIdentity_FromContext_Mismatch(t *testing.T) {
 
 	verifier, _, _ := New(context.Background(), &Config{})
 	ctx := makeCtxWithCallerID(body, model.RoleBPP, "bap.example.com")
-	if err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true); err == nil {
+	err := verifier.ValidateAck(ctx, body, header, outboundAuth, publicKey, true)
+	if err == nil {
 		t.Fatal("expected error: signer evil.com does not match callerID bap.example.com")
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != codeUnauthorizedAction {
+		t.Errorf("signErr.Code = %s, want %s", signErr.Code, codeUnauthorizedAction)
 	}
 }
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -60,6 +60,19 @@ var (
 
 	// ErrInvalidConfig indicates that the configuration is invalid.
 	ErrInvalidConfig = errors.New("invalid configuration")
+
+	// ErrKeyExpiredOrRevoked indicates that the matched subscriber's key exists but
+	// is no longer usable (registry status EXPIRED, UNSUBSCRIBED, or INVALID_SSL).
+	ErrKeyExpiredOrRevoked = errors.New("subscriber key is expired or revoked")
+)
+
+// AUT_* codes reachable from LookupNPKeys.
+const (
+	// codeSubscriberNotFound is used when the registry lookup returns zero results.
+	codeSubscriberNotFound = "AUT_SUBSCRIBER_NOT_FOUND"
+	// codeKeyExpiredOrRevoked is used when a matched subscriber's key is no
+	// longer usable per model.IsKeyStatusUsable.
+	codeKeyExpiredOrRevoked = "AUT_KEY_EXPIRED_OR_REVOKED"
 )
 
 // ValidateCfg validates the SimpleKeyManager configuration.
@@ -230,6 +243,12 @@ func (skm *SimpleKeyMgr) Keyset(ctx context.Context, keyID string) (*model.Keyse
 }
 
 // LookupNPKeys retrieves the signing and encryption public keys for the given subscriber ID and unique key ID.
+//
+// A zero-result lookup and a matched-but-unusable-status subscriber are both
+// AUT_* authentication failures, so both are returned already classified as
+// *model.SignValidationErr — the caller (signvalidator's validateSignStep)
+// propagates this as-is; it does not need to know keymanager's own sentinel
+// errors to build the correct NACK code.
 func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueKeyID string) (string, string, error) {
 	if err := validateParams(subscriberID, uniqueKeyID); err != nil {
 		return "", "", err
@@ -266,7 +285,10 @@ func (skm *SimpleKeyMgr) LookupNPKeys(ctx context.Context, subscriberID, uniqueK
 			return "", "", fmt.Errorf("failed to lookup registry: %w", err)
 		}
 		if len(subscribers) == 0 {
-			return "", "", ErrSubscriberNotFound
+			return "", "", model.NewCodedSignValidationErr(codeSubscriberNotFound, ErrSubscriberNotFound)
+		}
+		if !model.IsKeyStatusUsable(subscribers[0].Status) {
+			return "", "", model.NewCodedSignValidationErr(codeKeyExpiredOrRevoked, ErrKeyExpiredOrRevoked)
 		}
 	}
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -3,15 +3,23 @@ package simplekeymanager
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Mock implementations for testing
-type mockRegistry struct{}
+type mockRegistry struct {
+	// LookupFunc overrides the default lookup behavior when set.
+	LookupFunc func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error)
+}
 
 func (m *mockRegistry) Lookup(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+	if m.LookupFunc != nil {
+		return m.LookupFunc(ctx, sub)
+	}
 	return []model.Subscription{
 		{
 			Subscriber: model.Subscriber{
@@ -43,12 +51,12 @@ func TestValidateCfg(t *testing.T) {
 		{
 			name: "valid config with all keys",
 			cfg: &Config{
-				SubscriberID: "test-np",
-				KeyID:        "test-key",
-				SigningPrivateKey:  "dGVzdC1zaWduaW5nLXByaXZhdGU=",
-				SigningPublicKey:   "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				EncrPrivateKey:     "dGVzdC1lbmNyLXByaXZhdGU=",
-				EncrPublicKey:      "dGVzdC1lbmNyLXB1YmxpYw==",
+				SubscriberID:      "test-np",
+				KeyID:             "test-key",
+				SigningPrivateKey: "dGVzdC1zaWduaW5nLXByaXZhdGU=",
+				SigningPublicKey:  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
+				EncrPrivateKey:    "dGVzdC1lbmNyLXByaXZhdGU=",
+				EncrPublicKey:     "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
@@ -95,12 +103,12 @@ func TestNew(t *testing.T) {
 		{
 			name: "valid config with keys",
 			cfg: &Config{
-				SubscriberID:     "test-np",
-				KeyID:            "test-key",
+				SubscriberID:      "test-np",
+				KeyID:             "test-key",
 				SigningPrivateKey: "dGVzdC1zaWduaW5nLXByaXZhdGU=",
 				SigningPublicKey:  "dGVzdC1zaWduaW5nLXB1YmxpYw==",
-				EncrPrivateKey:   "dGVzdC1lbmNyLXByaXZhdGU=",
-				EncrPublicKey:    "dGVzdC1lbmNyLXB1YmxpYw==",
+				EncrPrivateKey:    "dGVzdC1lbmNyLXByaXZhdGU=",
+				EncrPublicKey:     "dGVzdC1lbmNyLXB1YmxpYw==",
 			},
 			wantErr: false,
 		},
@@ -333,6 +341,75 @@ func TestLookupNPKeys(t *testing.T) {
 	}
 }
 
+func TestLookupNPKeys_SubscriberNotFound(t *testing.T) {
+	skm := &SimpleKeyMgr{
+		Registry: &mockRegistry{
+			LookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	_, _, err := skm.LookupNPKeys(context.Background(), "test-subscriber", "test-key")
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
+	if !strings.Contains(err.Error(), "no subscriber found with given credentials") {
+		t.Errorf("err = %v, want message to contain 'no subscriber found with given credentials'", err)
+	}
+	var signErr *model.SignValidationErr
+	if !errors.As(err, &signErr) {
+		t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+	}
+	if signErr.Code != "AUT_SUBSCRIBER_NOT_FOUND" {
+		t.Errorf("signErr.Code = %s, want AUT_SUBSCRIBER_NOT_FOUND", signErr.Code)
+	}
+	if !errors.Is(err, ErrSubscriberNotFound) {
+		t.Error("expected errors.Is(err, ErrSubscriberNotFound) = true")
+	}
+}
+
+func TestLookupNPKeys_KeyExpiredOrRevoked(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "EXPIRED", status: "EXPIRED"},
+		{name: "UNSUBSCRIBED", status: "UNSUBSCRIBED"},
+		{name: "INVALID_SSL", status: "INVALID_SSL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skm := &SimpleKeyMgr{
+				Registry: &mockRegistry{
+					LookupFunc: func(ctx context.Context, sub *model.Subscription) ([]model.Subscription, error) {
+						return []model.Subscription{{Status: tt.status}}, nil
+					},
+				},
+			}
+
+			_, _, err := skm.LookupNPKeys(context.Background(), "test-subscriber", "test-key")
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			if !strings.Contains(err.Error(), "subscriber key is expired or revoked") {
+				t.Errorf("err = %v, want message to contain 'subscriber key is expired or revoked'", err)
+			}
+			var signErr *model.SignValidationErr
+			if !errors.As(err, &signErr) {
+				t.Fatalf("expected err to be a *model.SignValidationErr, got: %T (%v)", err, err)
+			}
+			if signErr.Code != "AUT_KEY_EXPIRED_OR_REVOKED" {
+				t.Errorf("signErr.Code = %s, want AUT_KEY_EXPIRED_OR_REVOKED", signErr.Code)
+			}
+			if !errors.Is(err, ErrKeyExpiredOrRevoked) {
+				t.Error("expected errors.Is(err, ErrKeyExpiredOrRevoked) = true")
+			}
+		})
+	}
+}
+
 func TestParseKey(t *testing.T) {
 	skm := &SimpleKeyMgr{}
 
@@ -370,12 +447,12 @@ func TestLoadKeysFromConfig(t *testing.T) {
 
 	// Test with valid config
 	cfg := &Config{
-		SubscriberID: "test-np",
-		KeyID:        "test-key",
-		SigningPrivateKey:  base64.StdEncoding.EncodeToString([]byte("signing-private")),
-		SigningPublicKey:   base64.StdEncoding.EncodeToString([]byte("signing-public")),
-		EncrPrivateKey:     base64.StdEncoding.EncodeToString([]byte("encr-private")),
-		EncrPublicKey:      base64.StdEncoding.EncodeToString([]byte("encr-public")),
+		SubscriberID:      "test-np",
+		KeyID:             "test-key",
+		SigningPrivateKey: base64.StdEncoding.EncodeToString([]byte("signing-private")),
+		SigningPublicKey:  base64.StdEncoding.EncodeToString([]byte("signing-public")),
+		EncrPrivateKey:    base64.StdEncoding.EncodeToString([]byte("encr-private")),
+		EncrPublicKey:     base64.StdEncoding.EncodeToString([]byte("encr-public")),
 	}
 
 	err := skm.loadKeysFromConfig(ctx, cfg)

--- a/pkg/plugin/implementation/vcvalidator/README.md
+++ b/pkg/plugin/implementation/vcvalidator/README.md
@@ -89,7 +89,7 @@ The NACK body matches beckn-onix's v2 shape and is signed by the handler
 (`Signature` response header) like every other pipeline NACK:
 
 ```json
-{"message":{"status":"NACK","messageId":"…","error":{"code":"Unauthorized","message":"Signature Validation Error: CREDENTIAL_REVOKED: …"}}}
+{"message":{"status":"NACK","messageId":"…","error":{"code":"AUT_KEY_EXPIRED_OR_REVOKED","message":"Signature Validation Error: CREDENTIAL_REVOKED: …"}}}
 ```
 
 ## Configuration

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator.go
@@ -81,7 +81,7 @@ func (s *step) Run(ctx *model.StepContext) error {
 	// revocation fetch, so an unbounded count would let a single request tie up
 	// a handler goroutine indefinitely.
 	if len(creds) > s.cfg.MaxCredentials {
-		ve := failf(failStructure, "request carries %d credentials, exceeding maxCredentials=%d",
+		ve := failf(failStructure, codeSchSchemaValidation, "request carries %d credentials, exceeding maxCredentials=%d",
 			len(creds), s.cfg.MaxCredentials)
 		log.Errorf(ctx, ve, "validateVC: action=%s rejected", action)
 		return nackErr(ve)
@@ -103,20 +103,31 @@ func (s *step) Run(ctx *model.StepContext) error {
 // NACK mapping understands: a structurally broken credential is a Bad
 // Request, while every other failure (proof, issuer, expiry, revocation,
 // resolution) means the credential's authenticity could not be established,
-// which maps to Unauthorized. The machine-readable failure class stays at the
-// start of the NACK error message (e.g. "CREDENTIAL_REVOKED: …").
+// which maps to Unauthorized. Either way the specific Beckn v2.0.0 ErrorCode
+// ve carries (set at the failf call site) rides along on the wire. The
+// machine-readable failure class also stays at the start of the NACK error
+// message (e.g. "CREDENTIAL_REVOKED: …").
+//
+// Known limitation (see #870/#884): every non-failStructure class routes to
+// SignValidationErr, which core/module/handler/responsestep.go always maps
+// to HTTP 401 — including failResolution's NET_TIMEOUT/NET_DOWNSTREAM_UNAVAILABLE
+// codes, which then surface under a 401 rather than a network-appropriate
+// status. Splitting the HTTP-status mapping by Code family (not just Go
+// type) would fix this but is a nackBecknError-level change affecting every
+// plugin that returns SignValidationErr, deferred rather than folded into
+// #870/#884's classification-only scope.
 func nackErr(ve *vcError) error {
 	if ve.class == failStructure {
-		return model.NewBadReqErr(ve)
+		return model.NewCodedBadReqErr(ve.code, ve)
 	}
-	return model.NewSignValidationErr(ve)
+	return model.NewCodedSignValidationErr(ve.code, ve)
 }
 
 func asVCError(err error) *vcError {
 	if ve, ok := err.(*vcError); ok {
 		return ve
 	}
-	return &vcError{class: failStructure, msg: err.Error()}
+	return &vcError{class: failStructure, code: codeSchSchemaValidation, msg: err.Error()}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
+++ b/pkg/plugin/implementation/vcvalidator/vcvalidator_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,13 +82,14 @@ func TestVectors(t *testing.T) {
 	cases := []struct {
 		file      string
 		wantClass failClass // "" => must be accepted
+		wantCode  string    // checked when wantClass is non-empty
 	}{
-		{"didkey-unrevoked.json", ""},
-		{"didkey-revoked.json", failRevoked},
-		{"didjwk-unrevoked.json", ""},
-		{"didjwk-revoked.json", failRevoked},
-		{"didweb-unrevoked.json", ""},
-		{"didweb-revoked.json", failRevoked},
+		{"didkey-unrevoked.json", "", ""},
+		{"didkey-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
+		{"didjwk-unrevoked.json", "", ""},
+		{"didjwk-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
+		{"didweb-unrevoked.json", "", ""},
+		{"didweb-revoked.json", failRevoked, codeAutKeyExpiredOrRevoked},
 	}
 
 	for _, tc := range cases {
@@ -108,7 +110,7 @@ func TestVectors(t *testing.T) {
 				}
 				return
 			}
-			assertClass(t, err, tc.wantClass)
+			assertClassCode(t, err, tc.wantClass, tc.wantCode)
 		})
 	}
 }
@@ -156,21 +158,21 @@ func TestTamperedSignature(t *testing.T) {
 
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failProof)
+	assertClassCode(t, err, failProof, codeAutSignatureInvalid)
 }
 
 func TestExpired(t *testing.T) {
 	v := testVerifier(nil)
 	v.now = func() time.Time { return time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC) }
 	err := v.verify(context.Background(), vcBytes(t, loadVC(t)))
-	assertClass(t, err, failExpired)
+	assertClassCode(t, err, failExpired, codeAutKeyExpiredOrRevoked)
 }
 
 func TestNotYetValid(t *testing.T) {
 	v := testVerifier(nil)
 	v.now = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
 	err := v.verify(context.Background(), vcBytes(t, loadVC(t)))
-	assertClass(t, err, failExpired)
+	assertClassCode(t, err, failExpired, codeAutKeyExpiredOrRevoked)
 }
 
 func TestIssuerMismatch(t *testing.T) {
@@ -179,7 +181,7 @@ func TestIssuerMismatch(t *testing.T) {
 	vc["issuer"] = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failIssuer)
+	assertClassCode(t, err, failIssuer, codeAutUnauthorizedAction)
 }
 
 // TestDIDWebHappyPath builds a VC-JWT signed by an ed25519 key, publishes the
@@ -231,7 +233,9 @@ func TestDIDWebUnreachableFailsClosed(t *testing.T) {
 	})
 	v.now = fixedNow
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failResolution)
+	// "dial tcp: no such host" is network-caused (isNetErr) but not a timeout,
+	// so it lands on NET_DOWNSTREAM_UNAVAILABLE rather than NET_TIMEOUT.
+	assertClassCode(t, err, failResolution, codeNetDownstreamUnavailable)
 
 	// fail-open should let it through.
 	cfg.FailOpen = true
@@ -281,7 +285,7 @@ func dediVC(t *testing.T, statusCode int) (*verifier, json.RawMessage) {
 
 func TestDEDIRevoked(t *testing.T) {
 	v, raw := dediVC(t, 200) // DEDI record exists → revoked
-	assertClass(t, v.verify(context.Background(), raw), failRevoked)
+	assertClassCode(t, v.verify(context.Background(), raw), failRevoked, codeAutKeyExpiredOrRevoked)
 }
 
 func TestDEDINotRevoked(t *testing.T) {
@@ -303,7 +307,135 @@ func TestDataIntegrityProofRejectedWhenRequired(t *testing.T) {
 	}
 	v := testVerifier(nil)
 	err := v.verify(context.Background(), vcBytes(t, vc))
-	assertClass(t, err, failProof)
+	assertClassCode(t, err, failProof, codeAutSignatureInvalid)
+}
+
+// TestResolutionCode exercises resolutionCode's three-way split directly: a
+// timeout is NET_TIMEOUT, another network cause (matched by the same isNetErr
+// heuristic) is NET_DOWNSTREAM_UNAVAILABLE, and anything else — the key
+// genuinely couldn't be found rather than an unreachable network — is
+// AUT_KEY_NOT_FOUND.
+// fakeTimeoutErr implements the timeouter interface (Timeout() bool) the way
+// *url.Error/net.Error do — its message text deliberately contains no
+// "timeout" substring, so a test built on it only passes if isTimeoutErr
+// actually uses the interface rather than falling back to string matching.
+type fakeTimeoutErr struct{ msg string }
+
+func (e *fakeTimeoutErr) Error() string { return e.msg }
+func (e *fakeTimeoutErr) Timeout() bool { return true }
+
+func TestResolutionCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"network timeout (string fallback)", fmt.Errorf("did:web fetch https://x: dial tcp: i/o timeout"), codeNetTimeout},
+		{"network, not a timeout", fmt.Errorf("did:web fetch https://x: dial tcp: no such host"), codeNetDownstreamUnavailable},
+		{"non-network", fmt.Errorf("did method %q not allowed (allowed: [key jwk web])", "example"), codeAutKeyNotFound},
+		{
+			// msg deliberately contains no "timeout" substring anywhere, so
+			// this only passes if isTimeoutErr actually consults the
+			// Timeout() interface rather than falling back to string
+			// matching.
+			"timeout detected via Timeout() interface, not message text",
+			fmt.Errorf("did:web fetch https://x: %w", &fakeTimeoutErr{msg: "context deadline exceeded (no server response)"}),
+			codeNetTimeout,
+		},
+		{
+			"ordinary non-2xx HTTP status is not a network failure",
+			fmt.Errorf("did:web fetch https://x: http 404 for https://x"),
+			codeAutKeyNotFound,
+		},
+		{
+			// A real *url.Error (what http.Client.Do returns) wrapping a TLS
+			// failure — message text contains none of "dial"/"no such
+			// host"/"connection"/"timeout", so this only passes if isNetErr's
+			// errors.As(*url.Error) type check is actually working.
+			"real *url.Error (TLS failure) is a network failure despite no recognizable substring",
+			fmt.Errorf("did:web fetch https://x: %w", &url.Error{Op: "Get", URL: "https://x", Err: errors.New("tls: failed to verify certificate: x509: certificate signed by unknown authority")}),
+			codeNetDownstreamUnavailable,
+		},
+		{
+			"real *url.Error wrapping a genuine timeout",
+			fmt.Errorf("did:web fetch https://x: %w", &url.Error{Op: "Get", URL: "https://x", Err: &fakeTimeoutErr{msg: "context deadline exceeded (no server response)"}}),
+			codeNetTimeout,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolutionCode(tt.err); got != tt.want {
+				t.Errorf("resolutionCode(%v) = %s, want %s", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNoProof asserts a credential with no proof block at all is distinguished
+// from every other proof failure: AUT_SIGNATURE_MISSING, not
+// AUT_SIGNATURE_INVALID.
+func TestNoProof(t *testing.T) {
+	vc := map[string]any{
+		"issuer":            "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+		"credentialSubject": map[string]any{"id": "x"},
+	}
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failProof, codeAutSignatureMissing)
+}
+
+// TestProofPresentButEmpty asserts a credential whose proof object exists but
+// has neither jwt nor proofValue is classified the same as no proof at all
+// (AUT_SIGNATURE_MISSING) — both mean there's no usable proof content, so
+// they shouldn't be split across two different codes.
+func TestProofPresentButEmpty(t *testing.T) {
+	vc := map[string]any{
+		"issuer":            "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+		"credentialSubject": map[string]any{"id": "x"},
+		"proof":             map[string]any{"type": "SomeProofType"},
+	}
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failProof, codeAutSignatureMissing)
+}
+
+// TestUnsupportedDIDMethodIsKeyNotFound asserts a resolution failure caused by
+// a disallowed/unsupported DID method (not a network problem) is classified
+// AUT_KEY_NOT_FOUND rather than a NET_* code.
+func TestUnsupportedDIDMethodIsKeyNotFound(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(nil)
+	did := "did:example:abc"
+	kid := did + "#key-1"
+	jwt := signVCJWT(t, priv, kid, did, "did:key:z6MkSubject", fixedNow())
+	vc := map[string]any{
+		"issuer":            did,
+		"credentialSubject": map[string]any{"id": "did:key:z6MkSubject"},
+		"proof":             map[string]any{"type": "JsonWebSignature2020", "jwt": jwt},
+	}
+	v := testVerifier(nil)
+	v.now = fixedNow
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failResolution, codeAutKeyNotFound)
+}
+
+// TestMalformedCredentialJSON asserts a credential body that isn't valid JSON
+// at all is classified SCH_INVALID_JSON, distinct from a well-formed-but-
+// incomplete credential (SCH_REQUIRED_FIELD_MISSING).
+func TestMalformedCredentialJSON(t *testing.T) {
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), json.RawMessage(`{"issuer": "x", "credentialSubject": {`))
+	assertClassCode(t, err, failStructure, codeSchInvalidJSON)
+}
+
+// TestMalformedCredentialStatus asserts an unparseable credentialStatus is
+// classified SCH_INVALID_JSON, same as any other malformed-JSON structural
+// failure.
+func TestMalformedCredentialStatus(t *testing.T) {
+	vc := loadVC(t)
+	vc["credentialStatus"] = 123 // neither an object nor an array
+	v := testVerifier(nil)
+	err := v.verify(context.Background(), vcBytes(t, vc))
+	assertClassCode(t, err, failStructure, codeSchInvalidJSON)
 }
 
 func TestConfigRequiresActions(t *testing.T) {
@@ -433,6 +565,9 @@ func TestStepNackErrorTypes(t *testing.T) {
 		if !strings.Contains(err.Error(), string(failIssuer)) {
 			t.Fatalf("failure class missing from error: %v", err)
 		}
+		if code := signErr.BecknError().Code; code != codeAutUnauthorizedAction {
+			t.Fatalf("BecknError().Code = %s, want %s", code, codeAutUnauthorizedAction)
+		}
 	})
 	t.Run("structural failure is BadReqErr", func(t *testing.T) {
 		vc := map[string]any{ // no issuer → failStructure
@@ -446,6 +581,9 @@ func TestStepNackErrorTypes(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), string(failStructure)) {
 			t.Fatalf("failure class missing from error: %v", err)
+		}
+		if code := badReq.BecknError().Code; code != codeSchRequiredFieldMissing {
+			t.Fatalf("BecknError().Code = %s, want %s", code, codeSchRequiredFieldMissing)
 		}
 	})
 }
@@ -480,6 +618,9 @@ func TestStepMaxCredentials(t *testing.T) {
 	}
 	if !strings.Contains(runErr.Error(), "maxCredentials") {
 		t.Fatalf("expected cap rejection, got: %v", runErr)
+	}
+	if code := badReq.BecknError().Code; code != codeSchSchemaValidation {
+		t.Fatalf("BecknError().Code = %s, want %s", code, codeSchSchemaValidation)
 	}
 
 	// At the cap it must fall through to per-credential verification.
@@ -568,7 +709,9 @@ func TestRedirectCap(t *testing.T) {
 
 // ── helpers ─────────────────────────────────────────────────────────────
 
-func assertClass(t *testing.T, err error, want failClass) {
+// assertClassCode asserts err is a *vcError with the given class, and — when
+// wantCode is non-empty — the given Beckn v2.0.0 ErrorCode too.
+func assertClassCode(t *testing.T, err error, want failClass, wantCode string) {
 	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error of class %s, got nil", want)
@@ -579,6 +722,9 @@ func assertClass(t *testing.T, err error, want failClass) {
 	}
 	if ve.class != want {
 		t.Fatalf("expected class %s, got %s (%s)", want, ve.class, ve.msg)
+	}
+	if wantCode != "" && ve.code != wantCode {
+		t.Fatalf("expected code %s, got %s (%s)", wantCode, ve.code, ve.msg)
 	}
 }
 

--- a/pkg/plugin/implementation/vcvalidator/verify.go
+++ b/pkg/plugin/implementation/vcvalidator/verify.go
@@ -13,10 +13,12 @@ import (
 	"crypto/elliptic"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"syscall"
@@ -46,16 +48,76 @@ const (
 	failIssuer     failClass = "ISSUER_MISMATCH"
 )
 
-// vcError is a credential validation failure with a machine-readable class.
+// Beckn v2.0.0 ErrorCode values this package classifies its failures onto.
+// Named locally (rather than inlined at each of the ~20 call sites below,
+// unlike the single-use-per-plugin convention elsewhere in this codebase)
+// since several codes here are reused across many sites and a typo in a
+// string literal wouldn't be caught by the compiler.
+const (
+	codeSchInvalidJSON          = "SCH_INVALID_JSON"
+	codeSchRequiredFieldMissing = "SCH_REQUIRED_FIELD_MISSING"
+	codeSchSchemaValidation     = "SCH_SCHEMA_VALIDATION_FAILED"
+	codeAutSignatureMissing     = "AUT_SIGNATURE_MISSING"
+	codeAutSignatureInvalid     = "AUT_SIGNATURE_INVALID"
+	codeAutUnauthorizedAction   = "AUT_UNAUTHORIZED_ACTION"
+	// No dedicated credential-expiry/revocation code exists in the v2.0.0
+	// taxonomy (CTX_TTL_EXPIRED is the beckn message TTL, a different
+	// concept) — this is the closest existing bucket, reusing the pattern
+	// keymanager/simplekeymanager already established for key lifecycle
+	// expiry. Flagged in the PR description as a taxonomy-completeness gap.
+	codeAutKeyExpiredOrRevoked   = "AUT_KEY_EXPIRED_OR_REVOKED"
+	codeAutKeyNotFound           = "AUT_KEY_NOT_FOUND"
+	codeNetTimeout               = "NET_TIMEOUT"
+	codeNetDownstreamUnavailable = "NET_DOWNSTREAM_UNAVAILABLE"
+)
+
+// vcError is a credential validation failure with a machine-readable class
+// and the Beckn v2.0.0 ErrorCode nackErr carries to the wire.
 type vcError struct {
 	class failClass
+	code  string
 	msg   string
 }
 
 func (e *vcError) Error() string { return string(e.class) + ": " + e.msg }
 
-func failf(class failClass, format string, a ...any) *vcError {
-	return &vcError{class: class, msg: fmt.Sprintf(format, a...)}
+func failf(class failClass, code, format string, a ...any) *vcError {
+	return &vcError{class: class, code: code, msg: fmt.Sprintf(format, a...)}
+}
+
+// resolutionCode picks the ErrorCode for a failResolution failure: a
+// network-caused resolution failure (detected via the same isNetErr
+// heuristic already used for FailOpen decisions) gets a NET_* code, anything
+// else (unsupported/disallowed DID method, malformed key material, no
+// matching verification method) means the key genuinely couldn't be found.
+func resolutionCode(err error) string {
+	if !isNetErr(err) {
+		return codeAutKeyNotFound
+	}
+	if isTimeoutErr(err) {
+		return codeNetTimeout
+	}
+	return codeNetDownstreamUnavailable
+}
+
+// timeouter is implemented by *url.Error (returned from http.Client.Do,
+// including for did:web/DEDI fetches) and other stdlib network errors — a
+// reliable signal independent of the wrapped error's message text or
+// casing, reachable through %w-wrapping via errors.As. Duck-typed by design
+// (any Timeout() bool method matches); no conflicting implementation exists
+// in this codebase today, but a future unrelated type defining the same
+// method name would be silently treated as a network-timeout signal.
+type timeouter interface{ Timeout() bool }
+
+// isTimeoutErr reports whether err is a timeout, preferring the standard
+// Timeout() bool interface and falling back to a case-insensitive substring
+// match for errors that don't implement it (e.g. synthetic/test errors).
+func isTimeoutErr(err error) bool {
+	var te timeouter
+	if errors.As(err, &te) {
+		return te.Timeout()
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout")
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +147,7 @@ type proof struct {
 // object with an "id" field.
 func (c *credential) issuerDID() (string, error) {
 	if len(c.Issuer) == 0 {
-		return "", failf(failStructure, "credential has no issuer")
+		return "", failf(failStructure, codeSchRequiredFieldMissing, "credential has no issuer")
 	}
 	var s string
 	if err := json.Unmarshal(c.Issuer, &s); err == nil && s != "" {
@@ -97,7 +159,7 @@ func (c *credential) issuerDID() (string, error) {
 	if err := json.Unmarshal(c.Issuer, &obj); err == nil && obj.ID != "" {
 		return obj.ID, nil
 	}
-	return "", failf(failStructure, "credential issuer has no id")
+	return "", failf(failStructure, codeSchRequiredFieldMissing, "credential issuer has no id")
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +188,7 @@ func newVerifier(cfg *Config, fetch fetcher) *verifier {
 func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 	var cred credential
 	if err := json.Unmarshal(raw, &cred); err != nil {
-		return failf(failStructure, "cannot parse credential: %v", err)
+		return failf(failStructure, codeSchInvalidJSON, "cannot parse credential: %v", err)
 	}
 	issuer, err := cred.issuerDID()
 	if err != nil {
@@ -142,7 +204,7 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 
 	// 2. Proof.
 	if cred.Proof == nil {
-		return failf(failProof, "credential has no proof")
+		return failf(failProof, codeAutSignatureMissing, "credential has no proof")
 	}
 	if cred.Proof.JWT != "" {
 		if err := v.verifyJWTProof(ctx, &cred, issuer); err != nil {
@@ -153,7 +215,7 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 		// it requires RDF canonicalisation (URDNA2015), which this plugin does
 		// not implement.
 		if v.cfg.RequireProof {
-			return failf(failProof,
+			return failf(failProof, codeAutSignatureInvalid,
 				"proof type %q requires JSON-LD canonicalisation which is not supported; "+
 					"set requireProof=false to accept on expiry/revocation only",
 				cred.Proof.Type)
@@ -162,12 +224,14 @@ func (v *verifier) verify(ctx context.Context, raw json.RawMessage) error {
 		if vm := cred.Proof.VerificationMethod; vm != "" {
 			if _, err := resolveDID(ctx, vm, "", v.cfg, v.fetch); err != nil {
 				if !v.cfg.FailOpen {
-					return failf(failResolution, "verificationMethod %q did not resolve: %v", vm, err)
+					return failf(failResolution, resolutionCode(err), "verificationMethod %q did not resolve: %v", vm, err)
 				}
 			}
 		}
 	} else {
-		return failf(failProof, "proof has neither jwt nor proofValue")
+		// No jwt and no proofValue means no usable proof content at all — the
+		// same defect as cred.Proof == nil above, just one level deeper.
+		return failf(failProof, codeAutSignatureMissing, "proof has neither jwt nor proofValue")
 	}
 
 	// 3. Revocation.
@@ -186,7 +250,7 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 	token := cred.Proof.JWT
 	header, err := decodeJWTHeader(token)
 	if err != nil {
-		return failf(failProof, "%v", err)
+		return failf(failProof, codeAutSignatureInvalid, "%v", err)
 	}
 
 	// The signing key DID comes from the JWT `kid` (its controller). It MUST
@@ -197,7 +261,7 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 		signerDID = issuer
 	}
 	if base(signerDID) != base(issuer) {
-		return failf(failIssuer,
+		return failf(failIssuer, codeAutUnauthorizedAction,
 			"proof signer %q does not match issuer %q", signerDID, issuer)
 	}
 
@@ -206,18 +270,18 @@ func (v *verifier) verifyJWTProof(ctx context.Context, cred *credential, issuer 
 		if isNetErr(err) && v.cfg.FailOpen {
 			return nil
 		}
-		return failf(failResolution, "resolve %q: %v", header.Kid, err)
+		return failf(failResolution, resolutionCode(err), "resolve %q: %v", header.Kid, err)
 	}
 
 	// Alg-confusion protection: the header alg must match the resolved key.
 	if header.Alg != key.alg.String() {
-		return failf(failProof,
+		return failf(failProof, codeAutSignatureInvalid,
 			"header alg %q does not match issuer key algorithm %q", header.Alg, key.alg.String())
 	}
 
 	payload, err := jws.Verify([]byte(token), jws.WithKey(key.alg, key.pub))
 	if err != nil {
-		return failf(failProof, "signature verification failed: %v", err)
+		return failf(failProof, codeAutSignatureInvalid, "signature verification failed: %v", err)
 	}
 
 	// Validate JWT temporal claims (nbf/exp) too.
@@ -264,10 +328,10 @@ func (v *verifier) checkJWTClaims(payload []byte) error {
 	}
 	now := v.now().Unix()
 	if claims.Nbf != 0 && now < claims.Nbf {
-		return failf(failExpired, "credential not yet valid (nbf=%d, now=%d)", claims.Nbf, now)
+		return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential not yet valid (nbf=%d, now=%d)", claims.Nbf, now)
 	}
 	if claims.Exp != 0 && now > claims.Exp {
-		return failf(failExpired, "credential expired (exp=%d, now=%d)", claims.Exp, now)
+		return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential expired (exp=%d, now=%d)", claims.Exp, now)
 	}
 	return nil
 }
@@ -278,13 +342,13 @@ func (v *verifier) checkWindow(validFrom, validUntil string) error {
 	if validFrom != "" {
 		t, err := time.Parse(time.RFC3339, validFrom)
 		if err == nil && now.Before(t) {
-			return failf(failExpired, "credential not yet valid (validFrom=%s)", validFrom)
+			return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential not yet valid (validFrom=%s)", validFrom)
 		}
 	}
 	if validUntil != "" {
 		t, err := time.Parse(time.RFC3339, validUntil)
 		if err == nil && now.After(t) {
-			return failf(failExpired, "credential expired (validUntil=%s)", validUntil)
+			return failf(failExpired, codeAutKeyExpiredOrRevoked, "credential expired (validUntil=%s)", validUntil)
 		}
 	}
 	return nil
@@ -313,10 +377,29 @@ func isNetErr(err error) bool {
 	if err == nil {
 		return false
 	}
+	// *url.Error is what http.Client.Do returns for ANY failure to complete
+	// the round trip — dial, DNS, TLS handshake, connection reset, timeout,
+	// context cancellation — regardless of message text. It's a reliable
+	// type-based signal, reachable through %w-wrapping (e.g. resolveDIDWeb's
+	// "did:web fetch %s: %w") via errors.As. Deliberately does NOT match on
+	// message substrings like "fetch" or "http " (httpFetcher's own non-2xx-
+	// status message, "http %d for %s") — those appeared unconditionally
+	// regardless of cause and previously caused a completed round trip that
+	// merely returned a bad status to be misclassified as a network failure;
+	// that case correctly falls through to AUT_KEY_NOT_FOUND below, since a
+	// non-2xx response is never itself a *url.Error.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	if isTimeoutErr(err) {
+		return true
+	}
+	// Fallback for synthetic/test errors with no real *url.Error in their
+	// chain (e.g. hand-built fmt.Errorf strings used in unit tests).
 	s := err.Error()
-	return strings.Contains(s, "fetch") || strings.Contains(s, "http ") ||
-		strings.Contains(s, "dial") || strings.Contains(s, "timeout") ||
-		strings.Contains(s, "no such host") || strings.Contains(s, "connection")
+	return strings.Contains(s, "dial") || strings.Contains(s, "no such host") ||
+		strings.Contains(s, "connection")
 }
 
 // ---------------------------------------------------------------------------
@@ -663,7 +746,7 @@ type statusEntry struct {
 func (v *verifier) checkRevocation(ctx context.Context, raw json.RawMessage) error {
 	entries, err := parseStatusEntries(raw)
 	if err != nil {
-		return failf(failStructure, "credentialStatus: %v", err)
+		return failf(failStructure, codeSchInvalidJSON, "credentialStatus: %v", err)
 	}
 	for _, e := range entries {
 		// Only revocation-purpose entries gate acceptance. Empty purpose is
@@ -676,10 +759,10 @@ func (v *verifier) checkRevocation(ctx context.Context, raw json.RawMessage) err
 			if v.cfg.FailOpen {
 				continue
 			}
-			return failf(failResolution, "revocation check: %v", err)
+			return failf(failResolution, resolutionCode(err), "revocation check: %v", err)
 		}
 		if revoked {
-			return failf(failRevoked, "credential revoked via %s", e.statusURL())
+			return failf(failRevoked, codeAutKeyExpiredOrRevoked, "credential revoked via %s", e.statusURL())
 		}
 	}
 	return nil

--- a/pkg/testutil/becknerr.go
+++ b/pkg/testutil/becknerr.go
@@ -1,0 +1,29 @@
+// Package testutil holds small assertion helpers shared across this repo's
+// test files. It is a regular (non-_test.go) package so it can be imported
+// from other packages' tests, unlike a _test.go file which Go restricts to
+// its own package.
+package testutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/beckn-one/beckn-onix/pkg/model"
+)
+
+// RequireBadReqCode asserts that errors.As finds a *model.BadReqErr in err
+// and that its BecknError().Code equals wantCode. Shared by every plugin test
+// suite that classifies failures onto *model.BadReqErr (reqmapper, router,
+// reqpreprocessor, encrypter, decrypter, ...) instead of each reimplementing
+// the same assertion locally.
+func RequireBadReqCode(t *testing.T, err error, wantCode string) {
+	t.Helper()
+
+	var badReqErr *model.BadReqErr
+	if !errors.As(err, &badReqErr) {
+		t.Fatalf("expected errors.As to find a *model.BadReqErr in %v (%T)", err, err)
+	}
+	if code := badReqErr.BecknError().Code; code != wantCode {
+		t.Errorf("BecknError().Code = %s, want %s", code, wantCode)
+	}
+}


### PR DESCRIPTION
## Summary

Aligns beckn-onix's NACK error responses with the Beckn v2.0.0 LTS `ErrorCode` taxonomy (`SCH_*`, `AUT_*`, `POL_*`, `NET_*`, `BIZ_*`, `CTX_*`). Closes #861.

**⚠️ Breaking change:** existing NACK bodies (uncoded/legacy error shapes) are replaced by the new taxonomy. There is no feature flag, version gate, or dual-emission compatibility shim — this is a hard cutover. Consumers should update any error-code handling before upgrading; this will be called out explicitly in the release notes.

## What's included

Nine sub-tickets, each remapping one plugin's already-producible failures onto the taxonomy (not adding new detection logic):

- **#862** — reshaped `model.Error` for the v2.0.0 taxonomy; added shared `codedErr`/`FirstNonEmptyCode` helpers reused by later tickets.
- **#863** — schemav2validator → `SCH_*`.
- **#864** — signvalidator/keymanager → `AUT_*`.
- **#865** — opapolicychecker → `POL_*`.
- **#867** — reqmapper → `SCH_*` (parseRequestBody only).
- **#868** — reqpreprocessor → `SCH_*` (its 3 existing failure checks).
- **#869** — router → `SCH_*` (3 already-reachable sites); introduced shared `model.ExtractContext`/`WrapExtractContextErr`, now used by reqmapper, reqpreprocessor, and router alike.
- **#870** — encrypter/decrypter/publisher/vcvalidator → `AUT_*`/`NET_*`.
- **#871** — final legacy-default cleanup (`SchemaValidationErr`/`BadReqErr` → `SCH_INVALID_FORMAT`, `NotFoundErr` → `NET_ENTITY_NOT_FOUND`, `schemaversionmediator`'s codes renamed onto the taxonomy) + doc updates.

## Post-review fixes (this branch, on top of the 9 merged sub-ticket PRs)

A full whole-epic review (8 independent angles across all 45 changed files) was run before opening this PR. It found and this branch now fixes:

- **schemav2validator**: `validateReferencedObject` was dropping both the wrapped cause and the failing object's JSON path when a referenced schema failed to load or its `@type` couldn't be found, breaking `errors.As` reachability and losing which object failed on the wire. Fixed via a new `model.NewCodedErrorWithCause` constructor plus an `Error.Unwrap()` method.
- **Taxonomy naming consistency**: `schemaversionmediator` used `SCH_ADAPTATION_FAILED` while `schemav2validator` independently used `SCH_SCHEMA_ADAPTATION_FAILED` for the same failure concept (schema/artifact adaptation failure). Standardized on `SCH_SCHEMA_ADAPTATION_FAILED` everywhere.
- **`MediationError` dispatch gap**: `schemaversionmediator`'s `MediationError` was never wired into `nackBecknError`'s dispatch, so a real subscriber-not-onboarded or adaptation-failure case fell through to a generic HTTP 500 instead of a coded NACK. Added a `model.BecknErrorer` interface (`error` + `BecknError() *Error`) so any plugin's error type can opt into NACK dispatch without `core/module/handler` importing plugin packages directly; `MediationError` now implements it.
- **Test duplication**: a `requireBadReqCode` assertion helper had been independently reimplemented 4 times (decrypter, encrypter, reqmapper, router tests) with two subtly different implementations. Consolidated into `pkg/testutil.RequireBadReqCode`.
- **Simplification**: added `Unwrap()` to `model.Error` itself, letting `ExtractContext` drop from 4 return values to 3 and `WrapExtractContextErr` drop its separate `cause` parameter — both now rely on `Error.Unwrap()` for `errors.As`/`errors.Is` reachability.
- Fixed a duplicate-looking `SCH_SCHEMA_ADAPTATION_FAILED` table row in `CONFIG.md` and `schemaversionmediator/README.md` (two distinct causes sharing one code, now presented as a single row).
- Collapsed `BadReqErr`/`SignValidationErr`/`NotFoundErr`'s duplicated `BecknError()` bodies into a shared `codedErr.becknError(prefix, defaultCode)` helper, so a new plugin error type that fits the common shape (a code with a default, plus a fixed message prefix) can write `BecknError()` as a one-liner.

A broader follow-up — collapsing these three types' constructor pairs (`New*Err`/`NewCoded*Err`) into one each, and potentially the three types themselves into a single generic coded-error type parameterized by HTTP status — is filed as #888, out of scope here given its ~58-call-site blast radius across 16 files.

## Known, intentional scope decisions (not fixed here)

- **Router's `domain` field type-checking is intentionally loose.** Adopting the shared `model.ExtractContext` helper (#869) replaced a strict typed-struct decode with a map-based lookup that silently ignores a wrong-JSON-type `domain` field rather than hard-rejecting the request. This is deliberate: `domain` is a v1-era field being deprecated (v2.x routing already ignores it via the `*` wildcard), so tightening its validation isn't worth the added complexity.
- **NET_\* classification remains incomplete.** `router.go`'s own deferred failure sites, `stdHandler.go`'s reverse-proxy dispatch, and deeper `publisher.go` sites are not yet classified — no follow-up issue has been filed for this yet.
- **Coverage gaps below 80%** in `vcvalidator` (67%), `pkg/model` (73%), and `reqmapper` (75%) predate this epic and are out of scope for a taxonomy-remapping change; not addressed here.
- **dediregistry** (#866) and **reqmapper's JSONata transform-failure path** (#880) have zero existing error classification — building that is new infrastructure, not a remap, and is tracked as separate standalone issues outside #861.

## Testing

- `go build ./...` and `go vet ./...` clean (only pre-existing, unrelated `func main` warnings on `-buildmode=plugin` packages).
- Full `go test ./...` suite passes.
- Added/extended tests for every fix above (`extended_schema_test.go`, `responsestep_test.go`, `schemaversionmediator_test.go`, `model_test.go`).
